### PR TITLE
v0.2.23 Arena Benchmark Fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.22"
+version = "0.2.23"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/cli/_arena.py
+++ b/src/sparkrun/cli/_arena.py
@@ -217,6 +217,8 @@ def arena_benchmark(
         rootful,
         bench_timeout,
         dry_run,
+        executor_args=None,
+        extra_args=None,
         export_results_files=False,
     )
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,5 +2,5 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.22
+sparkrun: 0.2.23
 sparkrun-cc-plugin: 0.0.4


### PR DESCRIPTION
This pull request updates the project version from 0.2.22 to 0.2.23 and introduces new optional arguments to the `arena_benchmark` function. The changes primarily focus on version bumping and extending the CLI's flexibility.

Version bump:

* Updated the version of `sparkrun` to 0.2.23 in both `pyproject.toml` and `versions.yaml` to reflect the new release. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)

CLI enhancements:

* Added `executor_args` and `extra_args` parameters to the `arena_benchmark` function in `src/sparkrun/cli/_arena.py`