### PR TITLE
update docs to reflect change in vllm runtime handling for v0.0.22

### DIFF
--- a/website/src/content/docs/cli/run.mdx
+++ b/website/src/content/docs/cli/run.mdx
@@ -29,9 +29,9 @@ Jobs launch in the background (detached containers) and sparkrun follows logs au
 | `--foreground` | Run in foreground (don't detach) |
 | `--no-follow` | Don't follow container logs after launch |
 | `--skip-ib` | Skip InfiniBand detection (not recommended) |
-| `--ray-port` | Ray GCS port — default: 46379 (vLLM) |
+| `--ray-port` | Ray GCS port — default: 46379 (`vllm-ray` and `eugr-vllm` only) |
 | `--init-port` | SGLang distributed init port — default: 25000 |
-| `--dashboard` | Enable Ray dashboard on head node (vLLM) |
+| `--dashboard` | Enable Ray dashboard on head node (`vllm-ray` and `eugr-vllm` only) |
 | `--dashboard-port` | Ray dashboard port — default: 8265 |
 
 ## Examples

--- a/website/src/content/docs/recipes/format.mdx
+++ b/website/src/content/docs/recipes/format.mdx
@@ -104,12 +104,14 @@ Which inference engine to use:
 
 | Value | Engine | Clustering | Notes |
 |---|---|---|---|
-| `vllm` | vLLM | Ray | First-class. Solo and multi-node. |
+| `vllm` | vLLM | varies | Virtual alias — resolves to `vllm-distributed` (default) or `vllm-ray`. See [vLLM runtime](/runtimes/vllm/). |
+| `vllm-distributed` | vLLM | Native | Default vLLM variant. Uses vLLM's built-in distributed backend. |
+| `vllm-ray` | vLLM | Ray | vLLM with Ray head/worker orchestration. |
 | `sglang` | SGLang | Native | First-class. Solo and multi-node. |
 | `llama-cpp` | llama.cpp | N/A | Solo mode. GGUF models. |
-| `eugr-vllm` | vLLM (eugr) | Ray | Extends vLLM with eugr builds and mods. |
+| `eugr-vllm` | vLLM (eugr) | Ray | Extends `vllm-ray` with eugr builds and mods. |
 
-Defaults to `vllm` if omitted.
+Defaults to `vllm` if omitted, which resolves to `vllm-distributed` unless Ray hints are present.
 
 ### `container` (required)
 

--- a/website/src/content/docs/recipes/writing-recipes.mdx
+++ b/website/src/content/docs/recipes/writing-recipes.mdx
@@ -26,6 +26,8 @@ sparkrun show qwen3-1.7b-vllm
 
 ## Example: vLLM recipe
 
+Using `runtime: vllm` here resolves to `vllm-distributed` by default (see [vLLM runtime](/runtimes/vllm/) for details on the two variants).
+
 ```yaml
 model: my-org/my-model
 runtime: vllm

--- a/website/src/content/docs/runtimes/eugr-vllm.mdx
+++ b/website/src/content/docs/runtimes/eugr-vllm.mdx
@@ -3,9 +3,9 @@ title: eugr-vllm
 description: The gold standard for community-driven use of vLLM on DGX Spark.
 ---
 
-The `eugr-vllm` runtime extends sparkrun's native `vllm` runtime with support for [eugr/spark-vllm-docker](https://github.com/eugr/spark-vllm-docker) container builds and mods. Eugr's repo is the gold standard for community-driven use of vLLM on the NVIDIA DGX Spark — frequently updated with patches and details to support the latest models. It provides a container build system to facilitate building the latest from the main branch of vLLM and a system of maintained mods to resolve issues related to running models on the Spark.
+The `eugr-vllm` runtime extends sparkrun's [`vllm-ray`](/runtimes/vllm/) variant with support for [eugr/spark-vllm-docker](https://github.com/eugr/spark-vllm-docker) container builds and mods. Eugr's repo is the gold standard for community-driven use of vLLM on the NVIDIA DGX Spark — frequently updated with patches and details to support the latest models. It provides a container build system to facilitate building the latest from the main branch of vLLM and a system of maintained mods to resolve issues related to running models on the Spark.
 
-Since `eugr-vllm` extends `vllm`, it inherits all native Ray-based orchestration: multi-node clustering, container distribution, InfiniBand detection, log following, and cluster stop all work identically to the `vllm` runtime. The eugr-specific additions are:
+Since `eugr-vllm` extends `vllm-ray`, it inherits all Ray-based orchestration: multi-node clustering via Ray head/worker nodes, container distribution, InfiniBand detection, log following, and cluster stop all work identically to the `vllm-ray` runtime. The eugr-specific additions are:
 
 - **Container builds**: When a recipe specifies `build_args`, sparkrun calls eugr's `build-and-copy.sh` to build the image locally before distribution.
 - **Mods**: When a recipe specifies `mods`, sparkrun copies each mod directory into the container and runs its `run.sh` after container launch but before the serve command starts.
@@ -18,7 +18,7 @@ Use `eugr-vllm` when you want:
 - Custom modifications (mods) to patch as needed for the latest models
 - Local container builds with full control
 
-For prebuilt images without mods or custom builds, use the standard `vllm` runtime instead.
+For prebuilt images without mods or custom builds, use the standard `vllm` runtime instead (which resolves to [`vllm-distributed`](/runtimes/vllm/) by default).
 
 ## Example recipe
 

--- a/website/src/content/docs/runtimes/overview.mdx
+++ b/website/src/content/docs/runtimes/overview.mdx
@@ -9,10 +9,21 @@ sparkrun supports multiple inference runtimes through a plugin system. Each runt
 
 | Runtime | Engine | Multi-Node | Use Case |
 |---|---|---|---|
-| `vllm` | vLLM | Yes (Ray) | Production inference, broad model support |
+| `vllm-distributed` | vLLM | Yes (native) | Default vLLM variant. Uses vLLM's built-in distributed backend. |
+| `vllm-ray` | vLLM | Yes (Ray) | vLLM with Ray head/worker orchestration. |
 | `sglang` | SGLang | Yes (native) | High-throughput inference, structured generation, experimental GGUF |
 | `llama-cpp` | llama.cpp | Experimental | GGUF quantized models, lightweight deployment |
-| `eugr-vllm` | vLLM (eugr) | Yes (Ray) | Gold standard community vLLM — nightly builds, mods, battle-tested |
+| `eugr-vllm` | vLLM (eugr) | Yes (Ray) | Gold standard community vLLM — nightly builds, mods, battle-tested. Extends `vllm-ray`. |
+
+### The `vllm` alias
+
+You can write `runtime: vllm` in a recipe — sparkrun treats it as a virtual alias and resolves it to a concrete runtime:
+
+1. If the recipe has eugr signals (`build_args`, `mods`, or `recipe_version: "1"`) → **`eugr-vllm`**
+2. If the recipe hints at Ray usage (`distributed_executor_backend: ray` in defaults, or `--distributed-executor-backend ray` in the command template) → **`vllm-ray`**
+3. Otherwise → **`vllm-distributed`** (the default)
+
+Both `vllm-distributed` and `vllm-ray` use the same container images and support the same vLLM flags — they differ only in how multi-node clustering is orchestrated.
 
 ## How runtimes work
 
@@ -20,16 +31,18 @@ sparkrun supports multiple inference runtimes through a plugin system. Each runt
 
 - Container launch configuration (volumes, networking, GPU access)
 - InfiniBand/RDMA detection and NCCL environment variables
-- Multi-node clustering (Ray for vLLM, native for SGLang)
+- Multi-node clustering (native distributed for `vllm-distributed` and `sglang`, Ray for `vllm-ray` and `eugr-vllm`)
 - Model pre-sync and cache path resolution
 - Command generation when no explicit `command` template is provided
 
 ## Choosing a runtime
 
-- **vLLM** is the default and most widely supported. Use it unless you have a specific reason to choose another.
+- **vLLM** is the default and most widely supported. Write `runtime: vllm` and sparkrun picks the right variant automatically (see [the `vllm` alias](#the-vllm-alias) above).
+  - **vllm-distributed** (default) uses vLLM's built-in distributed backend — each node runs the full serve command with node-rank arguments (`--nnodes`, `--node-rank`, `--master-addr`).
+  - **vllm-ray** uses Ray head/worker orchestration — a Ray cluster is formed first, then the serve command runs on the head node.
 - **SGLang** offers competitive performance, good structured generation support, and experimental GGUF quantized model serving.
 - **llama.cpp** is ideal for GGUF quantized models or when you want a lightweight alternative.
-- **eugr-vllm** extends vLLM with eugr's container build system and mod support — nightly builds, mods, and a battle-tested container pipeline.
+- **eugr-vllm** extends `vllm-ray` with eugr's container build system and mod support — nightly builds, mods, and a battle-tested container pipeline.
 
 ## Maintained container images
 

--- a/website/src/content/docs/runtimes/vllm.mdx
+++ b/website/src/content/docs/runtimes/vllm.mdx
@@ -3,25 +3,42 @@ title: vLLM
 description: Using vLLM for inference on DGX Spark.
 ---
 
-[vLLM](https://github.com/vllm-project/vllm) is the default runtime in sparkrun. It provides first-class support for solo and multi-node inference via Ray.
+[vLLM](https://github.com/vllm-project/vllm) is the default runtime in sparkrun. It provides first-class support for solo and multi-node inference with two clustering variants:
+
+- **`vllm-distributed`** — uses vLLM's built-in distributed backend (the default)
+- **`vllm-ray`** — uses Ray head/worker orchestration
+
+You can write `runtime: vllm` in a recipe and sparkrun resolves it automatically — see [Runtime alias resolution](#runtime-alias-resolution) below.
 
 ## Features
 
-- Solo and multi-node clustering via Ray
+- Solo and multi-node tensor parallelism across DGX Spark nodes
 - Broad model support (most HuggingFace models)
-- Tensor parallelism across DGX Spark nodes
 - PagedAttention for efficient KV cache management
 - Tool calling support
+- Two multi-node strategies: vLLM native distributed or Ray clustering
 
 ## Container images
 
-sparkrun works with ready-built images including:
+Both `vllm-distributed` and `vllm-ray` use the same container images. sparkrun works with ready-built images including:
 
 - [Self-built community images from eugr/spark-vllm-docker](https://github.com/eugr/spark-vllm-docker) (often the first to have the latest fixes)
 - [scitrera/dgx-spark-vllm](https://hub.docker.com/r/scitrera/dgx-spark-vllm)
 - [Official NVIDIA Images](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vllm)
 
+## Runtime alias resolution
+
+When a recipe specifies `runtime: vllm` (or omits `runtime` entirely), sparkrun resolves it to a concrete runtime in this order:
+
+1. If the recipe has eugr signals (`build_args`, `mods`, or `recipe_version: "1"`) → **`eugr-vllm`** (see [eugr-vllm](/runtimes/eugr-vllm/))
+2. If the recipe hints at Ray usage (`distributed_executor_backend: ray` in defaults, or `--distributed-executor-backend ray` in the command template) → **`vllm-ray`**
+3. Otherwise → **`vllm-distributed`** (the default)
+
+You can also set `runtime: vllm-distributed` or `runtime: vllm-ray` explicitly to bypass this resolution.
+
 ## Example recipe
+
+This recipe uses `runtime: vllm`, which resolves to `vllm-distributed` by default:
 
 ```yaml
 model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
@@ -54,22 +71,56 @@ command: |
       --port {port}
 ```
 
-## Multi-node with Ray
+## Multi-node with vllm-distributed (default)
 
-For multi-node tensor parallel, sparkrun:
-1. Detects InfiniBand/RDMA interfaces on all hosts
-2. Starts a Ray head node on the first host
-3. Joins worker nodes to the Ray cluster
-4. Launches vLLM with the configured tensor parallelism
+`vllm-distributed` uses vLLM's built-in multi-node support. Each node runs the full `vllm serve` command with node-specific arguments:
+
+1. Cleans up existing containers on each node
+2. Detects InfiniBand/RDMA interfaces on all hosts
+3. Detects the head node IP
+4. Launches the head node (rank 0) with `--nnodes`, `--node-rank 0`, and `--master-addr`
+5. Waits for the master port to become ready
+6. Launches worker nodes in parallel, each with `--node-rank N` and `--headless`
 
 ```bash
 sparkrun run nemotron3-nano-30b-nvfp4-vllm --tp 2
 ```
 
+No Ray cluster is involved — vLLM coordinates the nodes directly via its native distributed backend.
+
+## Multi-node with vllm-ray
+
+`vllm-ray` forms a Ray cluster first, then runs the serve command on the head node:
+
+1. Cleans up existing containers on each node
+2. Detects InfiniBand/RDMA interfaces on all hosts
+3. Starts a Ray head node on the first host
+4. Joins worker nodes to the Ray cluster
+5. Launches the vLLM serve command on the head container
+
+To use `vllm-ray`, either set `runtime: vllm-ray` explicitly or add the Ray hint to defaults:
+
+```yaml
+runtime: vllm
+defaults:
+  distributed_executor_backend: ray
+```
+
 ### Ray-specific options
+
+These options apply only to `vllm-ray` (and `eugr-vllm`, which extends it):
 
 | Option | Default | Description |
 |---|---|---|
 | `--ray-port` | 46379 | Ray GCS port |
 | `--dashboard` | off | Enable Ray dashboard |
 | `--dashboard-port` | 8265 | Ray dashboard port |
+
+## Choosing between variants
+
+Both variants support the same models and vLLM flags. The difference is in multi-node orchestration:
+
+- **`vllm-distributed`** is simpler — no Ray dependency, each node runs independently with vLLM's built-in coordination. This is the default.
+- **`vllm-ray`** provides Ray's cluster management, dashboard, and monitoring. Use it when you need Ray-specific features or when running `eugr-vllm` (which extends `vllm-ray`).
+
+For single-node (solo) workloads, both variants behave identically.


### PR DESCRIPTION
This pull request updates the documentation to clarify and formalize the distinction between different vLLM runtime variants in sparkrun, introduces a new alias resolution system for the `vllm` runtime, and consistently describes how `eugr-vllm` relates to `vllm-ray`. The changes improve user understanding of runtime selection, multi-node orchestration strategies, and the relationship between the various vLLM-based runtimes.

**vLLM Runtime Variants and Alias Resolution**

- Introduced two explicit vLLM runtime variants: `vllm-distributed` (default, uses vLLM's native distributed backend) and `vllm-ray` (uses Ray for orchestration), and documented how the `vllm` alias is resolved to these variants based on recipe hints. [[1]](diffhunk://#diff-d121187b653e1dc6e9a54e27f916e70fe9b64e9b1f40cf3bc516461a1ffecb01L6-R42) [[2]](diffhunk://#diff-d121187b653e1dc6e9a54e27f916e70fe9b64e9b1f40cf3bc516461a1ffecb01L57-R126) [[3]](diffhunk://#diff-028e4a0140f03db9ab494a2a12411220107f978937ec5f1fc4c772faf244116dL107-R114) [[4]](diffhunk://#diff-46366e447671aaaf74487ff4710cde6f5bff892e0b2f384dd51454dbc857c758L12-R45)
- Clarified that `eugr-vllm` extends `vllm-ray`, not the general `vllm` runtime, and inherits Ray-based orchestration. [[1]](diffhunk://#diff-74499b6249167d26c1a3bb4934448d579b43cde608b302baa10f112ed2e8a6b1L6-R8) [[2]](diffhunk://#diff-74499b6249167d26c1a3bb4934448d579b43cde608b302baa10f112ed2e8a6b1L21-R21) [[3]](diffhunk://#diff-028e4a0140f03db9ab494a2a12411220107f978937ec5f1fc4c772faf244116dL107-R114) [[4]](diffhunk://#diff-46366e447671aaaf74487ff4710cde6f5bff892e0b2f384dd51454dbc857c758L12-R45)

**Documentation Consistency and Clarity**

- Updated runtime option tables, command-line flags, and notes to specify which options apply to which vLLM variants (e.g., Ray-specific flags only apply to `vllm-ray` and `eugr-vllm`). [[1]](diffhunk://#diff-f778986e3092ce7b8b4465c3f4763b1cb50bad6d4336f50da2dfbc58f614159fL32-R34) [[2]](diffhunk://#diff-028e4a0140f03db9ab494a2a12411220107f978937ec5f1fc4c772faf244116dL107-R114)
- Revised example recipes and usage notes to explain how `runtime: vllm` resolves by default, and when to use explicit variants. [[1]](diffhunk://#diff-969afc22f902983c5b5d8c9e3b3a5144681fcca63a25c56504e7dbe822dc8fd3R29-R30) [[2]](diffhunk://#diff-d121187b653e1dc6e9a54e27f916e70fe9b64e9b1f40cf3bc516461a1ffecb01L6-R42)

**Multi-node Orchestration Details**

- Added detailed explanations of multi-node orchestration for both `vllm-distributed` (vLLM native) and `vllm-ray` (Ray-based), including step-by-step launch sequences and guidance on when to use each. [[1]](diffhunk://#diff-d121187b653e1dc6e9a54e27f916e70fe9b64e9b1f40cf3bc516461a1ffecb01L57-R126) [[2]](diffhunk://#diff-d121187b653e1dc6e9a54e27f916e70fe9b64e9b1f40cf3bc516461a1ffecb01L6-R42) [[3]](diffhunk://#diff-46366e447671aaaf74487ff4710cde6f5bff892e0b2f384dd51454dbc857c758L12-R45)

These changes make the runtime selection process and orchestration strategies much clearer for users writing recipes or choosing between vLLM variants.