### PR TITLE
fix(cli): wire labels_override to executor_config

### DIFF
--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -253,7 +253,8 @@ def run(
         cli_executor_opts["memory_limit"] = memory
     if restart_policy:
         cli_executor_opts["restart_policy"] = restart_policy
-
+    if labels_override:
+        cli_executor_opts["labels"] = list(labels_override)
 
     # --- Diagnostics setup ---
     diag = None


### PR DESCRIPTION
Inject labels_override into cli_executor_opts so Docker properly attaches layer 8 telemetry labels.