### PR TITLE
feat: add step to install uv in publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -609,10 +609,11 @@ class TestEngineLifecycle:
         from sparkrun.proxy.engine import ProxyEngine
 
         engine = ProxyEngine(state_dir=state_dir)
-        rc = engine.start(
-            config_path=state_dir / "fake.yaml",
-            dry_run=True,
-        )
+        with patch("shutil.which", return_value="/usr/bin/uvx"):
+            rc = engine.start(
+                config_path=state_dir / "fake.yaml",
+                dry_run=True,
+            )
         assert rc == 0
 
     def test_start_no_uvx(self, state_dir: Path):


### PR DESCRIPTION
This pull request introduces improvements to the CI workflow and test reliability. The main changes include adding a step to install `uv` in the GitHub Actions workflow and updating a test to patch the location of the `uvx` executable for more consistent test results.

Continuous Integration workflow enhancements:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R45-R47): Added a step to install `uv` using the `astral-sh/setup-uv` action, ensuring that the required tool is available during the workflow execution.

Testing reliability improvements:

* [`tests/test_proxy.py`](diffhunk://#diff-b9ecf408d1b452bd12965c145b2eeb879624500e868ab8e2ce1c2138f05062cbR612): Updated the `test_start_dry_run` test to patch `shutil.which` and return a fixed path (`/usr/bin/uvx`), making the test more deterministic and less dependent on the environment.