### PR TITLE
v0.2.19: fix update solo_entries handling in _stop_logs.py and discovery.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.18"
+version = "0.2.19"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/cli/_stop_logs.py
+++ b/src/sparkrun/cli/_stop_logs.py
@@ -91,8 +91,8 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run):
     for cid, group in result.groups.items():
         recipe_label = group.meta.get("recipe", "unknown")
         click.echo("  %s (%s) — %d container(s)" % (cid, recipe_label, len(group.members)))
-    for host, name, status, image in result.solo_entries:
-        click.echo("  %s on %s" % (name, host))
+    for entry in result.solo_entries:
+        click.echo("  %s on %s" % (entry.name, entry.host))
 
     # Build per-host container name mapping
     host_containers: dict[str, list[str]] = {}
@@ -100,8 +100,8 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run):
         for host, role, status, image in group.members:
             container_name = "%s_%s" % (cid, role)
             host_containers.setdefault(host, []).append(container_name)
-    for host, name, status, image in result.solo_entries:
-        host_containers.setdefault(host, []).append(name)
+    for entry in result.solo_entries:
+        host_containers.setdefault(entry.host, []).append(entry.name)
 
     # Stop containers per host
     click.echo("Stopping all containers...")
@@ -115,8 +115,8 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run):
     if not dry_run:
         for cid in result.groups:
             remove_job_metadata(cid, cache_dir=str(config.cache_dir))
-        for _host, name, _status, _image in result.solo_entries:
-            solo_cid = name.removesuffix("_solo") if name.endswith("_solo") else name
+        for entry in result.solo_entries:
+            solo_cid = entry.name.removesuffix("_solo") if entry.name.endswith("_solo") else entry.name
             remove_job_metadata(solo_cid, cache_dir=str(config.cache_dir))
 
     hosts_touched = len(host_containers)

--- a/src/sparkrun/proxy/discovery.py
+++ b/src/sparkrun/proxy/discovery.py
@@ -113,10 +113,10 @@ def _discover_live(
         if ep:
             endpoints.append(ep)
 
-    for host, name, _status, _image in result.solo_entries:
-        cid = name.removesuffix("_solo")
+    for entry in result.solo_entries:
+        cid = entry.name.removesuffix("_solo")
         meta = load_job_metadata(cid, cache_dir=cache_dir) or {}
-        ep = _endpoint_from_meta(cid, meta, fallback_host=host)
+        ep = _endpoint_from_meta(cid, meta, fallback_host=entry.host)
         if ep:
             endpoints.append(ep)
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,5 +2,5 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.18
+sparkrun: 0.2.19
 sparkrun-cc-plugin: 0.0.4


### PR DESCRIPTION
This pull request updates the `sparkrun` package to version 0.2.19 and refactors code handling solo container entries to use attribute access instead of tuple unpacking, improving code clarity and maintainability.

Version bump:

* Updated the `sparkrun` package version from `0.2.18` to `0.2.19` in both `pyproject.toml` and `versions.yaml`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)

Refactoring for solo container entries:

* Refactored code in `_stop_all` (`src/sparkrun/cli/_stop_logs.py`) and `_discover_live` (`src/sparkrun/proxy/discovery.py`) to access solo container entry fields via attributes (e.g., `entry.name`, `entry.host`) instead of tuple unpacking, enhancing readability and reducing potential errors if the structure changes. [[1]](diffhunk://#diff-35af377bb933ad8cadd6069632aa606d76d20c4c18c3a68cdf337d12fb5c15b9L94-R104) [[2]](diffhunk://#diff-35af377bb933ad8cadd6069632aa606d76d20c4c18c3a68cdf337d12fb5c15b9L118-R119) [[3]](diffhunk://#diff-91b3c2ff2a7fad1b651b18150ff8bd90ee25a6dd5a4e0baa0d311e0612ec0599L116-R119)