### PR TITLE
Add Initial OpenClaw plugin

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,66 @@
+name: Publish typescript plugins
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to npm"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    name: Publish to npm
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish == 'true'
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if OpenClaw plugin version changed
+        id: check
+        run: |
+          cd sparkrun-openclaw-plugin
+          CURRENT=$(node -p "require('./package.json').version")
+          # Compare against the previous commit's version (if the file existed)
+          PREVIOUS=$(git show HEAD~1:sparkrun-openclaw-plugin/package.json 2>/dev/null \
+            | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version" 2>/dev/null \
+            || echo "")
+          if [ "$CURRENT" != "$PREVIOUS" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+            echo "OpenClaw plugin version changed: $PREVIOUS -> $CURRENT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "OpenClaw plugin version unchanged ($CURRENT), skipping publish"
+          fi
+
+      - name: Set up Node.js
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        if: steps.check.outputs.changed == 'true'
+        working-directory: sparkrun-openclaw-plugin
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.23"
+version = "0.2.24"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -64,6 +64,10 @@ PROJECT_RULES: dict[str, list[UpdateRule]] = {
         ("plugin", Path("sparkrun-cc-plugin/.claude-plugin/plugin.json")),
         ("marketplace", Path(".claude-plugin/marketplace.json"), "sparkrun-cc-plugin"),
     ],
+    "sparkrun-openclaw-plugin": [
+        ("package", Path("sparkrun-openclaw-plugin/package.json")),
+        ("plugin", Path("sparkrun-openclaw-plugin/openclaw.plugin.json")),
+    ],
 }
 
 # ---------------------------------------------------------------------------

--- a/sparkrun-openclaw-plugin/.gitignore
+++ b/sparkrun-openclaw-plugin/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+dist/

--- a/sparkrun-openclaw-plugin/LICENSE
+++ b/sparkrun-openclaw-plugin/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Scitrera LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sparkrun-openclaw-plugin/README.md
+++ b/sparkrun-openclaw-plugin/README.md
@@ -1,0 +1,109 @@
+# sparkrun Plugin for OpenClaw
+
+AI-assisted inference on NVIDIA DGX Spark -- run, manage, and stop LLM workloads with OpenClaw.
+
+## What It Does
+
+This plugin teaches OpenClaw how to use [sparkrun](https://github.com/scitrera/sparkrun) to manage LLM inference
+workloads on NVIDIA DGX Spark systems. It provides:
+
+- **Skills** -- Detailed reference that OpenClaw uses automatically when working with sparkrun
+- **sparkrun_exec Tool** -- A dedicated tool for executing sparkrun CLI commands
+
+## Installation
+
+### From npm
+
+```bash
+openclaw plugins install @sparkarena/sparkrun-openclaw
+```
+
+### From Local Directory
+
+```bash
+# Clone the repo
+git clone https://github.com/spark-arena/sparkrun.git
+cd sparkrun
+
+# Install from local path
+openclaw plugins install ./sparkrun-openclaw-plugin
+
+# Or link for development
+openclaw plugins install ./sparkrun-openclaw-plugin --link
+```
+
+## Prerequisites
+
+### sparkrun CLI
+
+The plugin requires sparkrun to be installed:
+
+```bash
+# Install via uvx (recommended)
+uvx sparkrun setup install
+
+# Or via uv
+uv tool install sparkrun
+```
+
+### DGX Spark Cluster
+
+You need SSH access to one or more NVIDIA DGX Spark systems. The fastest way to get started:
+
+```bash
+# Interactive setup wizard (handles everything)
+sparkrun setup wizard
+
+# Or manual cluster creation
+sparkrun cluster create mylab --hosts 192.168.11.13,192.168.11.14 -d "My DGX Spark lab"
+sparkrun cluster set-default mylab
+sparkrun setup ssh --cluster mylab
+```
+
+## Skills (Automatic)
+
+OpenClaw automatically uses these skills when the task context matches:
+
+| Skill      | Activates When                                                                                            |
+|------------|-----------------------------------------------------------------------------------------------------------|
+| `run`      | Running, monitoring, stopping, benchmarking, tuning, or managing inference workloads and proxy            |
+| `setup`    | Installing sparkrun, configuring clusters, SSH setup, CX7 networking, Docker group, permissions, earlyoom |
+| `registry` | Managing recipe registries, browsing benchmark profiles, creating/editing recipes                         |
+
+## Usage Examples
+
+Describe what you want in natural language -- OpenClaw will use the skills automatically:
+
+- "Run the Qwen3 1.7B model on my cluster"
+- "What inference jobs are running?"
+- "Stop all inference jobs on my cluster"
+- "Show me available recipes for llama models"
+- "Benchmark the sglang recipe on a single node"
+- "Set up sparkrun on my DGX Spark cluster"
+- "Configure CX7 networking on my cluster"
+- "Create a recipe for Mistral 7B on vLLM"
+- "Monitor my cluster's GPU usage"
+- "Start the inference proxy and load a model"
+- "Check if my job is healthy"
+
+## Key Concepts
+
+- **Recipes** are YAML files describing an inference workload (model, runtime, container, defaults)
+- **Runtimes** are inference engines: vLLM, SGLang, llama.cpp, TensorRT-LLM
+- **Clusters** are named groups of DGX Spark hosts
+- **Registries** are git-based collections of recipes and benchmark profiles
+- **Benchmark profiles** define standardized benchmark configurations from registries
+- **Proxy** is a unified OpenAI-compatible gateway in front of multiple inference endpoints
+- Each DGX Spark has 1 GPU, so `--tp N` (tensor parallelism) = N hosts
+- sparkrun launches detached containers -- Ctrl+C detaches from logs, never kills the job
+- Recipe names support `@registry/name` syntax for explicit registry selection
+
+## Links
+
+- [sparkrun Documentation](https://sparkrun.dev)
+- [sparkrun github repo](https://github.com/spark-arena/sparkrun)
+- [Recipe Format Specification](https://sparkrun.dev/recipes/format/)
+
+## License
+
+Apache 2.0 License -- see [LICENSE](./LICENSE) for details.

--- a/sparkrun-openclaw-plugin/index.ts
+++ b/sparkrun-openclaw-plugin/index.ts
@@ -1,0 +1,78 @@
+// noinspection TypeScriptCheckImport
+
+// @ts-ignore
+import {definePluginEntry} from "openclaw/plugin-sdk/plugin-entry";
+// @ts-ignore
+import {Type} from "@sinclair/typebox";
+import {execSync} from "node:child_process";
+
+export default definePluginEntry({
+    // @ts-ignore
+    register(api) {
+        api.logger.info("sparkrun plugin loaded");
+
+        api.registerTool({
+            name: "sparkrun_exec",
+            description:
+                "Execute a sparkrun CLI command. Use this tool for all sparkrun operations: " +
+                "launching inference workloads, checking status, stopping jobs, browsing recipes, " +
+                "benchmarking, cluster management, and more. The command should start with 'sparkrun'.",
+            parameters: Type.Object({
+                command: Type.String({
+                    description:
+                        "The full sparkrun CLI command to execute (e.g. 'sparkrun list', " +
+                        "'sparkrun run qwen3-1.7b-vllm --tp 1 --no-follow', 'sparkrun cluster status')",
+                }),
+                timeout: Type.Optional(
+                    Type.Number({
+                        description: "Command timeout in milliseconds (default: 120000)",
+                    }),
+                ),
+            }),
+            // @ts-ignore
+            execute: async ({command, timeout}) => {
+                // Ensure the command starts with sparkrun for safety
+                const trimmed = command.trim();
+                if (!trimmed.startsWith("sparkrun")) {
+                    return {
+                        content: [
+                            {
+                                type: "text" as const,
+                                text: "Error: Command must start with 'sparkrun'. Use this tool only for sparkrun CLI commands.",
+                            },
+                        ],
+                    };
+                }
+
+                try {
+                    const result = execSync(trimmed, {
+                        encoding: "utf-8",
+                        timeout: timeout ?? 120_000,
+                        stdio: ["pipe", "pipe", "pipe"],
+                    });
+
+                    return {
+                        content: [{type: "text" as const, text: result}],
+                    };
+                } catch (err: unknown) {
+                    const error = err as {
+                        stdout?: string;
+                        stderr?: string;
+                        status?: number;
+                        message?: string;
+                    };
+                    const output = [error.stdout, error.stderr].filter(Boolean).join("\n");
+
+                    return {
+                        content: [
+                            {
+                                type: "text" as const,
+                                text: output || error.message || "Command failed with no output",
+                            },
+                        ],
+                    };
+                }
+            },
+        });
+    },
+});

--- a/sparkrun-openclaw-plugin/openclaw.plugin.json
+++ b/sparkrun-openclaw-plugin/openclaw.plugin.json
@@ -1,0 +1,15 @@
+{
+  "id": "@sparkarena/sparkrun",
+  "name": "sparkrun",
+  "version": "0.0.1",
+  "description": "AI-assisted inference on NVIDIA DGX Spark - run, manage, and stop LLM workloads",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false
+  },
+  "skills": [
+    "skills/run",
+    "skills/setup",
+    "skills/registry"
+  ]
+}

--- a/sparkrun-openclaw-plugin/package.json
+++ b/sparkrun-openclaw-plugin/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@sparkarena/sparkrun-openclaw",
+  "version": "0.0.1",
+  "description": "AI-assisted inference on NVIDIA DGX Spark - run, manage, and stop LLM workloads with OpenClaw",
+  "type": "module",
+  "main": "index.ts",
+  "author": {
+    "name": "scitrera.ai",
+    "email": "open-source-team@scitrera.com"
+  },
+  "homepage": "https://sparkrun.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/spark-arena/sparkrun.git",
+    "directory": "sparkrun-openclaw-plugin"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "inference",
+    "llm",
+    "dgx-spark",
+    "nvidia",
+    "vllm",
+    "sglang",
+    "gpu",
+    "cluster",
+    "openclaw-plugin"
+  ],
+  "openclaw": {
+    "extensions": [
+      "index.ts"
+    ],
+    "compat": {
+      "pluginApi": "1.0"
+    }
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "files": [
+    "index.ts",
+    "openclaw.plugin.json",
+    "skills/**/*.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "devDependencies": {
+    "@types/node": "^25.6.0"
+  }
+}

--- a/sparkrun-openclaw-plugin/skills/registry/SKILL.md
+++ b/sparkrun-openclaw-plugin/skills/registry/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: registry
+description: Manage recipe registries and create inference recipes
+---
+
+<Purpose>
+Provides complete reference for managing sparkrun recipe registries, browsing and searching recipes, managing benchmark profiles, validating recipes, and understanding the recipe file format for NVIDIA DGX Spark inference workloads.
+</Purpose>
+
+<Use_When>
+- User wants to add, remove, enable, disable, or update recipe registries
+- User wants to browse or search for available recipes
+- User wants to create or edit a recipe YAML file
+- User wants to validate a recipe or check VRAM requirements
+- User wants to browse or inspect benchmark profiles
+- User asks about recipe format or fields
+</Use_When>
+
+<Do_Not_Use_When>
+- User wants to run, stop, or monitor workloads -- use the run skill instead
+- User wants to install sparkrun or set up clusters -- use the setup skill instead
+</Do_Not_Use_When>
+
+<Steps>
+
+## Registry Commands
+
+```bash
+# List configured registries (enabled only by default)
+sparkrun registry list
+sparkrun registry list --show-disabled
+sparkrun registry list --only-show-visible
+
+# Add registries from a git repo's .sparkrun/registry.yaml manifest
+sparkrun registry add <git_url>
+
+# Remove a registry
+sparkrun registry remove <name>
+
+# Enable a disabled registry
+sparkrun registry enable <name>
+
+# Disable a registry (recipes will not appear in searches)
+sparkrun registry disable <name>
+
+# Update all enabled registries from git (fetches latest recipes)
+sparkrun registry update
+
+# Update a specific registry
+sparkrun registry update <name>
+
+# Update sparkrun + registries in one command
+sparkrun update
+```
+
+## Browsing Recipes
+
+```bash
+# List all recipes across all registries (no filter)
+sparkrun list
+
+# List with filters
+sparkrun list --all                         # include hidden registry recipes
+sparkrun list --registry <name>             # filter by registry
+sparkrun list --runtime vllm                # filter by runtime (vllm, sglang, llama-cpp)
+sparkrun list <query>                       # filter by name
+
+# Search for recipes by name, model, runtime, or description (contains-match)
+sparkrun recipe search <query>
+sparkrun recipe search <query> --registry <name> --runtime sglang
+
+# Inspect a specific known recipe (by exact name or file path)
+sparkrun recipe show <recipe> [--tp N]
+
+# Export a normalized recipe
+sparkrun recipe export <recipe>
+sparkrun recipe export <recipe> --json
+sparkrun recipe export <recipe> --save out.yaml
+```
+
+Use `sparkrun recipe search` as the first attempt when looking for a particular recipe. Use `sparkrun recipe show` when given a specific recipe name or file -- it may not appear in search results.
+
+Recipe names support `@registry/name` syntax for explicit registry selection (e.g. `@spark-arena/qwen3-1.7b-vllm`).
+
+## Benchmark Profiles
+
+```bash
+# List available benchmark profiles across registries
+sparkrun registry list-benchmark-profiles
+sparkrun registry list-benchmark-profiles --registry <name>
+sparkrun registry list-benchmark-profiles --all    # include hidden registries
+
+# Show detailed benchmark profile information
+sparkrun registry show-benchmark-profile <name>
+```
+
+## Validating Recipes
+
+```bash
+# Check a recipe for issues
+sparkrun recipe validate <recipe>
+
+# Estimate VRAM usage with overrides
+sparkrun recipe vram <recipe> [--tp N] [--max-model-len 32768] [--gpu-mem 0.9]
+```
+
+## Recipe File Format
+
+Recipes are YAML files defining an inference workload:
+
+```yaml
+model: org/model-name                  # HuggingFace model ID (required)
+runtime: vllm | sglang | llama-cpp     # Inference runtime (required)
+container: registry/image:tag          # Docker image (required)
+min_nodes: 1                           # Minimum hosts needed
+max_nodes: 4                           # Maximum hosts (optional)
+model_revision: abc123                 # Pin to specific HF revision (optional)
+
+metadata:
+  description: Human-readable description
+  maintainer: name <email>
+  model_params: 7B
+  model_dtype: fp16
+  category: general                    # Recipe category
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  pipeline_parallel: 1
+  gpu_memory_utilization: 0.9
+  max_model_len: 32768
+  served_model_name: my-model
+  tokenizer_path: org/base-model       # Required for GGUF models on SGLang
+
+# Optional: explicit command template (overrides auto-generation)
+command: |
+  python3 -m vllm.entrypoints.openai.api_server \
+      --model {model} \
+      --tensor-parallel-size {tensor_parallel} \
+      --port {port}
+
+# Optional: environment variables passed to the container
+env:
+  NCCL_DEBUG: INFO
+
+# Optional: post-launch hooks
+post_exec:                             # Commands to run inside the head container
+  - "echo 'Model loaded'"
+post_commands:                         # Commands to run on the control machine
+  - "curl http://{head_ip}:{port}/v1/models"
+stop_after_post: false                 # Stop workload after post hooks (default: false)
+```
+
+**Key fields:**
+- `{placeholder}` in `command:` templates are substituted from defaults + CLI overrides
+- `model_revision` pins downloads to a specific HuggingFace commit/tag
+- `tokenizer_path` is required for GGUF models on SGLang (points to base non-GGUF model)
+- `min_nodes` / `max_nodes` control cluster size validation
+- Shell variable references like `${HF_TOKEN}` in `env:` are expanded from the control machine's environment
+- `post_exec` and `post_commands` run after the server is healthy (port listening + /v1/models check)
+- `pipeline_parallel` enables pipeline parallelism (total nodes = TP * PP)
+
+</Steps>
+
+<Tool_Usage>
+Use the `sparkrun_exec` tool for all sparkrun commands.
+</Tool_Usage>
+
+<Important_Notes>
+- Run `sparkrun registry update` or `sparkrun update` periodically to get the latest community recipes
+- Use `sparkrun recipe validate` before publishing custom recipes
+- Use `sparkrun recipe vram` to check if a model fits on DGX Spark before trying to run it
+- When creating GGUF + SGLang recipes, always set `tokenizer_path` in defaults
+- Custom command templates should include all relevant `{placeholder}` references to pick up defaults and CLI overrides
+- Registries are cached at `~/.cache/sparkrun/registries/` and updated with `sparkrun registry update`
+- sparkrun ships with built-in recipes; additional registries point to any git repo containing `.yaml` recipe files
+- Use `sparkrun registry list-benchmark-profiles` to discover available benchmark profiles from registries
+- Recipe names support `@registry/name` syntax for explicit registry selection
+- Use `sparkrun recipe export` to get a normalized view of a recipe (useful for debugging)
+</Important_Notes>
+
+Task: {{ARGUMENTS}}

--- a/sparkrun-openclaw-plugin/skills/run/SKILL.md
+++ b/sparkrun-openclaw-plugin/skills/run/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: run
+description: "ALWAYS invoke this skill before running any sparkrun CLI commands. Never run sparkrun directly without loading this skill first. Covers launching, monitoring, stopping, and checking status of inference workloads on NVIDIA DGX Spark."
+---
+
+<Purpose>
+Provides complete reference for launching, monitoring, and stopping LLM inference workloads using sparkrun on NVIDIA DGX Spark systems. Covers the full lifecycle: browse recipes, check VRAM fit, launch jobs, view logs, check status, stop workloads, run benchmarks, tune kernels, and manage the inference proxy.
+</Purpose>
+
+<Use_When>
+- User wants to run an LLM inference model on DGX Spark
+- User wants to check status of running workloads
+- User wants to stop a running inference job
+- User wants to view logs from a running workload
+- User wants to preview VRAM requirements before launching
+- User wants to benchmark an inference workload
+- User wants to tune MoE kernels for better performance
+- User wants to manage the inference proxy
+- User wants to monitor cluster metrics
+- User asks "how do I run", "start", "launch", "deploy" a model
+</Use_When>
+
+<Do_Not_Use_When>
+- User wants to install sparkrun or set up a cluster -- use the setup skill instead
+- User wants to manage recipe registries or create custom recipes -- use the registry skill instead
+- User is asking about sparkrun internals or development
+</Do_Not_Use_When>
+
+<Steps>
+
+## Run a Recipe
+
+```bash
+# Single host
+sparkrun run <recipe> --tp 1 --no-follow
+sparkrun run <recipe> --hosts <ip> --no-follow
+
+# Multi-node cluster
+sparkrun run <recipe> --cluster <name> --no-follow
+sparkrun run <recipe> --hosts <ip1>,<ip2>,... --no-follow
+sparkrun run <recipe> --tp <N> --no-follow
+
+# With overrides
+sparkrun run <recipe> --port 9000 --gpu-mem 0.8 --no-follow
+sparkrun run <recipe> -o max_model_len=8192 -o attention_backend=triton --no-follow
+sparkrun run <recipe> --served-model-name my-model --no-follow
+sparkrun run <recipe> --pp 2 --tp 2 --no-follow   # pipeline + tensor parallelism
+sparkrun run <recipe> --max-model-len 32768 --no-follow
+
+# Idempotent launch (exit 0 if already running)
+sparkrun run <recipe> --ensure --no-follow
+
+# With Docker options
+sparkrun run <recipe> --restart unless-stopped --no-follow
+sparkrun run <recipe> --no-rm --no-follow   # keep containers after stop
+sparkrun run <recipe> --transfer-mode push --no-follow  # force push-based distribution
+
+# Dry-run (show what would happen)
+sparkrun run <recipe> --dry-run
+```
+
+**CRITICAL: Always use `--no-follow`** when running from an agent/skill context to avoid blocking on log streaming. Then use `sparkrun cluster status` or `sparkrun logs` separately to check on the job.
+
+## Check Status
+
+```bash
+# Show all sparkrun containers across cluster hosts
+# NOTE: `sparkrun status` is an alias for `sparkrun cluster status` — only run one.
+sparkrun cluster status
+sparkrun cluster status --cluster <name>
+sparkrun cluster status --hosts <ip1>,<ip2>,...
+
+# Output shows:
+#   - Grouped containers by job (with recipe name if cached)
+#   - Container role, host, status, and image
+#   - Ready-to-use logs and stop commands for each job
+#   - Pending operations (downloads/distributions in progress)
+#   - Idle hosts
+
+# Check if a specific job is running (scripting-friendly)
+sparkrun cluster check-job <recipe> --cluster <name>
+sparkrun cluster check-job <cluster_id> --hosts <ip1>,<ip2>
+sparkrun cluster check-job <recipe> --check-http-models   # also verify /v1/models endpoint
+sparkrun cluster check-job <recipe> --json                 # JSON output
+# Exit code: 0 = running, 1 = not running
+```
+
+## Monitor Cluster Metrics
+
+```bash
+# Plain-text output (agent-friendly)
+sparkrun cluster monitor --cluster <name> --simple
+
+# JSON streaming (automation-friendly)
+sparkrun cluster monitor --cluster <name> --json
+
+# Custom interval
+sparkrun cluster monitor --cluster <name> --interval 5
+```
+
+## View Logs
+
+```bash
+# By recipe name
+sparkrun logs <recipe> --cluster <name>
+sparkrun logs <recipe> --hosts <ip1>,<ip2>,...
+sparkrun logs <recipe> --tp <N>
+
+# By cluster ID (from sparkrun status output)
+sparkrun logs <cluster_id>
+sparkrun logs <cluster_id> --cluster <name>
+
+# Control log tail length
+sparkrun logs <recipe> --tail 200
+```
+
+## Stop a Workload
+
+```bash
+# By recipe name
+sparkrun stop <recipe> --cluster <name>
+sparkrun stop <recipe> --hosts <ip1>,<ip2>,...
+sparkrun stop <recipe> --tp <N>
+
+# By cluster ID (from sparkrun status output)
+sparkrun stop <cluster_id>
+sparkrun stop <cluster_id> --cluster <name>
+
+# Stop all sparkrun containers (no recipe needed)
+sparkrun stop --all --cluster <name>
+sparkrun stop --all --hosts <ip1>,<ip2>,...
+
+# Dry-run
+sparkrun stop <recipe> --dry-run
+```
+
+## Browse and Inspect Recipes
+
+```bash
+# List all available recipes (no filter)
+sparkrun list
+
+# List with filters
+sparkrun list --all                         # include hidden registry recipes
+sparkrun list --registry <name>             # filter by registry
+sparkrun list --runtime vllm                # filter by runtime
+sparkrun list <query>                       # filter by name
+
+# Search for recipes by name, model, runtime, or description (contains-match)
+sparkrun recipe search <query>
+sparkrun recipe search <query> --registry <name> --runtime sglang
+
+# Inspect a specific known recipe (by exact name or file path)
+sparkrun recipe show <recipe>
+sparkrun recipe show <recipe> --tp <N>
+
+# Validate or estimate VRAM
+sparkrun recipe validate <recipe>
+sparkrun recipe vram <recipe> --tp <N> --max-model-len 32768
+
+# Export a recipe
+sparkrun recipe export <recipe>
+sparkrun recipe export <recipe> --json
+sparkrun recipe export <recipe> --save out.yaml
+```
+
+Use `sparkrun recipe search` as the first attempt when looking for a particular recipe. Use `sparkrun recipe show` when given a specific recipe name or file -- it may not appear in search results.
+
+## Benchmark
+
+```bash
+# Full flow: launch inference -> benchmark -> stop
+sparkrun benchmark <recipe> --tp 1
+sparkrun benchmark <recipe> --cluster <name>
+sparkrun benchmark <recipe> --tp 2 --profile <profile_name>
+
+# Benchmark an already-running instance (skip launch)
+sparkrun benchmark <recipe> --skip-run --tp 1
+
+# Keep inference running after benchmark completes
+sparkrun benchmark <recipe> --no-stop --tp 1
+
+# Override benchmark args (use -b for benchmark args, -o for recipe overrides)
+sparkrun benchmark <recipe> -b depth=0,2048,4096 -b tg=32,128
+
+# Specify framework and timeout
+sparkrun benchmark <recipe> --framework llama-benchy --timeout 3600
+
+# Dry-run
+sparkrun benchmark <recipe> --dry-run
+```
+
+## Kernel Tuning
+
+```bash
+# Tune SGLang fused MoE kernels
+sparkrun tune sglang <recipe> --hosts <ip>
+sparkrun tune sglang <recipe> --cluster <name> --tp 1 --tp 2 --tp 4
+sparkrun tune sglang <recipe> -H <ip> --parallel 2
+
+# Tune vLLM fused MoE kernels
+sparkrun tune vllm <recipe> --hosts <ip>
+sparkrun tune vllm <recipe> --cluster <name> --tp 4
+```
+
+## Inference Proxy
+
+```bash
+# Start the unified OpenAI-compatible proxy
+sparkrun proxy start --cluster <name>
+sparkrun proxy start --port 4000
+
+# Check proxy status and registered models
+sparkrun proxy status
+sparkrun proxy models
+sparkrun proxy models --refresh
+
+# Load/unload models through the proxy
+sparkrun proxy load <recipe> --cluster <name>
+sparkrun proxy unload <recipe> --cluster <name>
+
+# Manage model aliases
+sparkrun proxy alias add my-model "Qwen/Qwen3-1.7B"
+sparkrun proxy alias remove my-model
+sparkrun proxy alias list
+
+# Stop the proxy
+sparkrun proxy stop
+```
+
+</Steps>
+
+<Tool_Usage>
+Use the `sparkrun_exec` tool for all sparkrun commands. This tool accepts the full sparkrun CLI command as a string.
+
+When running workloads:
+1. Always use `--no-follow` flag with `sparkrun run`
+2. After launching, run `sparkrun cluster status` to confirm containers are running
+3. Use the logs/stop commands from status output to manage jobs
+4. For monitoring, use `--simple` or `--json` mode (TUI requires interactive terminal)
+</Tool_Usage>
+
+<Key_Options>
+
+**`sparkrun run` options:**
+
+| Option | Description |
+|--------|-------------|
+| `--hosts, -H` | Comma-separated host list |
+| `--hosts-file` | File with hosts (one per line) |
+| `--cluster` | Use a saved cluster |
+| `--tp, --tensor-parallel` | Override tensor parallelism (= node count) |
+| `--pp, --pipeline-parallel` | Override pipeline parallelism |
+| `--port` | Override serve port |
+| `--gpu-mem` | GPU memory utilization (0.0-1.0) |
+| `--max-model-len` | Override maximum model context length |
+| `--served-model-name` | Override the served model name |
+| `--image` | Override container image |
+| `-o KEY=VALUE` | Override any recipe default |
+| `--ensure` | Only launch if not already running; exit 0 if already up |
+| `--no-rm` | Don't auto-remove containers on exit |
+| `--restart POLICY` | Docker restart policy (no, always, unless-stopped, on-failure[:N]) |
+| `--transfer-mode` | Resource transfer mode (auto, local, push, delegated) |
+| `--dry-run, -n` | Show what would be done |
+| `--no-follow` | Don't attach to logs after launch |
+| `--foreground` | Run in foreground (blocking) |
+
+</Key_Options>
+
+<Important_Notes>
+- **Always use `--no-follow`** when running from an automated/agent context to avoid blocking
+- Use `sparkrun cluster status` after launching to confirm containers are running
+- `--tp N` must match the number of hosts (DGX Spark = 1 GPU per host)
+- `sparkrun stop` and `sparkrun logs` accept both recipe names and cluster IDs as targets
+- If `--tp`, `--port`, or `--served-model-name` were used during `run`, pass the same values to `stop` and `logs`
+- Use `sparkrun show <recipe> --tp N` to preview VRAM estimates before running
+- Container names follow the pattern `sparkrun_{hash}_{role}` where the hash is derived from runtime + model + sorted hosts + overrides
+- Ctrl+C while following logs detaches safely -- it never kills the inference job
+- Use `sparkrun stop --all` to stop all sparkrun containers without specifying a recipe
+- `--solo` is deprecated; use `--tp 1` instead
+- Recipe names support `@registry/name` syntax for explicit registry selection
+- `sparkrun update` upgrades sparkrun itself (if installed via uv) and updates all registries
+</Important_Notes>
+
+Task: {{ARGUMENTS}}

--- a/sparkrun-openclaw-plugin/skills/setup/SKILL.md
+++ b/sparkrun-openclaw-plugin/skills/setup/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: setup
+description: Install sparkrun and configure DGX Spark clusters
+---
+
+<Purpose>
+Provides complete reference for installing sparkrun, creating and managing cluster configurations, setting up SSH mesh for multi-node inference, configuring CX7 networking, Docker group membership, file permissions, page cache, earlyoom OOM protection, and diagnostics on NVIDIA DGX Spark systems.
+</Purpose>
+
+<Use_When>
+- User wants to install or update sparkrun
+- User wants to create, modify, or manage cluster configurations
+- User wants to set up SSH for multi-node inference
+- User wants to configure CX7 network interfaces
+- User wants to fix file permissions on cluster hosts
+- User wants to clear page cache on cluster hosts
+- User wants to set up Docker group or earlyoom
+- User asks about sparkrun configuration or setup
+- User is getting started with DGX Spark inference for the first time
+</Use_When>
+
+<Do_Not_Use_When>
+- User wants to run, stop, or monitor workloads -- use the run skill instead
+- User wants to manage recipe registries or create recipes -- use the registry skill instead
+</Do_Not_Use_When>
+
+<Steps>
+
+## Installation
+
+```bash
+# Ensure that uv is installed
+uv --version
+
+# uv can be installed with (IF NEEDED)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install sparkrun as a CLI tool
+uvx sparkrun setup install
+
+# Update sparkrun + registries (top-level shortcut)
+sparkrun update
+
+# Update to latest version (and registries)
+sparkrun setup update
+
+# Update sparkrun only (skip registry sync)
+sparkrun setup update --no-update-registries
+```
+
+## Setup Wizard (Recommended for First-Time Setup)
+
+The wizard handles all setup steps in a single guided flow:
+
+```bash
+# Interactive wizard (auto-launches when no default cluster exists)
+sparkrun setup wizard
+
+# Pre-populate hosts and cluster name
+sparkrun setup wizard --hosts <ip1>,<ip2> --cluster mylab
+
+# Non-interactive (accept all defaults)
+sparkrun setup wizard --yes --hosts <ip1>,<ip2>
+
+# Dry-run preview
+sparkrun setup wizard --dry-run --hosts <ip1>,<ip2>
+```
+
+The wizard performs these phases:
+1. **Cluster Setup** -- detects CX7 peers, creates cluster, sets default
+2. **SSH Mesh** -- passwordless SSH across all hosts + control machine
+3. **CX7 Configuration** -- high-speed networking (if CX7 detected)
+4. **Docker Group** -- ensures user can run Docker without sudo
+5. **Sudoers Entries** -- scoped sudoers for fix-permissions and clear-cache
+6. **earlyoom** -- OOM protection to prevent system hangs
+
+Running `sparkrun setup` with no subcommand auto-launches the wizard when no default cluster is configured.
+
+## Cluster Management
+
+Clusters are named host groups saved in `~/.config/sparkrun/clusters/`.
+
+```bash
+# Create a cluster (first host = head node)
+sparkrun cluster create <name> --hosts <ip1>,<ip2>,... [-d "description"] [--user <ssh_user>]
+sparkrun cluster create <name> --hosts <ips> --transfer-mode push --transfer-interface cx7
+
+# Set as default (used when --hosts/--cluster not specified)
+sparkrun cluster set-default <name>
+
+# View clusters
+sparkrun cluster list
+sparkrun cluster show <name>
+sparkrun cluster default
+
+# Modify
+sparkrun cluster update <name> --hosts <new_hosts> [--user <user>] [-d "desc"]
+sparkrun cluster update <name> --add-host 10.0.0.5
+sparkrun cluster update <name> --add-host 10.0.0.5,10.0.0.6
+sparkrun cluster update <name> --remove-host 10.0.0.2
+sparkrun cluster update <name> --transfer-mode push --transfer-interface cx7
+sparkrun cluster delete <name>
+sparkrun cluster unset-default
+```
+
+### Cluster Options
+
+| Option | Description |
+|--------|-------------|
+| `--hosts, -H` | Comma-separated host list |
+| `--hosts-file` | File with hosts (one per line) |
+| `--user, -u` | SSH username for this cluster |
+| `--cache-dir` | HuggingFace cache directory for this cluster |
+| `--transfer-mode` | Resource transfer mode (auto, local, push, delegated) |
+| `--transfer-interface` | Network interface for transfers (auto, cx7, mgmt) |
+| `--add-host` | Add host(s) to the cluster (repeatable, comma-ok) |
+| `--remove-host` | Remove host(s) from the cluster (repeatable, comma-ok) |
+
+## SSH Setup
+
+Multi-node inference requires passwordless SSH between all hosts. sparkrun bundles a mesh setup script.
+
+```bash
+# Set up SSH mesh across cluster hosts (interactive -- prompts for passwords)
+sparkrun setup ssh --cluster <name>
+sparkrun setup ssh --hosts <ip1>,<ip2> [--user <username>]
+
+# Include extra hosts (e.g. control machine) in the mesh
+sparkrun setup ssh --cluster <name> --extra-hosts <control_ip>
+
+# Exclude the local machine from the mesh
+sparkrun setup ssh --cluster <name> --no-include-self
+
+# Dry-run to see what would happen
+sparkrun setup ssh --cluster <name> --dry-run
+```
+
+**IMPORTANT:** The SSH setup script runs interactively (prompts for passwords on first connection). Do NOT capture its output -- let it pass through to the terminal.
+
+## CX7 Networking
+
+Configure ConnectX-7 network interfaces on cluster hosts for high-speed transfers.
+
+```bash
+# Auto-detect CX7 interfaces and configure with defaults
+sparkrun setup cx7 --cluster <name>
+sparkrun setup cx7 --hosts <ip1>,<ip2>
+
+# Override subnets
+sparkrun setup cx7 --cluster <name> --subnet1 192.168.11.0/24 --subnet2 192.168.12.0/24
+
+# Force reconfiguration and set MTU
+sparkrun setup cx7 --cluster <name> --force --mtu 9000
+
+# Dry-run
+sparkrun setup cx7 --cluster <name> --dry-run
+```
+
+Requires passwordless sudo on target hosts. Will prompt for sudo password if needed.
+
+## Docker Group Membership
+
+Ensure the SSH user can run Docker commands without sudo.
+
+```bash
+sparkrun setup docker-group --cluster <name>
+sparkrun setup docker-group --hosts <ip1>,<ip2> [--user <username>]
+sparkrun setup docker-group --cluster <name> --dry-run
+```
+
+## Fix File Permissions
+
+Fix file ownership in HuggingFace cache directories on cluster hosts.
+
+```bash
+# Fix permissions on default cache directory
+sparkrun setup fix-permissions --cluster <name>
+
+# Custom cache directory
+sparkrun setup fix-permissions --cluster <name> --cache-dir /data/hf-cache
+
+# Install sudoers entry for passwordless future runs
+sparkrun setup fix-permissions --cluster <name> --save-sudo
+
+# Dry-run
+sparkrun setup fix-permissions --cluster <name> --dry-run
+```
+
+## Clear Page Cache
+
+Drop the Linux page cache on cluster hosts to free memory for inference.
+
+```bash
+sparkrun setup clear-cache --cluster <name>
+sparkrun setup clear-cache --cluster <name> --save-sudo
+sparkrun setup clear-cache --cluster <name> --dry-run
+```
+
+## earlyoom OOM Protection
+
+Install earlyoom on cluster hosts to prevent system hangs from memory pressure.
+
+```bash
+sparkrun setup earlyoom --cluster <name>
+sparkrun setup earlyoom --hosts <ip1>,<ip2> [--user <username>]
+sparkrun setup earlyoom --cluster <name> --dry-run
+```
+
+## Diagnostics
+
+Collect diagnostic information from cluster hosts (hidden command, useful for debugging).
+
+```bash
+sparkrun setup diagnose --cluster <name>
+sparkrun setup diagnose --cluster <name> --output diag.json
+sparkrun setup diagnose --cluster <name> --json   # JSON to stdout
+sparkrun setup diagnose --cluster <name> --sudo   # include sudo-level checks
+```
+
+## Configuration
+
+Config file: `~/.config/sparkrun/config.yaml`
+
+Key settings:
+- `cluster.hosts`: Default host list (used when no --hosts/--cluster given)
+- `ssh.user`: Default SSH username
+- `ssh.key`: Path to SSH private key
+- `ssh.options`: Additional SSH options list
+- `cache_dir`: sparkrun cache directory (default: `~/.cache/sparkrun`)
+- `hf_cache_dir`: HuggingFace cache directory (default: `~/.cache/huggingface`)
+
+</Steps>
+
+<Tool_Usage>
+Use the `sparkrun_exec` tool for all sparkrun commands.
+
+When running SSH setup, the command is interactive and must be run with inherited stdio -- use the shell tool directly for `sparkrun setup ssh` instead of `sparkrun_exec`, as it requires terminal interaction.
+</Tool_Usage>
+
+<Important_Notes>
+- The **setup wizard** is recommended for first-time setup -- it handles all steps automatically
+- Always create a cluster and set it as default for the user's lab setup
+- The first host in a cluster is the **head node** for multi-node jobs
+- SSH mesh must be set up before multi-node inference will work
+- `sparkrun setup ssh` is interactive -- let it pass through to the terminal
+- DGX Spark systems have 1 GPU per host, so `tensor_parallel` maps to node count
+- `uv` is the recommended Python package manager; install with `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- `sparkrun setup cx7` requires passwordless sudo; use `--force` to reconfigure already-valid hosts
+- `sparkrun setup fix-permissions` and `clear-cache` try non-interactive sudo first, then prompt if needed
+- Use `--save-sudo` to install scoped sudoers entries for passwordless future runs
+- `sparkrun update` is a top-level shortcut that upgrades sparkrun (if uv-installed) and updates registries
+- Cluster `--transfer-mode` options: `auto` (default), `local` (no transfer), `push` (head pushes to workers), `delegated` (workers pull)
+- Cluster `--transfer-interface` options: `auto` (default), `cx7` (use CX7 IPs), `mgmt` (use management IPs)
+- Use `--add-host` / `--remove-host` for incremental cluster changes instead of replacing the full host list
+</Important_Notes>
+
+Task: {{ARGUMENTS}}

--- a/sparkrun-openclaw-plugin/tsconfig.json
+++ b/sparkrun-openclaw-plugin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["index.ts"]
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -4,3 +4,4 @@
 
 sparkrun: 0.2.24
 sparkrun-cc-plugin: 0.0.4
+sparkrun-openclaw-plugin: 0.0.1

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,5 +2,5 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.23
+sparkrun: 0.2.24
 sparkrun-cc-plugin: 0.0.4


### PR DESCRIPTION
This pull request introduces a new OpenClaw plugin for the `sparkrun` project, enabling AI-assisted inference workload management on NVIDIA DGX Spark systems. It adds the `sparkrun-openclaw-plugin` package, documentation, licensing, and automates publishing to npm. It also updates the Python package version and the version management script to support the new plugin.

**New Plugin Integration:**

* Added the `sparkrun-openclaw-plugin` directory, including the main plugin entry point (`index.ts`), which registers a `sparkrun_exec` tool for executing sparkrun CLI commands through OpenClaw.
* Provided plugin metadata (`package.json` and `openclaw.plugin.json`), specifying skills, compatibility, and publishing details. [[1]](diffhunk://#diff-397c94486f8921459042245182b497da85aa2414debab43297b17aa35bbb9328R1-R50) [[2]](diffhunk://#diff-6aa3f3203d66b2e9eee4638328539b6f3155681c1d744a01556b561573dea70aR1-R15)
* Added a comprehensive `README.md` explaining installation, usage, and key concepts for the new plugin.
* Included an Apache 2.0 license for the plugin.
* Added `.gitignore` for typical Node.js artifacts.

**Build and Release Automation:**

* Introduced a new GitHub Actions workflow (`.github/workflows/publish-npm.yml`) to automate npm publishing for TypeScript plugins, including version-change detection for the OpenClaw plugin.

**Version Management:**

* Updated the `pyproject.toml` version of the main `sparkrun` Python package to `0.2.24`.
* Enhanced the `update-versions.py` script to support version management for the new OpenClaw plugin.