### PR TITLE
fix: correct run_rsync_parallel call in eugr _apply_mod

### DIFF
--- a/src/sparkrun/runtimes/eugr_vllm_ray.py
+++ b/src/sparkrun/runtimes/eugr_vllm_ray.py
@@ -202,9 +202,12 @@ class EugrVllmRayRuntime(VllmRayRuntime):
                 ssh_kwargs=ssh_kwargs, timeout=30,
             )
             # rsync mod contents to remote
+            kw = ssh_kwargs or {}
             run_rsync_parallel(
-                [host], str(mod_path) + "/", remote_tmp + "/",
-                ssh_kwargs=ssh_kwargs,
+                str(mod_path) + "/", [host], remote_tmp + "/",
+                ssh_user=kw.get("ssh_user"),
+                ssh_key=kw.get("ssh_key"),
+                ssh_options=kw.get("ssh_options"),
             )
             # docker cp into container and run
             script = (


### PR DESCRIPTION
Arguments were in the wrong order (hosts passed as source_path) and ssh_kwargs was passed as a bundled dict, which run_rsync_parallel does not accept. Unpack ssh_kwargs into individual ssh_user/ssh_key/ssh_options params to match the function signature.