### PR TITLE
feat: update proxy commands and version to 0.1.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.1.12"
+version = "0.1.13"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/cli/_proxy.py
+++ b/src/sparkrun/cli/_proxy.py
@@ -88,15 +88,12 @@ def start(port, bind_host, master_key, cluster_name, hosts, hosts_file,
             click.echo("Found %d endpoint(s) but none are healthy." % len(endpoints))
         else:
             click.echo("No inference endpoints found.")
-        click.echo("Start inference workloads first: sparkrun run <recipe>")
-        if not dry_run:
-            sys.exit(1)
-        return
-
-    click.echo("Discovered %d healthy endpoint(s):" % len(healthy))
-    for ep in healthy:
-        models_str = ", ".join(ep.actual_models) if ep.actual_models else ep.model
-        click.echo("  %s:%d — %s (%s)" % (ep.host, ep.port, models_str, ep.runtime))
+        click.echo("Load models with: sparkrun proxy load <recipe>")
+    else:
+        click.echo("Discovered %d healthy endpoint(s):" % len(healthy))
+        for ep in healthy:
+            models_str = ", ".join(ep.actual_models) if ep.actual_models else ep.model
+            click.echo("  %s:%d — %s (%s)" % (ep.host, ep.port, models_str, ep.runtime))
 
     # Generate config
     config_dict = build_litellm_config(healthy, effective_key)
@@ -131,6 +128,12 @@ def start(port, bind_host, master_key, cluster_name, hosts, hosts_file,
             "host_list": live_hosts,
             "ssh_kwargs": ssh_kwargs,
         }
+
+    # Check if already running
+    if engine.is_running():
+        click.echo("Proxy is already running (PID %s) on port %d." % (engine._read_pid(), engine.port))
+        click.echo("Use 'sparkrun proxy stop' first, or 'sparkrun proxy load <recipe>' to add models.")
+        return
 
     click.echo("Starting proxy on %s:%d..." % (effective_host, effective_port))
     rc = engine.start(

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,5 +2,5 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.1.12
+sparkrun: 0.1.13
 sparkrun-cc-plugin: 0.0.3


### PR DESCRIPTION
This pull request updates the `sparkrun` package to version 0.1.13 and improves the user experience when managing inference workloads and the proxy. The most important changes are:

Version bump:

* Bumped the `sparkrun` version from 0.1.12 to 0.1.13 in both `pyproject.toml` and `versions.yaml` to reflect the new release. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)

Proxy command usability improvements:

* Updated the proxy startup messaging to instruct users to load models using `sparkrun proxy load <recipe>` instead of starting inference workloads, clarifying the next step if no healthy endpoints are found.
* Added a check to prevent starting the proxy if it is already running, displaying the current PID and port, and guiding the user to stop or load models as appropriate.