### PR TITLE
v0.2.20 json outputs for sparkrun proxy; improvements for quant+parameters detection on smaller models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.19"
+version = "0.2.20"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/benchmarking/base.py
+++ b/src/sparkrun/benchmarking/base.py
@@ -174,6 +174,13 @@ class BenchmarkResult:
     recipe_name: Optional[str] = None
     launch_result: Optional["LaunchResult"] = None
 
+    # store detailed recipe info for "non-launch" scenarios
+    recipe: Optional["Recipe"] = None
+    overrides: Optional[dict[str, Any]] = None
+    cluster_id: Optional[str] = None
+    host_list: Optional[list[str]] = None
+    container_image: Optional[str] = None
+
     # benchmark info
     framework: Optional["BenchmarkingPlugin"] = None
     profile: Optional[str] = None
@@ -213,17 +220,31 @@ class BenchmarkResult:
         from sparkrun.models.download import parse_gguf_model_spec
         from sparkrun.utils.cli_formatters import RUNTIME_DISPLAY as _RUNTIME_DISPLAY
 
-        launch_result = self.launch_result
-        recipe = launch_result.recipe
-        overrides = launch_result.overrides
+        # Use launch_result fields when available, fall back to direct fields
+        # (e.g. when --skip-run was used and no launch occurred).
+        if launch_result := self.launch_result:
+            recipe = launch_result.recipe
+            overrides = launch_result.overrides
+            cluster_id = launch_result.cluster_id
+            host_list = launch_result.host_list
+            container_image = launch_result.container_image
+            runtime_info = launch_result.runtime_info
+        else:
+            recipe = self.recipe
+            overrides = self.overrides or {}
+            cluster_id = self.cluster_id
+            host_list = self.host_list or []
+            container_image = self.container_image
+            runtime_info = {}
+
         framework = self.framework
         profile = self.profile
         benchmark_args = self.benchmark_args
 
         # Resolve container image to a pinned long-term reference when possible
         container_pinned = False
-        recipe_container = launch_result.container_image
-        if launch_result.builder:
+        recipe_container = container_image or recipe.container
+        if launch_result and launch_result.builder:
             try:
                 resolved_image, pinned = launch_result.builder.resolve_long_term_image(
                     container_image=launch_result.container_image,
@@ -238,7 +259,6 @@ class BenchmarkResult:
                 logger.debug("Long-term image resolution failed", exc_info=True)
 
         recipe_hash = hashlib.sha256(recipe.export(overrides=None).encode("utf-8")).hexdigest()
-        # effective_recipe = recipe.export(overrides=overrides, container_image=recipe_container, )
 
         hf_model = parse_gguf_model_spec(recipe.model)[0]
         model_meta: dict[str, Any] = {}
@@ -282,14 +302,14 @@ class BenchmarkResult:
                 "end": self.end_time.isoformat(),
                 "duration": (self.end_time - self.start_time).total_seconds(),
             },
-            "cluster": _build_cluster_meta(recipe, overrides, launch_result.cluster_id, launch_result.host_list),
+            "cluster": _build_cluster_meta(recipe, overrides, cluster_id, host_list),
             "benchmark": {
                 "framework": framework.framework_name if framework else "unknown",
                 "profile": profile,
                 "args": benchmark_args,
             },
             "model": model_meta,
-            "runtime_info": launch_result.runtime_info,
+            "runtime_info": runtime_info,
         }
 
         # TODO: more care for sparkrun version and/or other metadata

--- a/src/sparkrun/cli/_arena.py
+++ b/src/sparkrun/cli/_arena.py
@@ -220,14 +220,14 @@ def arena_benchmark(
         export_results_files=False,
     )
 
-    # require result, success, and launch result data (cannot benchmark what we didn't start)
-    if not bench_result or not bench_result.success or not bench_result.launch_result:
+    # require result and success; launch_result may be absent with --skip-run
+    if not bench_result or not bench_result.success:
         click.echo("Benchmark did not complete successfully. Skipping upload.", err=True)
         return
 
