### PR TITLE
fix(benchmark): run against served_model_name if present

### DIFF
--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -485,9 +485,11 @@ def _run_benchmark(
         if est_tests is not None:
             logger.info("Estimated test iterations: %d", est_tests)
 
+        served_model = overrides.get("served_model_name", recipe.model)
+
         bench_cmd = fw.build_benchmark_command(
             target_url=base_url,
-            model=recipe.model,
+            model=served_model,
             args=bench_args,
             result_file=result_file,
         )


### PR DESCRIPTION
Pass the correct model alias to llama-benchy during benchmark execution.

When SparkRun serves a model with a custom alias via `served_model_name` in deployment overrides, the benchmark command previously continued using the original `recipe.model` identifier. This mismatch caused llama-benchy to fail or route queries incorrectly within the inference engine. 

This change ensures `build_benchmark_command` uses the `served_model_name` property when available, falling back to `recipe.model` as a default. This guarantees the benchmarking tool queries the exact model endpoint exposed by the container.