### PR TITLE
v0.2.5 enhance SSH mesh setup to handle user discrepancies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.4"
+version = "0.2.5"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/cli/_setup.py
+++ b/src/sparkrun/cli/_setup.py
@@ -516,6 +516,11 @@ def setup_ssh(ctx, hosts, hosts_file, cluster_name, extra_hosts, include_self, u
                 host_list[i] = ""
     host_list = [h for h in host_list if h]
 
+    # Resolve effective user early (needed for self-inclusion decision)
+    local_user = os.environ.get("USER", "root")
+    if user is None:
+        user = cluster_user or config.ssh_user or local_user
+
     # Track original cluster hosts before extras/self are appended
     cluster_hosts = list(host_list)
     seen = set(host_list)
@@ -532,12 +537,31 @@ def setup_ssh(ctx, hosts, hosts_file, cluster_name, extra_hosts, include_self, u
     # Use the local IP that can route to the first cluster host, since
     # remote hosts may not be able to resolve this machine's hostname.
     self_host: str | None = None
+    cross_user = user != local_user
     if include_self and host_list:
         self_host = local_ip_for(host_list[0])
-        if self_host and self_host not in seen:
+        if self_host and self_host in seen and cross_user:
+            # Control machine IP is in the cluster list but the SSH user
+            # differs from the local OS user — remove it to avoid trying
+            # to SSH as the cluster user on the control machine.
+            host_list = [h for h in host_list if h != self_host]
+            cluster_hosts = [h for h in cluster_hosts if h != self_host]
+            seen.discard(self_host)
+            click.echo(
+                "Note: Removed control machine (%s) from mesh — user '%s' differs from "
+                "local user '%s'. Control→cluster SSH is handled automatically by the mesh script."
+                % (self_host, user, local_user)
+            )
+        elif self_host and self_host not in seen and not cross_user:
             host_list.append(self_host)
             seen.add(self_host)
             added.append("%s (this machine)" % self_host)
+        elif self_host and self_host not in seen and cross_user:
+            click.echo(
+                "Note: Skipping control machine (%s) in mesh — user '%s' differs from "
+                "local user '%s'. Control→cluster SSH is handled automatically by the mesh script."
+                % (self_host, user, local_user)
+            )
 
     if not host_list:
         click.echo("Error: No hosts specified. Use --hosts, --hosts-file, or --cluster.", err=True)
@@ -549,10 +573,6 @@ def setup_ssh(ctx, hosts, hosts_file, cluster_name, extra_hosts, include_self, u
             err=True,
         )
         sys.exit(1)
-
-    # Default user: --user flag > cluster user > config ssh.user > OS user
-    if user is None:
-        user = cluster_user or config.ssh_user or os.environ.get("USER", "root")
 
     if not dry_run:
         click.echo("Setting up SSH mesh for user '%s' across %d hosts..." % (user, len(host_list)))

--- a/src/sparkrun/cli/_wizard.py
+++ b/src/sparkrun/cli/_wizard.py
@@ -355,8 +355,27 @@ def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
                     mesh_hosts = list(host_list)
                     seen = set(mesh_hosts)
                     self_ip = local_ip_for(host_list[0]) if host_list else None
-                    if self_ip and self_ip not in seen:
+                    local_user = os.environ.get("USER", "root")
+                    cross_user = user != local_user
+                    if self_ip and self_ip in seen and cross_user:
+                        # Control machine IP is in the cluster but SSH user
+                        # differs from local OS user — remove to avoid SSH
+                        # as the cluster user on the control machine.
+                        mesh_hosts = [h for h in mesh_hosts if h != self_ip]
+                        seen.discard(self_ip)
+                        click.echo(
+                            "Note: Removed control machine (%s) from mesh — user '%s' differs from "
+                            "local user '%s'. Control→cluster SSH is handled automatically."
+                            % (self_ip, user, local_user)
+                        )
+                    elif self_ip and self_ip not in seen and not cross_user:
                         mesh_hosts.append(self_ip)
+                    elif self_ip and self_ip not in seen and cross_user:
+                        click.echo(
+                            "Note: Skipping control machine (%s) in mesh — user '%s' differs from "
+                            "local user '%s'. Control→cluster SSH is handled automatically."
+                            % (self_ip, user, local_user)
+                        )
 
                     ok = _run_ssh_mesh(
                         mesh_hosts,

--- a/src/sparkrun/scripts/mesh_ssh_keys.sh
+++ b/src/sparkrun/scripts/mesh_ssh_keys.sh
@@ -101,7 +101,7 @@ if [[ "$CALLER" != "$USER_NAME" ]]; then
   echo "Installing caller's public key so the control machine can SSH as '$USER_NAME'..."
   for h in "${HOSTS[@]}"; do
     echo "[*] Installing caller key on $h ..."
-    printf '%s\n' "$LOCAL_PUBKEY" | ssh_stdin_cmd "$h" "set -euo pipefail
+    printf '%s\n' "$LOCAL_PUBKEY" | ssh_stdin_cmd "$h" "set -eu
       umask 077
       mkdir -p ~/.ssh
       chmod 700 ~/.ssh
@@ -118,10 +118,10 @@ fi
 echo "=== Phase 2: Ensure SSH key exists on each host ==="
 for h in "${HOSTS[@]}"; do
   echo "[*] Ensuring ~/.ssh and id_ed25519 exist on $h ..."
-  ssh_cmd "$h" "set -euo pipefail
+  ssh_cmd "$h" "set -eu
     mkdir -p ~/.ssh
     chmod 700 ~/.ssh
-    if [[ ! -f ~/.ssh/id_ed25519 ]]; then
+    if [ ! -f ~/.ssh/id_ed25519 ]; then
       ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519 >/dev/null
     fi
     chmod 600 ~/.ssh/id_ed25519
@@ -153,7 +153,7 @@ for src in "${HOSTS[@]}"; do
 
     echo "    - $src -> $dst"
     # Send the key over stdin and append only if not already present.
-    printf '%s\n' "$key" | ssh_stdin_cmd "$dst" "set -euo pipefail
+    printf '%s\n' "$key" | ssh_stdin_cmd "$dst" "set -eu
       umask 077
       mkdir -p ~/.ssh
       chmod 700 ~/.ssh

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2371,6 +2371,7 @@ class TestSetupSshCommand:
         import sparkrun.core.config
 
         monkeypatch.setattr(sparkrun.core.config, "DEFAULT_CONFIG_DIR", config_root)
+        monkeypatch.setenv("USER", "testuser")
 
         from sparkrun.orchestration.primitives import local_ip_for
 
@@ -2401,6 +2402,7 @@ class TestSetupSshCommand:
         import sparkrun.core.config
 
         monkeypatch.setattr(sparkrun.core.config, "DEFAULT_CONFIG_DIR", config_root)
+        monkeypatch.setenv("USER", "testuser")
 
         from sparkrun.orchestration.primitives import local_ip_for
 
@@ -2621,6 +2623,69 @@ class TestSetupSshCommand:
         call_ips = mock_dist.call_args[0][0]
         assert "192.168.11.1" in call_ips
         assert "192.168.11.2" in call_ips
+
+    def test_setup_ssh_exclude_self_when_user_differs(self, runner, tmp_path, monkeypatch):
+        """Test that --include-self skips control machine when SSH user differs from local user."""
+        config_root = tmp_path / "config"
+        config_root.mkdir()
+        import sparkrun.core.config
+
+        monkeypatch.setattr(sparkrun.core.config, "DEFAULT_CONFIG_DIR", config_root)
+        monkeypatch.setenv("USER", "localuser")
+
+        result = runner.invoke(
+            main,
+            [
+                "setup",
+                "ssh",
+                "--hosts",
+                "10.0.0.1,10.0.0.2",
+                "--user",
+                "differentuser",
+                "--include-self",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        # Self IP should NOT appear in the mesh command
+        assert "Skipping control machine" in result.output
+        assert "differs from local user" in result.output
+        # The two cluster hosts should still be there
+        assert "10.0.0.1" in result.output
+        assert "10.0.0.2" in result.output
+
+    def test_setup_ssh_remove_self_from_cluster_when_user_differs(self, runner, tmp_path, monkeypatch):
+        """Test that control machine IP is removed from host list when user differs."""
+        config_root = tmp_path / "config"
+        config_root.mkdir()
+        import sparkrun.core.config
+
+        monkeypatch.setattr(sparkrun.core.config, "DEFAULT_CONFIG_DIR", config_root)
+        monkeypatch.setenv("USER", "localuser")
+
+        from sparkrun.orchestration.primitives import local_ip_for
+
+        local_ip = local_ip_for("10.0.0.1")
+
+        result = runner.invoke(
+            main,
+            [
+                "setup",
+                "ssh",
+                "--hosts",
+                "10.0.0.1,%s,10.0.0.2" % local_ip,
+                "--user",
+                "differentuser",
+                "--include-self",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Removed control machine" in result.output
+        assert "differs from local user" in result.output
+        # The local IP should NOT appear in the mesh command line
+        cmd_line = result.output.split("Would run")[-1]
+        assert local_ip not in cmd_line
 
 
 class TestSetupFixPermissions:

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,5 +2,5 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.4
+sparkrun: 0.2.5
 sparkrun-cc-plugin: 0.0.4


### PR DESCRIPTION
This pull request improves the handling of SSH mesh setup when the specified SSH user differs from the local OS user. It ensures that the control machine is not included in the mesh in such cases, preventing attempts to SSH into itself as a different user, and provides clear user feedback. It also adds new tests to verify this behavior and includes minor shell script robustness improvements. The project version is bumped to 0.2.5.

**SSH mesh setup logic improvements:**

* Updated `setup_ssh` in `src/sparkrun/cli/_setup.py` to detect when the SSH user differs from the local OS user and to exclude or remove the control machine from the mesh accordingly, with clear CLI messages. This prevents SSH attempts as an unintended user on the control machine. [[1]](diffhunk://#diff-59858c41b1d886efbf01ec9341419fd7c51be4a1351aa246bc80a0b54225784bR519-R523) [[2]](diffhunk://#diff-59858c41b1d886efbf01ec9341419fd7c51be4a1351aa246bc80a0b54225784bR540-R564)
* Applied similar logic to the setup wizard in `src/sparkrun/cli/_wizard.py` to ensure consistent behavior and user feedback in interactive setup flows.

**Testing enhancements:**

* Added new tests in `tests/test_cli.py` to verify that the control machine is excluded or removed from the mesh when the SSH user differs from the local user, and to ensure correct CLI output.
* Updated existing tests to set the `USER` environment variable for consistent test behavior. [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR2374) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR2405)

**Shell script robustness:**

* Modified `src/sparkrun/scripts/mesh_ssh_keys.sh` to remove `-o pipefail` from `set -euo pipefail` (now `set -eu`) for better compatibility and replaced `[[ ... ]]` with `[ ... ]` for POSIX compliance. [[1]](diffhunk://#diff-f3a29beba01cb24d185ad0cef65fa36d4968e85f798a9f46547bfd7d5e50f138L104-R104) [[2]](diffhunk://#diff-f3a29beba01cb24d185ad0cef65fa36d4968e85f798a9f46547bfd7d5e50f138L121-R124) [[3]](diffhunk://#diff-f3a29beba01cb24d185ad0cef65fa36d4968e85f798a9f46547bfd7d5e50f138L156-R156)

**Version bump:**

* Bumped the version of the project to 0.2.5 in `pyproject.toml` and `versions.yaml` to reflect these changes. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)