### PR TITLE
v0.2.21 test: update NCCL_SOCKET_IFNAME assertion to check for absence in env

### DIFF
--- a/tests/test_infiniband.py
+++ b/tests/test_infiniband.py
@@ -98,7 +98,7 @@ def test_generate_nccl_env_with_ib():
     # Check detected values
     assert env["NCCL_IB_GID_INDEX"] == "3"
     assert env["NCCL_IB_HCA"] == "mlx5_0,mlx5_1"
-    assert env["NCCL_SOCKET_IFNAME"] == "eth0"
+    assert "NCCL_SOCKET_IFNAME" not in env  # assert env[] == "eth0"
     assert env["MN_IF_NAME"] == "eth0"
     assert env["OMPI_MCA_btl_tcp_if_include"] == "eth0"
     assert env["GLOO_SOCKET_IFNAME"] == "eth0"


### PR DESCRIPTION
This pull request makes a minor update to the `test_generate_nccl_env_with_ib` test to reflect a change in expected environment variables related to NCCL configuration.

- The test now asserts that `NCCL_SOCKET_IFNAME` is not present in the generated environment dictionary, instead of expecting it to be set to `"eth0"`.