### PR TITLE
v0.2.2 export systemd fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.1"
+version = "0.2.2"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/cli/_export.py
+++ b/src/sparkrun/cli/_export.py
@@ -36,7 +36,7 @@ def _apply_spark_arena_benchmarks(recipe, recipe_name: str):
         return  # already set
 
     if recipe_name.startswith(SPARK_ARENA_PREFIX):
-        uuid = recipe_name[len(SPARK_ARENA_PREFIX) :]
+        uuid = recipe_name[len(SPARK_ARENA_PREFIX):]
         tp = recipe.defaults.get("tensor_parallel", 1)
         recipe.metadata["spark_arena_benchmarks"] = [{"tp": tp, "uuid": uuid}]
 
@@ -321,13 +321,14 @@ def _render_uninstall_script(slug, cluster_name, user_home):
 def _detect_remote_sparkrun(host, ssh_kwargs, dry_run=False):
     """Detect sparkrun path and user home on a remote host.
 
-    Returns (sparkrun_path, user_home) or exits with error.
+    Returns (sparkrun_path, user_home) on success, or (None, None) if not found.
     """
     from sparkrun.orchestration.ssh import run_remote_script
 
     script = textwrap.dedent("""\
         #!/usr/bin/env bash
         set -euo pipefail
+        export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
         SPARKRUN_PATH=$(which sparkrun 2>/dev/null || true)
         if [ -z "$SPARKRUN_PATH" ]; then
             echo "ERROR: sparkrun not found on PATH" >&2
@@ -342,35 +343,59 @@ def _detect_remote_sparkrun(host, ssh_kwargs, dry_run=False):
 
     result = run_remote_script(host, script, **ssh_kwargs, timeout=15)
     if not result.success:
-        click.echo("Error: sparkrun not found on head node '%s'." % host, err=True)
-        stderr = result.stderr.strip()
-        if stderr:
-            click.echo("  %s" % stderr, err=True)
-        click.echo("  Install sparkrun on the head node before using --install.", err=True)
-        sys.exit(1)
+        return None, None
 
     lines = result.stdout.strip().splitlines()
     if len(lines) < 2:
-        click.echo("Error: Unexpected response from head node '%s'." % host, err=True)
-        sys.exit(1)
+        return None, None
 
     return lines[0].strip(), lines[1].strip()
 
 
+def _install_remote_sparkrun(host, ssh_kwargs, dry_run=False):
+    """Install sparkrun on a remote host via uvx.
+
+    Returns True on success, False on failure.
+    """
+    from sparkrun.orchestration.ssh import run_remote_script
+
+    script = textwrap.dedent("""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+        UV_PATH=$(which uv 2>/dev/null || true)
+        if [ -z "$UV_PATH" ]; then
+            echo "ERROR: uv not found — cannot auto-install sparkrun" >&2
+            echo "Install uv first: https://docs.astral.sh/uv/" >&2
+            exit 1
+        fi
+        "$UV_PATH" x sparkrun setup install --no-update-registries
+    """)
+
+    if dry_run:
+        click.echo("Would install sparkrun on %s via: uvx sparkrun setup install" % host)
+        return True
+
+    result = run_remote_script(host, script, **ssh_kwargs, timeout=120)
+    if result.stderr.strip():
+        click.echo(result.stderr.strip(), err=True)
+    return result.success
+
+
 def _resolve_recipe_for_systemd(
-    target,
-    config,
-    hosts,
-    hosts_file,
-    cluster_name,
-    options,
-    tensor_parallel,
-    pipeline_parallel,
-    gpu_mem,
-    max_model_len,
-    image,
-    port,
-    served_model_name,
+        target,
+        config,
+        hosts,
+        hosts_file,
+        cluster_name,
+        options,
+        tensor_parallel,
+        pipeline_parallel,
+        gpu_mem,
+        max_model_len,
+        image,
+        port,
+        served_model_name,
 ):
     """Resolve recipe, hosts, and overrides for the systemd command.
 
@@ -463,24 +488,24 @@ def _build_cluster_yaml(cluster_name, hosts, ssh_user=None):
 @dry_run_option
 @click.pass_context
 def export_systemd(
-    ctx,
-    target,
-    hosts,
-    hosts_file,
-    cluster_name,
-    tensor_parallel,
-    pipeline_parallel,
-    gpu_mem,
-    max_model_len,
-    options,
-    image,
-    port,
-    served_model_name,
-    do_install,
-    do_uninstall,
-    start,
-    service_name,
-    dry_run,
+        ctx,
+        target,
+        hosts,
+        hosts_file,
+        cluster_name,
+        tensor_parallel,
+        pipeline_parallel,
+        gpu_mem,
+        max_model_len,
+        options,
+        image,
+        port,
+        served_model_name,
+        do_install,
+        do_uninstall,
+        start,
+        service_name,
+        dry_run,
 ):
     """Generate a systemd service for a sparkrun inference workload.
 
@@ -546,8 +571,19 @@ def export_systemd(
         _do_uninstall(slug, systemd_cluster_name, head_host, ssh_user, ssh_kwargs, dry_run)
         return
 
-    # Detect sparkrun on head node (needed for unit file)
+    # Detect sparkrun on head node (needed for unit file), auto-install if missing
     sparkrun_path, user_home = _detect_remote_sparkrun(head_host, ssh_kwargs, dry_run=dry_run)
+    if sparkrun_path is None:
+        click.echo("sparkrun not found on %s, attempting auto-install..." % head_host)
+        if not _install_remote_sparkrun(head_host, ssh_kwargs, dry_run=dry_run):
+            click.echo("Error: Failed to install sparkrun on '%s'." % head_host, err=True)
+            click.echo("  Install manually: ssh %s 'uvx sparkrun setup install'" % head_host, err=True)
+            sys.exit(1)
+        sparkrun_path, user_home = _detect_remote_sparkrun(head_host, ssh_kwargs, dry_run=dry_run)
+        if sparkrun_path is None:
+            click.echo("Error: sparkrun installed but not found on PATH on '%s'." % head_host, err=True)
+            sys.exit(1)
+        click.echo("sparkrun installed on %s" % head_host)
 
     unit_contents = _render_systemd_unit(
         slug,
@@ -565,7 +601,7 @@ def export_systemd(
         user_home,
     )
     sudo_install_script = _render_sudo_install_script(slug, unit_contents)
-    uninstall_script = _render_uninstall_script(slug, systemd_cluster_name, user_home)
+    # uninstall_script = _render_uninstall_script(slug, systemd_cluster_name, user_home)
 
     if not do_install:
         # Dry-run mode: display all generated artifacts
@@ -585,8 +621,8 @@ def export_systemd(
         click.echo(install_script)
         click.echo("--- Install script (sudo) ---")
         click.echo(sudo_install_script)
-        click.echo("--- Uninstall script (sudo) ---")
-        click.echo(uninstall_script)
+        # click.echo("--- Uninstall script (sudo) ---")
+        # click.echo(uninstall_script)
         click.echo("To deploy, re-run with --install")
         return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -616,7 +616,6 @@ class TestExportSystemdCommand:
         assert "Baked recipe" in result.output
         assert "Cluster definition" in result.output
         assert "Install script" in result.output
-        assert "Uninstall script" in result.output
         assert "To deploy, re-run with --install" in result.output
 
     def test_export_systemd_from_running_job(self, runner, tmp_path, monkeypatch):
@@ -687,15 +686,15 @@ class TestExportSystemdCommand:
         assert ssh_calls[0][0] == "user"
         assert ssh_calls[1][0] == "sudo"
 
-    def test_export_systemd_sparkrun_not_found(self, runner, monkeypatch):
-        """Test error when head node lacks sparkrun."""
+    def test_export_systemd_sparkrun_not_found_install_fails(self, runner, monkeypatch):
+        """Test error when head node lacks sparkrun and auto-install fails (uv not found)."""
         from sparkrun.orchestration.ssh import RemoteResult
 
         monkeypatch.setattr(
             "sparkrun.orchestration.ssh.run_remote_script",
             lambda host, script, **kwargs: RemoteResult(
                 host=host, returncode=1, stdout="",
-                stderr="ERROR: sparkrun not found on PATH",
+                stderr="ERROR: uv not found",
             ),
         )
 
@@ -705,7 +704,34 @@ class TestExportSystemdCommand:
              "--hosts", "10.0.0.1"],
         )
         assert result.exit_code != 0
+        assert "Failed to install sparkrun" in result.output
+
+    def test_export_systemd_sparkrun_auto_install_success(self, runner, monkeypatch):
+        """Test detection fails → auto-install succeeds → re-detect succeeds."""
+        from sparkrun.orchestration.ssh import RemoteResult
+
+        call_count = {"detect": 0}
+
+        def mock_detect(host, ssh_kwargs, dry_run=False):
+            call_count["detect"] += 1
+            if call_count["detect"] == 1:
+                return None, None  # first detect fails
+            return "/home/user/.local/bin/sparkrun", "/home/user"
+
+        def mock_install(host, ssh_kwargs, dry_run=False):
+            return True
+
+        monkeypatch.setattr("sparkrun.cli._export._detect_remote_sparkrun", mock_detect)
+        monkeypatch.setattr("sparkrun.cli._export._install_remote_sparkrun", mock_install)
+
+        result = runner.invoke(
+            main,
+            ["export", "systemd", _TEST_RECIPE_NAME,
+             "--hosts", "10.0.0.1"],
+        )
+        assert result.exit_code == 0
         assert "sparkrun not found" in result.output
+        assert "sparkrun installed" in result.output
 
 
 class TestVramCommand:

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,5 +2,5 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.1
+sparkrun: 0.2.2
 sparkrun-cc-plugin: 0.0.4


### PR DESCRIPTION
This pull request adds automatic remote installation of `sparkrun` when exporting a systemd unit and the head node does not have `sparkrun` installed. If `sparkrun` is missing, the CLI will attempt to install it remotely using `uvx`. The pull request also updates tests to cover the new auto-install behavior and bumps the version to `0.2.2`.

**Auto-installation improvements:**

* Added `_install_remote_sparkrun` function to attempt remote installation of `sparkrun` via `uvx` if it is not found on the head node, with appropriate error handling and user feedback.
* Modified `_detect_remote_sparkrun` to return `(None, None)` instead of exiting on error, allowing the calling code to attempt installation.
* Updated `export_systemd` to use the new detection and auto-install logic, including error handling if installation fails or if `sparkrun` is still not found after installation.

**Testing improvements:**

* Added new test `test_export_systemd_sparkrun_auto_install_success` to verify that auto-install is attempted and succeeds if the initial detection fails but installation works.
* Updated the test for missing `sparkrun` to check for the new error message when installation fails, and removed assertions for the uninstall script in dry-run output. [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL690-R697) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL619)

**Version bump:**

* Bumped the version of `sparkrun` from `0.2.1` to `0.2.2` in both `pyproject.toml` and `versions.yaml`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)