### PR TITLE
add passthrough_args support for layered benchmark argument merging

### DIFF
--- a/src/sparkrun/benchmarking/base.py
+++ b/src/sparkrun/benchmarking/base.py
@@ -52,6 +52,7 @@ class BenchmarkingPlugin(Plugin):
     eager = False
     framework_name: str = ""
     default_args: dict[str, Any] = {}
+    passthrough_args: set[str] = set()
 
     # --- SAF Plugin interface ---
 

--- a/src/sparkrun/benchmarking/llama_benchy.py
+++ b/src/sparkrun/benchmarking/llama_benchy.py
@@ -34,6 +34,10 @@ _ARG_ALIASES: dict[str, str] = {
     "prefix_caching": "enable_prefix_caching",
 }
 
+_PASSTHROUGH_ARGS = {
+    'tokenizer',  # tokenizer value configured in a recipe can pass-thru to benchmark profile definitions
+}
+
 
 class LlamaBenchyFramework(BenchmarkingPlugin):
     """llama-benchy benchmarking framework.
@@ -46,8 +50,9 @@ class LlamaBenchyFramework(BenchmarkingPlugin):
     default_args: dict[str, Any] = {
         "pp": [2048],
         "depth": [0],
-        "enable_prefix_caching": True,
+        "prefix_caching": True,
     }
+    passthrough_args = _PASSTHROUGH_ARGS
 
     def initialize(self, v: Variables, logger_arg: Logger) -> LlamaBenchyFramework:
         return self

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -166,9 +166,21 @@ def _run_benchmark(
         click.echo("Error: %s" % e, err=True)
         sys.exit(1)
 
-    # If no args from profile or recipe, use framework defaults
-    if not bench_args:
-        bench_args = fw.get_default_args()
+    # Build layered bench args with cascading precedence (highest → lowest):
+    #   1. -o CLI overrides        (applied below)
+    #   2. Profile / recipe bench  (bench_args from above)
+    #   3. Recipe benchmark block passthrough keys (e.g. tokenizer)
+    #   4. Framework defaults      (lowest)
+    passthrough_layer: dict = {}
+    if fw.passthrough_args:
+        recipe_bench_block = recipe._raw.get("benchmark", {}) if hasattr(recipe, '_raw') else {}
+        if isinstance(recipe_bench_block, dict):
+            for key in fw.passthrough_args:
+                if key in recipe_bench_block:
+                    passthrough_layer[key] = recipe_bench_block[key]
+
+    # Merge layers: defaults < passthrough < profile/recipe bench args
+    bench_args = {**fw.get_default_args(), **passthrough_layer, **bench_args}
 
     # Apply -o overrides on top
     for opt_str in options:

--- a/src/sparkrun/runtimes/llama_cpp.py
+++ b/src/sparkrun/runtimes/llama_cpp.py
@@ -110,13 +110,16 @@ class LlamaCppRuntime(RuntimePlugin):
             # One > 1 and the other == 1: the 1 is a no-op, use the active one
             if tp_val > 1:
                 return "row"
-            # pp > 1, or both are 1 — layer is the default
-            return "layer"
+            if pp_val > 1:
+                return "layer"
+            # Both are 1 — no override needed (falls through to _LLAMA_CPP_DEFAULTS)
+            return None
 
-        if tp is not None and int(tp) > 1:
-            return "row"
-        # pp set, or neither set — default to layer
-        return "layer"
+        if tp is not None:
+            return "row" if int(tp) > 1 else None
+        if pp is not None:
+            return "layer" if int(pp) > 1 else None
+        return None
 
     def compute_required_nodes(self, recipe, overrides=None):
         """Compute required nodes from TP or PP (mutually exclusive).


### PR DESCRIPTION
This pull request introduces improvements to how benchmarking arguments are managed and merged in the `sparkrun` framework, with a focus on enabling passthrough of specific recipe-defined keys and refining default argument handling. Additionally, it updates the split mode resolution logic for the LlamaCpp runtime to ensure more accurate behavior based on configuration values.

**Benchmarking argument merging enhancements:**

* Added a new `passthrough_args` set to the `BenchmarkingPlugin` base class, allowing frameworks to specify which keys from a recipe's benchmark block should be merged into benchmark arguments. (`src/sparkrun/benchmarking/base.py`)
* Defined `_PASSTHROUGH_ARGS` (currently including `tokenizer`) for the LlamaBenchy framework, and set `passthrough_args` accordingly in `LlamaBenchyFramework`. (`src/sparkrun/benchmarking/llama_benchy.py`) [[1]](diffhunk://#diff-118dc2ace6aa71d2e338872cd7c1cac4abfc65d9bc9dc469ee4cf7cdbd3055b6R37-R40) [[2]](diffhunk://#diff-118dc2ace6aa71d2e338872cd7c1cac4abfc65d9bc9dc469ee4cf7cdbd3055b6L49-R55)
* Updated the benchmark argument merging logic in `_run_benchmark` to layer arguments in the following order: framework defaults < passthrough keys < profile/recipe bench args < CLI overrides, ensuring correct precedence and flexibility. (`src/sparkrun/cli/_benchmark.py`)

**LlamaCpp split mode resolution improvements:**

* Refined the logic in `_resolve_split_mode` so that it now returns `None` when both `tp` and `pp` are set to 1, and more accurately determines when to use "row" or "layer" modes based on the provided configuration. (`src/sparkrun/runtimes/llama_cpp.py`)