-    # gather recipe/metadata/runtime info
-    recipe = bench_result.launch_result.recipe
-    overrides = bench_result.launch_result.overrides
+    # gather recipe/metadata/runtime info (works with or without launch_result)
+    recipe = bench_result.launch_result.recipe if bench_result.launch_result else bench_result.recipe
+    overrides = bench_result.launch_result.overrides if bench_result.launch_result else (bench_result.overrides or {})
     metadata = bench_result.generate_metadata()
     effective_recipe = recipe.export(
         overrides=overrides,

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -366,6 +366,14 @@ def _run_benchmark(
 
     cluster_id = _gen_cid(recipe, host_list, overrides=overrides)
 
+    # Store recipe/cluster context on bench_result so callers (e.g. arena
+    # benchmark) can generate metadata even when --skip-run skips the launch.
+    bench_result.recipe = recipe
+    bench_result.overrides = overrides
+    bench_result.cluster_id = cluster_id
+    bench_result.host_list = host_list
+    bench_result.container_image = container_image
+
     try:
         # ---------------------------------------------------------------
         # 6. Launch inference (unless --skip-run)

--- a/src/sparkrun/cli/_proxy.py
+++ b/src/sparkrun/cli/_proxy.py
@@ -13,6 +13,8 @@ from ._common import (
     _resolve_hosts_or_exit,
     dry_run_option,
     host_options,
+    json_option,
+    print_json,
     recipe_override_options,
     resolve_cluster_config,
     validate_and_prepare_hosts,
@@ -196,7 +198,8 @@ def stop(dry_run):
 
 
 @proxy.command()
-def status():
+@json_option()
+def status(output_json):
     """Show proxy process status and registered models."""
     from sparkrun.proxy.engine import ProxyEngine
 
@@ -204,37 +207,69 @@ def status():
     state = engine.get_state()
 
     if not state:
+        if output_json:
+            print_json({"running": False})
+            return
         click.echo("No proxy state found.")
         return
 
     running = engine.is_running()
+
+    # Autodiscover status
+    ad_pid = state.get("autodiscover_pid")
+    ad_running = False
+    if ad_pid:
+        import os
+
+        try:
+            os.kill(int(ad_pid), 0)
+            ad_running = True
+        except (ProcessLookupError, PermissionError, ValueError):
+            pass
+
+    # Models (only if proxy is actually running)
+    model_list = []
+    if running:
+        for m in engine.list_models_via_api():
+            name = m.get("model_name", "?")
+            params = m.get("litellm_params", m.get("model_info", {}).get("litellm_params", {}))
+            api_base = params.get("api_base", "?")
+            model_list.append({"model_name": name, "api_base": api_base})
+
+    if output_json:
+        data = {
+            "running": running,
+            "pid": state.get("pid"),
+            "host": state.get("host"),
+            "port": state.get("port"),
+            "started_at": state.get("started_at"),
+            "models": model_list,
+        }
+        if ad_pid:
+            data["autodiscover"] = {"pid": int(ad_pid), "running": ad_running}
+        print_json(data)
+        return
+
     click.echo("Proxy status: %s" % ("running" if running else "stopped (stale state)"))
     click.echo("  PID:    %s" % state.get("pid", "?"))
     click.echo("  Host:   %s" % state.get("host", "?"))
     click.echo("  Port:   %s" % state.get("port", "?"))
     click.echo("  Start:  %s" % state.get("started_at", "?"))
 
-    ad_pid = state.get("autodiscover_pid")
     if ad_pid:
-        import os
-
-        try:
-            os.kill(int(ad_pid), 0)
+        if ad_running:
             click.echo("  Auto-discover: running (PID %s)" % ad_pid)
-        except (ProcessLookupError, PermissionError, ValueError):
+        else:
             click.echo("  Auto-discover: stopped (stale PID %s)" % ad_pid)
 
     if running:
-        models = engine.list_models_via_api()
-        if models:
+        if model_list:
             click.echo("")
-            click.echo("Registered models (%d):" % len(models))
-            for m in models:
-                name = m.get("model_name", "?")
-                info = m.get("model_info", {})
-                click.echo("  %s" % name)
-                if info.get("litellm_params", {}).get("api_base"):
-                    click.echo("    -> %s" % info["litellm_params"]["api_base"])
+            click.echo("Registered models (%d):" % len(model_list))
+            for m in model_list:
+                click.echo("  %s" % m["model_name"])
+                if m["api_base"] != "?":
+                    click.echo("    -> %s" % m["api_base"])
         else:
             click.echo("")
             click.echo("No models registered (or management API unavailable).")
@@ -307,7 +342,8 @@ def status():
 
 @proxy.command()
 @click.option("--refresh", is_flag=True, help="Re-discover endpoints and update proxy")
-def models(refresh):
+@json_option()
+def models(refresh, output_json):
     """List models registered with the proxy.
 
     Uses the management API to query the running proxy.
@@ -318,37 +354,52 @@ def models(refresh):
     engine = ProxyEngine()
 
     if not engine.is_running():
+        if output_json:
+            print_json([])
+            return
         click.echo("Proxy is not running. Start it with: sparkrun proxy start")
         return
 
     if refresh:
         from sparkrun.proxy.discovery import discover_endpoints
 
-        click.echo("Re-discovering endpoints...")
+        if not output_json:
+            click.echo("Re-discovering endpoints...")
         endpoints = discover_endpoints()
         healthy = [ep for ep in endpoints if ep.healthy]
         added, removed = engine.sync_models(healthy)
-        if added or removed:
-            parts = []
-            if added:
-                parts.append("added %d" % added)
-            if removed:
-                parts.append("removed %d stale" % removed)
-            click.echo("Synced proxy models: %s." % ", ".join(parts))
-        else:
-            click.echo("Proxy models already in sync.")
+        if not output_json:
+            if added or removed:
+                parts = []
+                if added:
+                    parts.append("added %d" % added)
+                if removed:
+                    parts.append("removed %d stale" % removed)
+                click.echo("Synced proxy models: %s." % ", ".join(parts))
+            else:
+                click.echo("Proxy models already in sync.")
 
-    model_list = engine.list_models_via_api()
+    raw_models = engine.list_models_via_api()
+
+    # Normalize model entries for both output modes
+    model_list = []
+    for m in raw_models:
+        name = m.get("model_name", "?")
+        params = m.get("litellm_params", m.get("model_info", {}).get("litellm_params", {}))
+        api_base = params.get("api_base", "?")
+        model_list.append({"model_name": name, "api_base": api_base})
+
+    if output_json:
+        print_json(model_list)
+        return
+
     if not model_list:
         click.echo("No models registered with the proxy.")
         return
 
     click.echo("Models (%d):" % len(model_list))
     for m in model_list:
-        name = m.get("model_name", "?")
-        params = m.get("litellm_params", m.get("model_info", {}).get("litellm_params", {}))
-        api_base = params.get("api_base", "?")
-        click.echo("  %-40s -> %s" % (name, api_base))
+        click.echo("  %-40s -> %s" % (m["model_name"], m["api_base"]))
 
 
 # ---------------------------------------------------------------------------
@@ -423,12 +474,17 @@ def alias_remove(alias_name):
 
 
 @alias.command("list")
-def alias_list():
+@json_option()
+def alias_list(output_json):
     """List all configured aliases."""
     from sparkrun.proxy.config import ProxyConfig
 
     proxy_cfg = ProxyConfig()
     aliases = proxy_cfg.list_aliases()
+
+    if output_json:
+        print_json(dict(aliases))
+        return
 
     if not aliases:
         click.echo("No aliases configured.")

--- a/src/sparkrun/cli/_setup/_commands.py
+++ b/src/sparkrun/cli/_setup/_commands.py
@@ -1710,6 +1710,197 @@ def setup_earlyoom(ctx, hosts, hosts_file, cluster_name, user, extra_prefer, ext
 
 
 # ---------------------------------------------------------------------------
+# Founders Edition System Update
+# ---------------------------------------------------------------------------
+
+
+_FE_UPDATE_STEPS = [
+    ("Updating package lists", "apt update"),
+    ("Upgrading packages", "DEBIAN_FRONTEND=noninteractive apt dist-upgrade -y"),
+    ("Refreshing firmware metadata", "fwupdmgr refresh --force"),
+    ("Upgrading firmware", "fwupdmgr upgrade -y --no-reboot-check"),
+]
+
+
+@setup.command("fe-system-update", hidden=True)
+@host_options
+@click.option("--user", default=None, help="SSH user (default: cluster user or $USER)")
+@dry_run_option
+@click.pass_context
+def setup_fe_system_update(ctx, hosts, hosts_file, cluster_name, user, dry_run):
+    """Run a full system update on DGX Spark Founders Edition hosts.
+
+    Updates system packages (apt), firmware (fwupdmgr), and reboots.
+    Can target the local machine, cluster hosts, or both.
+
+    \b
+    Steps performed (as root):
+      1. apt update
+      2. apt dist-upgrade
+      3. fwupdmgr refresh
+      4. fwupdmgr upgrade
+      5. reboot
+    """
+    from sparkrun.core.config import SparkrunConfig
+
+    from .._common import _resolve_setup_context
+    from ._sudo import ensure_sudo_password
+
+    # TODO: should use same sctx init as we typically use
+    config = SparkrunConfig()
+
+    # --- Step 1: Determine target hosts ---
+    # If explicit hosts/cluster provided, use those directly
+    explicit_hosts = hosts or hosts_file or cluster_name
+    if explicit_hosts:
+        host_list, user, ssh_kwargs = _resolve_setup_context(hosts, hosts_file, cluster_name, config, user)
+    else:
+        # Interactive: ask local vs cluster
+        click.echo("Where would you like to run the system update?")
+        click.echo()
+        click.echo("  1) Local machine only")
+
+        # Try to list cluster hosts
+        mgr = _get_cluster_manager()
+        default_cluster = mgr.get_default()
+        cluster_hosts = []
+        if default_cluster:
+            try:
+                cdata = mgr.get_cluster(default_cluster)
+                cluster_hosts = cdata.get("hosts", [])
+            except Exception:
+                pass
+
+        if cluster_hosts:
+            click.echo("  2) Cluster hosts (%s): %s" % (default_cluster, ", ".join(cluster_hosts)))
+            click.echo("  3) All (local + cluster hosts)")
+            choice = click.prompt("Selection", type=click.IntRange(1, 3), default=2)
+        else:
+            click.echo("  (No default cluster configured — cluster option unavailable)")
+            choice = click.prompt("Selection", type=click.IntRange(1, 1), default=1)
+
+        click.echo()
+
+        import socket
+
+        if choice == 1:
+            host_list = [socket.gethostname()]
+        elif choice == 2:
+            host_list = list(cluster_hosts)
+        else:
+            local = socket.gethostname()
+            host_list = [local] + [h for h in cluster_hosts if h != local]
+
+        import os
+
+        if user is None:
+            user = config.ssh_user or os.environ.get("USER", "root")
+        from sparkrun.orchestration.primitives import build_ssh_kwargs
+
+        ssh_kwargs = build_ssh_kwargs(config)
+        if user:
+            ssh_kwargs["ssh_user"] = user
+
+    # TODO: guard to detect non-founders edition hosts and block them
+
+    # --- Step 2: Confirm the activity ---
+    click.echo("Founders Edition System Update")
+    click.echo("=" * 40)
+    click.echo("Target hosts: %s" % ", ".join(host_list))
+    click.echo()
+    click.echo("The following will be executed as root:")
+    for desc, cmd in _FE_UPDATE_STEPS:
+        click.echo("  - %s  (%s)" % (desc, cmd))
+    click.echo("  - Reboot")
+    click.echo()
+
+    if not dry_run:
+        if not click.confirm("Proceed?", default=False):
+            click.echo("Aborted.")
+            return
+
+    # --- Step 3: Get sudo access ---
+    sudo_password, indirect_user = ensure_sudo_password(
+        host_list,
+        user,
+        ssh_kwargs,
+        dry_run=dry_run,
+        allow_indirect=True,
+        default_user=user,
+    )
+    sudo_ssh_kwargs = dict(ssh_kwargs)
+    if indirect_user:
+        sudo_ssh_kwargs["ssh_user"] = indirect_user
+
+    # --- Step 4: Run update steps ---
+    from sparkrun.orchestration.sudo import run_sudo_script_on_host
+
+    failed_hosts: set[str] = set()
+    for desc, cmd in _FE_UPDATE_STEPS:
+        active_hosts = [h for h in host_list if h not in failed_hosts]
+        if not active_hosts:
+            click.echo("All hosts failed — aborting remaining steps.")
+            break
+
+        click.echo()
+        click.echo("[%s]" % desc)
+        for h in active_hosts:
+            click.echo("  %-30s ..." % h, nl=False)
+            r = run_sudo_script_on_host(
+                h,
+                cmd,
+                password=sudo_password,
+                ssh_kwargs=sudo_ssh_kwargs,
+                timeout=600,
+                dry_run=dry_run,
+            )
+            if r.success:
+                click.echo(" OK")
+                if r.stdout.strip():
+                    # Show last few lines of output for visibility
+                    for line in r.stdout.strip().splitlines()[-3:]:
+                        click.echo("    %s" % line)
+            else:
+                click.echo(" FAILED")
+                click.echo("    %s" % r.stderr.strip()[:200], err=True)
+                failed_hosts.add(h)
+
+    # --- Step 5: Reboot ---
+    reboot_hosts = [h for h in host_list if h not in failed_hosts]
+    if reboot_hosts:
+        click.echo()
+        click.echo("[Reboot]")
+        if dry_run:
+            click.echo("  [dry-run] Would reboot: %s" % ", ".join(reboot_hosts))
+        else:
+            if not click.confirm("Updates complete. Reboot %d host(s) now?" % len(reboot_hosts), default=True):
+                click.echo("Skipping reboot. Remember to reboot manually for updates to take effect.")
+            else:
+                for h in reboot_hosts:
+                    click.echo("  %-30s rebooting..." % h)
+                    run_sudo_script_on_host(
+                        h,
+                        "nohup bash -c 'sleep 2 && reboot' &>/dev/null &",
+                        password=sudo_password,
+                        ssh_kwargs=sudo_ssh_kwargs,
+                        timeout=10,
+                        dry_run=dry_run,
+                    )
+                click.echo()
+                click.echo("Reboot initiated on %d host(s)." % len(reboot_hosts))
+
+    # --- Summary ---
+    click.echo()
+    ok = len([h for h in host_list if h not in failed_hosts])
+    fail = len(failed_hosts)
+    if fail:
+        click.echo("Results: %d updated, %d failed (%s)" % (ok, fail, ", ".join(sorted(failed_hosts))))
+        sys.exit(1)
+    else:
+        click.echo("Results: %d host(s) updated successfully." % ok)
+
+
+# ---------------------------------------------------------------------------
 # Diagnose
 # ---------------------------------------------------------------------------
 

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -238,26 +238,88 @@ def fetch_safetensors_size(
 
         from sparkrun.models.download import _hub_cache
 
-        kwargs: dict[str, Any] = {
-            "repo_id": model_id,
-            "filename": "model.safetensors.index.json",
-        }
+        hub_kwargs: dict[str, Any] = {"repo_id": model_id}
         if revision:
-            kwargs["revision"] = revision
+            hub_kwargs["revision"] = revision
         if cache_dir:
-            kwargs["cache_dir"] = _hub_cache(cache_dir)
-        disable_progress_bars()
+            hub_kwargs["cache_dir"] = _hub_cache(cache_dir)
+
+        # Try 1: sharded model with index file
         try:
-            index_path = hf_hub_download(**kwargs)
-        finally:
-            enable_progress_bars()
-        with open(index_path) as f:
-            index = json.load(f)
-        total_size = index.get("metadata", {}).get("total_size")
-        if total_size is not None:
-            return int(total_size)
+            disable_progress_bars()
+            try:
+                index_path = hf_hub_download(
+                    **hub_kwargs, filename="model.safetensors.index.json"
+                )
+            finally:
+                enable_progress_bars()
+            with open(index_path) as f:
+                index = json.load(f)
+            total_size = index.get("metadata", {}).get("total_size")
+            if total_size is not None:
+                return int(total_size)
+        except Exception:
+            pass
+
+        # Try 2: single-file model — read safetensors header for total param size
+        try:
+            import os
+
+            disable_progress_bars()
+            try:
+                sf_path = hf_hub_download(
+                    **hub_kwargs, filename="model.safetensors"
+                )
+            finally:
+                enable_progress_bars()
+            # safetensors header: first 8 bytes = header size (u64 LE),
+            # then JSON header with tensor metadata including shape/dtype
+            import struct
+
+            with open(sf_path, "rb") as f:
+                header_size = struct.unpack("<Q", f.read(8))[0]
+                header = json.loads(f.read(header_size))
+
+            total_bytes = 0
+            dtype_sizes = {
+                "F32": 4, "F16": 2, "BF16": 2, "F8_E4M3": 1, "F8_E5M2": 1,
+                "I64": 8, "I32": 4, "I16": 2, "I8": 1, "U8": 1, "BOOL": 1,
+            }
+            for key, info in header.items():
+                if key == "__metadata__":
+                    continue
+                shape = info.get("shape", [])
+                dtype = info.get("dtype", "")
+                elem_size = dtype_sizes.get(dtype, 2)  # default to 2 bytes
+                num_elements = 1
+                for dim in shape:
+                    num_elements *= dim
+                total_bytes += num_elements * elem_size
+            if total_bytes > 0:
+                return total_bytes
+        except Exception:
+            pass
+
+        # Try 3: fall back to file size as rough approximation
+        try:
+            import os
+
+            disable_progress_bars()
+            try:
+                sf_path = hf_hub_download(
+                    **hub_kwargs, filename="model.safetensors"
+                )
+            finally:
+                enable_progress_bars()
+            size = os.path.getsize(sf_path)
+            if size > 0:
+                logger.debug("Using file size as param size estimate for %s", model_id)
+                return size
+        except Exception:
+            pass
+
     except Exception as e:
-        logger.debug("Could not fetch safetensors index for %s: %s", model_id, e)
+        logger.debug("Could not fetch safetensors size for %s: %s", model_id, e)
     return None
 
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,5 +2,5 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.19
+sparkrun: 0.2.20
 sparkrun-cc-plugin: 0.0.4


### PR DESCRIPTION
This pull request introduces several improvements and new features to the `sparkrun` project. The most significant changes include enhanced support for JSON output in proxy-related CLI commands, and improved handling of benchmarking metadata for workflows that skip launching. These updates improve usability, automation capabilities, and robustness for both users and downstream tools.

**CLI Usability and Automation Improvements**
- Enhanced `sparkrun proxy` CLI commands (`status`, `models`, `alias list`) to support a `--json` option, enabling structured output for scripting and integration. Output is normalized for consistency across commands. [[1]](diffhunk://#diff-f404401803d18733ea3118206725a978805cce1fb7bf3fee95c17ad869868895R16-R17) [[2]](diffhunk://#diff-f404401803d18733ea3118206725a978805cce1fb7bf3fee95c17ad869868895L199-R272) [[3]](diffhunk://#diff-f404401803d18733ea3118206725a978805cce1fb7bf3fee95c17ad869868895L310-R346) [[4]](diffhunk://#diff-f404401803d18733ea3118206725a978805cce1fb7bf3fee95c17ad869868895R357-R371) [[5]](diffhunk://#diff-f404401803d18733ea3118206725a978805cce1fb7bf3fee95c17ad869868895L341-R402) [[6]](diffhunk://#diff-f404401803d18733ea3118206725a978805cce1fb7bf3fee95c17ad869868895L426-R488)

**Benchmarking and Metadata Handling**
- Improved `BenchmarkResult` to store recipe and cluster context even when the launch is skipped (e.g., with `--skip-run`), allowing metadata generation and result uploads in these scenarios. Adjusted CLI and metadata generation logic accordingly. [[1]](diffhunk://#diff-30b4805a1c7734a39171b707a5ef590c0de350bd046f91746fd118706d7c0720R177-R183) [[2]](diffhunk://#diff-642a32603a35eeb78e6fe0f6dfc131c1393c15d11c6cacc89bd56ae6c15c8265R369-R376) [[3]](diffhunk://#diff-30b4805a1c7734a39171b707a5ef590c0de350bd046f91746fd118706d7c0720L216-R247) [[4]](diffhunk://#diff-30b4805a1c7734a39171b707a5ef590c0de350bd046f91746fd118706d7c0720L241) [[5]](diffhunk://#diff-30b4805a1c7734a39171b707a5ef590c0de350bd046f91746fd118706d7c0720L285-R312) [[6]](diffhunk://#diff-72fc99a67d8746ecd3e5d8474f0fb7d66df5ca7c70a505cdb6bda1f6794d623bL223-R230)

**Version Update**
- Bumped the project version to `0.2.20` in `pyproject.toml`.