### PR TITLE
feat: implement 5s boot liveness check for --no-follow detached containers

### DIFF
--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -355,13 +355,33 @@ def run(
             sctx.progress.phase_skip(6)
 
     # Follow container logs after a successful detached launch
-    if result.rc == 0 and not foreground and not dry_run and not no_follow:
-        runtime.follow_logs(
-            hosts=host_list,
-            cluster_id=result.cluster_id,
-            config=config,
-            dry_run=dry_run,
-        )
+    if result.rc == 0 and not foreground and not dry_run:
+        if not no_follow:
+            runtime.follow_logs(
+                hosts=host_list,
+                cluster_id=result.cluster_id,
+                config=config,
+                dry_run=dry_run,
+            )
+        else:
+            # Perform a 5s boot liveness check for detached containers to catch crashes
+            import time
+
+            from sparkrun.orchestration.job_metadata import check_job_running
+            from sparkrun.orchestration.primitives import build_ssh_kwargs
+
+            time.sleep(5.0)
+            ssh_kwargs = build_ssh_kwargs(config)
+
+            status = check_job_running(
+                cluster_id=result.cluster_id,
+                hosts=host_list,
+                ssh_kwargs=ssh_kwargs,
+                cache_dir=remote_cache_dir,
+            )
+            if not status.running:
+                click.secho("\n[sparkrun] CRITICAL: Container died unexpectedly after detached launch.", fg="red", err=True, bold=True)
+                result.rc = 1
 
     # --- Diagnostics finalize ---
     if diag:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2297,7 +2297,12 @@ class TestFollowLogs:
             mock.patch("sparkrun.orchestration.distribution.distribute_resources", return_value=(None, {}, {})),
             mock.patch.object(SglangRuntime, "run", return_value=0),
             mock.patch.object(SglangRuntime, "follow_logs") as mock_follow,
+            mock.patch("sparkrun.orchestration.job_metadata.check_job_running") as mock_check,
         ):
+            from sparkrun.orchestration.job_metadata import JobStatus
+
+            mock_check.return_value = JobStatus(running=True, cluster_id="test")
+
             result = runner.invoke(
                 main,
                 [
@@ -2312,6 +2317,7 @@ class TestFollowLogs:
 
             assert result.exit_code == 0
             mock_follow.assert_not_called()
+            mock_check.assert_called_once()
 
     def test_dry_run_skips_follow_logs(self, runner, reset_bootstrap):
         """--dry-run prevents follow_logs from being called."""


### PR DESCRIPTION
Addresses silent boot crashes when containers are launched in detached mode (e.g. SGLang weights loading failures). If the container boots and dies instantly, SparkRun now catches it and exits with code 1 instead of 0.