### PR TITLE
v0.2.20 vram detection improvements for awq4 quants and small models

### DIFF
--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -659,6 +659,7 @@ class Recipe:
             estimate_vram as _estimate_vram,
             extract_model_info,
             fetch_model_config,
+            fetch_safetensors_params,
             fetch_safetensors_size,
             parse_param_count,
         )
@@ -732,15 +733,18 @@ class Recipe:
         # Parse model_params
         model_params = parse_param_count(model_params_raw) if model_params_raw is not None else None
 
-        # Fallback: derive model_params from safetensors index when metadata
-        # doesn't provide it.  The index file records total_size in bytes;
-        # dividing by bytes-per-element gives an approximate parameter count.
-        if model_params is None and model_vram is None and auto_detect and self.model and model_dtype:
-            bpe = bytes_per_element(str(model_dtype))
-            if bpe is not None and bpe > 0:
-                total_size = fetch_safetensors_size(self.model, revision=self.model_revision, cache_dir=cache_dir)
-                if total_size is not None:
-                    model_params = int(total_size / bpe)
+        # Fallback: derive model_params from HF API or safetensors index when
+        # metadata doesn't provide it.  Prefer the lightweight API call
+        # (fetch_safetensors_params) which returns param count directly and
+        # handles mixed-dtype quantized models correctly.
+        if model_params is None and model_vram is None and auto_detect and self.model:
+            model_params = fetch_safetensors_params(self.model, revision=self.model_revision)
+            if model_params is None and model_dtype:
+                bpe = bytes_per_element(str(model_dtype))
+                if bpe is not None and bpe > 0:
+                    total_size = fetch_safetensors_size(self.model, revision=self.model_revision, cache_dir=cache_dir)
+                    if total_size is not None:
+                        model_params = int(total_size / bpe)
 
         # Get effective max_model_len and tensor_parallel from config chain
         max_model_len = config.get("max_model_len")

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -23,6 +23,7 @@ _DTYPE_BYTES: dict[str, float] = {
     "int4": 0.5,
     "nvfp4": 0.5,
     "awq4": 0.5,
+    'w4a16_awq': 0.5,
     "awq8": 1.0,
     "gptq": 0.5,
     "mxfp4": 0.5,
@@ -175,9 +176,9 @@ def parse_param_count(value: int | float | str) -> int | None:
 
 
 def fetch_model_config(
-    model_id: str,
-    revision: str | None = None,
-    cache_dir: str | None = None,
+        model_id: str,
+        revision: str | None = None,
+        cache_dir: str | None = None,
 ) -> dict[str, Any] | None:
     """Fetch model config.json from HuggingFace Hub without downloading weights.
 
@@ -213,9 +214,9 @@ def fetch_model_config(
 
 
 def fetch_safetensors_size(
-    model_id: str,
-    revision: str | None = None,
-    cache_dir: str | None = None,
+        model_id: str,
+        revision: str | None = None,
+        cache_dir: str | None = None,
 ) -> int | None:
     """Fetch total parameter storage size from safetensors index metadata.
 
@@ -348,8 +349,8 @@ def fetch_safetensors_size(
 
 
 def fetch_safetensors_params(
-    model_id: str,
-    revision: str | None = None,
+        model_id: str,
+        revision: str | None = None,
 ) -> int | None:
     """Fetch total parameter count from HuggingFace model safetensors metadata.
 
@@ -487,19 +488,19 @@ def extract_model_info(hf_config: dict[str, Any]) -> dict[str, Any]:
 
 
 def estimate_vram(
-    *,
-    model_params: int | None = None,
-    model_dtype: str | None = None,
-    kv_dtype: str | None = None,
-    num_layers: int | None = None,
-    num_kv_heads: int | None = None,
-    head_dim: int | None = None,
-    max_model_len: int | None = None,
-    tensor_parallel: int = 1,
-    pipeline_parallel: int = 1,
-    model_vram: float | None = None,
-    kv_vram_per_token: float | None = None,
-    gpu_memory_utilization: float | None = None,
+        *,
+        model_params: int | None = None,
+        model_dtype: str | None = None,
+        kv_dtype: str | None = None,
+        num_layers: int | None = None,
+        num_kv_heads: int | None = None,
+        head_dim: int | None = None,
+        max_model_len: int | None = None,
+        tensor_parallel: int = 1,
+        pipeline_parallel: int = 1,
+        model_vram: float | None = None,
+        kv_vram_per_token: float | None = None,
+        gpu_memory_utilization: float | None = None,
 ) -> VRAMEstimate:
     """Estimate VRAM usage for an inference workload.
 
@@ -534,7 +535,7 @@ def estimate_vram(
     elif model_params and model_dtype:
         bpe = bytes_per_element(model_dtype)
         if bpe is not None:
-            model_weights_gb = model_params * bpe / (1024**3)
+            model_weights_gb = model_params * bpe / (1024 ** 3)
         else:
             warnings.append("Unknown dtype %r; cannot estimate model weight VRAM" % model_dtype)
     elif not model_params:
@@ -548,7 +549,7 @@ def estimate_vram(
 
     if kv_vram_per_token is not None:
         # Direct override: user provides GB per token
-        kv_cache_per_token_bytes = kv_vram_per_token * (1024**3)  # convert to bytes for display
+        kv_cache_per_token_bytes = kv_vram_per_token * (1024 ** 3)  # convert to bytes for display
         if max_model_len:
             kv_cache_total_gb = kv_vram_per_token * max_model_len
     elif num_layers and num_kv_heads and head_dim:
@@ -557,7 +558,7 @@ def estimate_vram(
             # Per token: 2 (K+V) * num_layers * num_kv_heads * head_dim * bytes
             kv_cache_per_token_bytes = 2.0 * num_layers * num_kv_heads * head_dim * kv_bpe
             if max_model_len:
-                kv_cache_total_gb = kv_cache_per_token_bytes * max_model_len / (1024**3)
+                kv_cache_total_gb = kv_cache_per_token_bytes * max_model_len / (1024 ** 3)
         else:
             warnings.append("Unknown KV cache dtype %r" % kv_dtype)
     else:
@@ -600,7 +601,7 @@ def estimate_vram(
 
         # Estimate max context tokens that fit in available KV space
         if kv_cache_per_token_bytes and kv_cache_per_token_bytes > 0:
-            per_gpu_kv_per_token_gb = (kv_cache_per_token_bytes / shard_factor) / (1024**3)
+            per_gpu_kv_per_token_gb = (kv_cache_per_token_bytes / shard_factor) / (1024 ** 3)
             if per_gpu_kv_per_token_gb > 0:
                 max_context_tokens = int(available_kv_gb / per_gpu_kv_per_token_gb)
 

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -244,6 +244,30 @@ def fetch_safetensors_size(
         if cache_dir:
             hub_kwargs["cache_dir"] = _hub_cache(cache_dir)
 
+        # Try 0: lightweight API call — no file download needed
+        try:
+            from huggingface_hub import model_info as _model_info
+
+            mi_kwargs: dict[str, Any] = {"repo_id": model_id}
+            if revision:
+                mi_kwargs["revision"] = revision
+            mi = _model_info(**mi_kwargs)
+            if mi.safetensors is not None:
+                _api_dtype_bytes = {
+                    "F64": 8, "F32": 4, "F16": 2, "BF16": 2,
+                    "F8_E4M3": 1, "F8_E5M2": 1,
+                    "I64": 8, "I32": 4, "I16": 2, "I8": 1, "U8": 1, "BOOL": 1,
+                }
+                total_bytes = 0
+                for dtype_name, count in mi.safetensors.parameters.items():
+                    elem_size = _api_dtype_bytes.get(dtype_name, 2)
+                    total_bytes += count * elem_size
+                if total_bytes > 0:
+                    logger.debug("Got %d bytes from model_info API for %s", total_bytes, model_id)
+                    return total_bytes
+        except Exception as e:
+            logger.debug("model_info API failed for %s: %s", model_id, e)
+
         # Try 1: sharded model with index file
         try:
             disable_progress_bars()
@@ -258,8 +282,8 @@ def fetch_safetensors_size(
             total_size = index.get("metadata", {}).get("total_size")
             if total_size is not None:
                 return int(total_size)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("safetensors index failed for %s: %s", model_id, e)
 
         # Try 2: single-file model — read safetensors header for total param size
         try:
@@ -297,8 +321,8 @@ def fetch_safetensors_size(
                 total_bytes += num_elements * elem_size
             if total_bytes > 0:
                 return total_bytes
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("safetensors header parse failed for %s: %s", model_id, e)
 
         # Try 3: fall back to file size as rough approximation
         try:
@@ -315,11 +339,47 @@ def fetch_safetensors_size(
             if size > 0:
                 logger.debug("Using file size as param size estimate for %s", model_id)
                 return size
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("safetensors file size fallback failed for %s: %s", model_id, e)
 
     except Exception as e:
         logger.debug("Could not fetch safetensors size for %s: %s", model_id, e)
+    return None
+
+
+def fetch_safetensors_params(
+    model_id: str,
+    revision: str | None = None,
+) -> int | None:
+    """Fetch total parameter count from HuggingFace model safetensors metadata.
+
+    Uses the HuggingFace Hub API (``model_info``) which returns parameter counts
+    per dtype without downloading any model files.  This is the preferred method
+    for single-file safetensors models that lack an index file.
+
+    Args:
+        model_id: HuggingFace model identifier.
+        revision: Optional revision (branch, tag, or commit hash).
+
+    Returns:
+        Total parameter count, or ``None`` if unavailable.
+    """
+    try:
+        from huggingface_hub import model_info as _model_info
+
+        kwargs: dict[str, Any] = {"repo_id": model_id}
+        if revision:
+            kwargs["revision"] = revision
+        info = _model_info(**kwargs)
+        if info.safetensors is not None:
+            total = info.safetensors.total
+            if total and total > 0:
+                logger.debug(
+                    "Got %d params from safetensors metadata for %s", total, model_id
+                )
+                return int(total)
+    except Exception as e:
+        logger.debug("Could not fetch safetensors params for %s: %s", model_id, e)
     return None
 
 

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -889,6 +889,14 @@ class TestRecipeMetadata:
         monkeypatch.setattr("sparkrun.models.vram.fetch_model_config", _fake_fetch)
 
     @pytest.fixture()
+    def _mock_safetensors_params_none(self, monkeypatch):
+        """Mock fetch_safetensors_params to return None so size fallback is tested."""
+        monkeypatch.setattr(
+            "sparkrun.models.vram.fetch_safetensors_params",
+            lambda model_id, revision=None: None,
+        )
+
+    @pytest.fixture()
     def _mock_safetensors(self, monkeypatch):
         """Mock fetch_safetensors_size to return a known total_size."""
         # 35B params * 2 bytes (bfloat16) = 70_000_000_000 bytes
@@ -897,7 +905,7 @@ class TestRecipeMetadata:
             lambda model_id, revision=None, cache_dir=None: 70_000_000_000,
         )
 
-    @pytest.mark.usefixtures("_mock_hf_config", "_mock_safetensors")
+    @pytest.mark.usefixtures("_mock_hf_config", "_mock_safetensors_params_none", "_mock_safetensors")
     def test_estimate_vram_safetensors_fallback(self):
         """model_params derived from safetensors index when metadata omits it."""
         recipe = Recipe.from_dict({
@@ -923,8 +931,12 @@ class TestRecipeMetadata:
         """Safetensors fallback should NOT fire when metadata provides model_params."""
         called = []
         monkeypatch.setattr(
+            "sparkrun.models.vram.fetch_safetensors_params",
+            lambda model_id, revision=None: called.append("params") or 99_999_999_999,
+        )
+        monkeypatch.setattr(
             "sparkrun.models.vram.fetch_safetensors_size",
-            lambda model_id, revision=None, cache_dir=None: called.append(1) or 99_999_999_999,
+            lambda model_id, revision=None, cache_dir=None: called.append("size") or 99_999_999_999,
         )
         recipe = Recipe.from_dict({
             "name": "Test",
@@ -941,8 +953,12 @@ class TestRecipeMetadata:
         """Safetensors fallback should NOT fire when model_vram override is set."""
         called = []
         monkeypatch.setattr(
+            "sparkrun.models.vram.fetch_safetensors_params",
+            lambda model_id, revision=None: called.append("params") or 99_999_999_999,
+        )
+        monkeypatch.setattr(
             "sparkrun.models.vram.fetch_safetensors_size",
-            lambda model_id, revision=None, cache_dir=None: called.append(1) or 99_999_999_999,
+            lambda model_id, revision=None, cache_dir=None: called.append("size") or 99_999_999_999,
         )
         recipe = Recipe.from_dict({
             "name": "Test",
@@ -956,7 +972,11 @@ class TestRecipeMetadata:
 
     @pytest.mark.usefixtures("_mock_hf_config")
     def test_estimate_vram_safetensors_returns_none(self, monkeypatch):
-        """When safetensors index unavailable, model_params stays None."""
+        """When both safetensors API and index unavailable, model_params stays None."""
+        monkeypatch.setattr(
+            "sparkrun.models.vram.fetch_safetensors_params",
+            lambda model_id, revision=None: None,
+        )
         monkeypatch.setattr(
             "sparkrun.models.vram.fetch_safetensors_size",
             lambda model_id, revision=None, cache_dir=None: None,
@@ -1000,6 +1020,29 @@ class TestRecipeMetadata:
         # 35B * 1 byte (fp8) / 1024^3 ≈ 32.6 GiB
         assert est.model_weights_gb < 35
         assert est.model_weights_gb > 30
+
+    @pytest.mark.usefixtures("_mock_hf_config")
+    def test_estimate_vram_safetensors_params_api_preferred(self, monkeypatch):
+        """fetch_safetensors_params should be used first, skipping fetch_safetensors_size."""
+        size_called = []
+        monkeypatch.setattr(
+            "sparkrun.models.vram.fetch_safetensors_params",
+            lambda model_id, revision=None: 9_400_000_000,
+        )
+        monkeypatch.setattr(
+            "sparkrun.models.vram.fetch_safetensors_size",
+            lambda model_id, revision=None, cache_dir=None: size_called.append(1) or 99_999_999_999,
+        )
+        recipe = Recipe.from_dict({
+            "name": "Test",
+            "model": "org/model-9b-awq",
+            "metadata": {},
+            "defaults": {"tensor_parallel": 1},
+        })
+        est = recipe.estimate_vram(auto_detect=True)
+        assert size_called == []  # fetch_safetensors_size never called
+        assert est.model_params == 9_400_000_000
+        assert est.model_weights_gb > 0
 
     def test_estimate_vram_recipe_quantization_default_overrides_hf(self, monkeypatch):
         """Recipe defaults quantization key should take priority over HF torch_dtype."""

--- a/tests/test_vram.py
+++ b/tests/test_vram.py
@@ -12,6 +12,8 @@ from sparkrun.models.vram import (
     bytes_per_element,
     estimate_vram,
     extract_model_info,
+    fetch_safetensors_params,
+    fetch_safetensors_size,
     parse_param_count,
 )
 
@@ -674,3 +676,109 @@ class TestResolveQuantDtype:
 
     def test_no_method(self):
         assert _resolve_quant_dtype({}) is None
+
+
+class _FakeSafeTensorsInfo:
+    """Minimal stand-in for huggingface_hub SafeTensorsInfo."""
+
+    def __init__(self, parameters: dict[str, int], total: int):
+        self.parameters = parameters
+        self.total = total
+
+
+class _FakeModelInfo:
+    """Minimal stand-in for huggingface_hub ModelInfo."""
+
+    def __init__(self, safetensors=None):
+        self.safetensors = safetensors
+
+
+class TestFetchSafetensorsParams:
+    """Tests for fetch_safetensors_params (HF API-based param count)."""
+
+    def test_returns_total_from_model_info(self):
+        """Should return total param count from model_info API."""
+        st_info = _FakeSafeTensorsInfo(
+            parameters={"BF16": 5_000_000_000, "F32": 100_000},
+            total=5_000_100_000,
+        )
+        mi = _FakeModelInfo(safetensors=st_info)
+        with mock.patch("huggingface_hub.model_info", return_value=mi):
+            result = fetch_safetensors_params("org/test-model")
+        assert result == 5_000_100_000
+
+    def test_returns_none_when_no_safetensors(self):
+        """Should return None for models without safetensors (e.g. GGUF)."""
+        mi = _FakeModelInfo(safetensors=None)
+        with mock.patch("huggingface_hub.model_info", return_value=mi):
+            result = fetch_safetensors_params("org/gguf-model")
+        assert result is None
+
+    def test_returns_none_on_api_error(self):
+        """Should return None when API call fails."""
+        with mock.patch("huggingface_hub.model_info", side_effect=Exception("network error")):
+            result = fetch_safetensors_params("org/missing-model")
+        assert result is None
+
+    def test_passes_revision(self):
+        """Should forward revision kwarg to model_info."""
+        st_info = _FakeSafeTensorsInfo(parameters={"BF16": 1000}, total=1000)
+        mi = _FakeModelInfo(safetensors=st_info)
+        captured = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return mi
+
+        with mock.patch("huggingface_hub.model_info", side_effect=_capture):
+            fetch_safetensors_params("org/model", revision="v2")
+        assert captured.get("revision") == "v2"
+
+    def test_returns_none_when_total_zero(self):
+        """Should return None when total is 0."""
+        st_info = _FakeSafeTensorsInfo(parameters={}, total=0)
+        mi = _FakeModelInfo(safetensors=st_info)
+        with mock.patch("huggingface_hub.model_info", return_value=mi):
+            result = fetch_safetensors_params("org/empty-model")
+        assert result is None
+
+
+class TestFetchSafetensorsSizeTry0:
+    """Tests for model_info API Try 0 in fetch_safetensors_size."""
+
+    def test_model_info_api_used_first(self, monkeypatch):
+        """API try should succeed without downloading any files."""
+        st_info = _FakeSafeTensorsInfo(
+            parameters={"BF16": 7_000_000_000},
+            total=7_000_000_000,
+        )
+        mi = _FakeModelInfo(safetensors=st_info)
+        download_called = []
+
+        with mock.patch("huggingface_hub.model_info", return_value=mi), \
+             mock.patch("huggingface_hub.hf_hub_download", side_effect=lambda **kw: download_called.append(1)):
+            result = fetch_safetensors_size("org/test-model")
+
+        # BF16 = 2 bytes per element → 7B * 2 = 14B bytes
+        assert result == 14_000_000_000
+        assert download_called == []  # no file download attempted
+
+    def test_falls_through_when_api_fails(self, monkeypatch, tmp_path):
+        """When API fails, should fall through to index file (Try 1)."""
+        import json
+
+        index_file = tmp_path / "model.safetensors.index.json"
+        index_file.write_text(json.dumps({"metadata": {"total_size": 20_000_000_000}}))
+
+        def _fake_download(**kwargs):
+            if kwargs.get("filename") == "model.safetensors.index.json":
+                return str(index_file)
+            raise FileNotFoundError("no such file")
+
+        with mock.patch("huggingface_hub.model_info", side_effect=Exception("offline")), \
+             mock.patch("huggingface_hub.hf_hub_download", side_effect=_fake_download), \
+             mock.patch("huggingface_hub.utils.disable_progress_bars"), \
+             mock.patch("huggingface_hub.utils.enable_progress_bars"):
+            result = fetch_safetensors_size("org/sharded-model")
+
+        assert result == 20_000_000_000


### PR DESCRIPTION
This pull request enhances the model parameter and VRAM estimation logic by introducing a new API-based method for retrieving parameter counts from HuggingFace safetensors metadata, preferring it over file-based fallbacks. The changes improve accuracy for quantized and mixed-dtype models, add robust error handling, and expand test coverage for these new behaviors.

**Core improvements to parameter/VRAM estimation:**

* Added `fetch_safetensors_params`, a new function that uses the HuggingFace Hub API to fetch the total parameter count directly from safetensors metadata, improving accuracy and efficiency for models lacking index files. This method is now preferred in the fallback logic within `estimate_vram`. [[1]](diffhunk://#diff-e7e901a18fcf97d27e0a23dcdb1d487d454aa157044bcbba4264a7c548bd3014R662) [[2]](diffhunk://#diff-e7e901a18fcf97d27e0a23dcdb1d487d454aa157044bcbba4264a7c548bd3014L735-R742) [[3]](diffhunk://#diff-76d5b6bc93edb88b277c63c720152a265fad1972743cd140213140347ba94836L318-R386)
* Updated `fetch_safetensors_size` to first attempt the API-based approach for estimating total bytes, and to log errors for each fallback step, aiding debugging and transparency. [[1]](diffhunk://#diff-76d5b6bc93edb88b277c63c720152a265fad1972743cd140213140347ba94836R248-R271) [[2]](diffhunk://#diff-76d5b6bc93edb88b277c63c720152a265fad1972743cd140213140347ba94836L261-R287) [[3]](diffhunk://#diff-76d5b6bc93edb88b277c63c720152a265fad1972743cd140213140347ba94836L300-R326)

**Model quantization support:**

* Added support for the `"w4a16_awq"` quantization type by mapping it to the correct bytes-per-element value in `vram.py`.

**Testing enhancements:**

* Added comprehensive tests for `fetch_safetensors_params`, including cases for normal operation, missing safetensors metadata, API errors, revision forwarding, and zero-total scenarios.
* Expanded tests for `fetch_safetensors_size` to ensure the API-based method is prioritized and that fallback logic is exercised when the API fails.
* Updated and added fixtures and tests in `test_recipe.py` to cover the new API-based fallback logic, ensuring correct behavior when parameters are provided, when VRAM overrides are set, and when all sources are unavailable. [[1]](diffhunk://#diff-7d8b251b9fe0e0371a54766e450033e08c423065033baafcd9dc74b041b5ceccR891-R898) [[2]](diffhunk://#diff-7d8b251b9fe0e0371a54766e450033e08c423065033baafcd9dc74b041b5ceccL900-R908) [[3]](diffhunk://#diff-7d8b251b9fe0e0371a54766e450033e08c423065033baafcd9dc74b041b5ceccR933-R939) [[4]](diffhunk://#diff-7d8b251b9fe0e0371a54766e450033e08c423065033baafcd9dc74b041b5ceccR955-R961) [[5]](diffhunk://#diff-7d8b251b9fe0e0371a54766e450033e08c423065033baafcd9dc74b041b5ceccL959-R979) [[6]](diffhunk://#diff-7d8b251b9fe0e0371a54766e450033e08c423065033baafcd9dc74b041b5ceccR1024-R1046)

**Test and import maintenance:**

* Updated imports to include the new functions in both implementation and test files. [[1]](diffhunk://#diff-e7e901a18fcf97d27e0a23dcdb1d487d454aa157044bcbba4264a7c548bd3014R662) [[2]](diffhunk://#diff-48e53d71519bdd3a8524304b8c918a238d6d37ed8b7c207cf58bb0c32eda9d80R15-R16)