### PR TITLE
v0.2.24

### DIFF
--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -34,7 +34,9 @@ logger = logging.getLogger(__name__)
 @click.argument("recipe_name", type=RECIPE_NAME)
 @host_options
 @recipe_override_options
-@click.option("--name", "cluster_id_override", default=None, help="Override deterministic cluster ID (static container name)")
+@click.option(
+    "--container-name", "cluster_id_override", default=None, hidden=True, help="Override deterministic cluster ID (static container name)"
+)
 @click.option("--solo", is_flag=True, help="Force single-node mode", hidden=True)
 @click.option("--port", type=int, default=None, help="Override serve port")
 @click.option("--served-model-name", default=None, help="Override served model name")
@@ -260,9 +262,19 @@ def run(
 
     # Also extract executor-specific keys from -o/--option overrides
     executor_keys = {
-        "auto_remove", "restart_policy", "privileged", "gpus", "ipc",
-        "shm_size", "network", "user", "security_opt", "cap_add",
-        "ulimit", "devices", "memory_limit",
+        "auto_remove",
+        "restart_policy",
+        "privileged",
+        "gpus",
+        "ipc",
+        "shm_size",
+        "network",
+        "user",
+        "security_opt",
+        "cap_add",
+        "ulimit",
+        "devices",
+        "memory_limit",
     }
     for key in list(overrides.keys()):
         if key in executor_keys:

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -267,7 +267,6 @@ def run(
     for key in list(overrides.keys()):
         if key in executor_keys:
             cli_executor_opts[key] = overrides.pop(key)
-
     # --- Diagnostics setup ---
     diag = None
     if diagnostics_path:

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 @click.argument("recipe_name", type=RECIPE_NAME)
 @host_options
 @recipe_override_options
+@click.option("--name", "cluster_id_override", default=None, help="Override deterministic cluster ID (static container name)")
 @click.option("--solo", is_flag=True, help="Force single-node mode", hidden=True)
 @click.option("--port", type=int, default=None, help="Override serve port")
 @click.option("--served-model-name", default=None, help="Override served model name")
@@ -75,6 +76,7 @@ def run(
     hosts,
     hosts_file,
     cluster_name,
+    cluster_id_override,
     solo,
     port,
     tensor_parallel,
@@ -256,6 +258,16 @@ def run(
     if labels_override:
         cli_executor_opts["labels"] = list(labels_override)
 
+    # Also extract executor-specific keys from -o/--option overrides
+    executor_keys = {
+        "auto_remove", "restart_policy", "privileged", "gpus", "ipc",
+        "shm_size", "network", "user", "security_opt", "cap_add",
+        "ulimit", "devices", "memory_limit",
+    }
+    for key in list(overrides.keys()):
+        if key in executor_keys:
+            cli_executor_opts[key] = overrides.pop(key)
+
     # --- Diagnostics setup ---
     diag = None
     if diagnostics_path:
@@ -308,6 +320,7 @@ def run(
             dashboard=dashboard,
             init_port=init_port,
             topology=cluster_cfg.topology,
+            cluster_id_override=cluster_id_override,
             executor_config=cli_executor_opts,
             extra_docker_opts=list(executor_args) if executor_args else None,
             rootless=not rootful,

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -36,7 +36,11 @@ logger = logging.getLogger(__name__)
 @host_options
 @recipe_override_options
 @click.option(
-    "--container-name", "cluster_id_override", default=None, hidden=True, help="Override deterministic cluster ID (static container name)"
+    "--container-name",
+    "cluster_id_override",
+    default=None,
+    hidden=HIDE_ADVANCED_OPTIONS,
+    help="Override deterministic cluster ID (static container name)",
 )
 @click.option("--solo", is_flag=True, help="Force single-node mode", hidden=True)
 @click.option("--port", type=int, default=None, help="Override serve port")

--- a/tests/test_name_alias.py
+++ b/tests/test_name_alias.py
@@ -1,0 +1,51 @@
+import pytest
+from click.testing import CliRunner
+from sparkrun.cli import main
+from unittest.mock import MagicMock
+
+
+def test_run_with_name_override(monkeypatch):
+    runner = CliRunner()
+
+    # Mock launch_inference in its original module, since _run.py imports it locally
+    mock_launch = MagicMock()
+    mock_result = MagicMock()
+    mock_result.cluster_id = "test-cluster-id"
+    mock_result.serve_command = "vllm serve"
+    mock_result.runtime_info = {}
+    mock_result.rc = 0
+    mock_result.head_host = "localhost"
+    mock_result.host_list = ["localhost"]
+    mock_launch.return_value = mock_result
+    monkeypatch.setattr("sparkrun.core.launcher.launch_inference", mock_launch)
+
+    monkeypatch.setattr("sparkrun.core.launcher.post_launch_lifecycle", MagicMock())
+    monkeypatch.setattr("sparkrun.cli._run._resolve_hosts_or_exit", lambda *args, **kwargs: (["localhost"], None))
+    mock_recipe = MagicMock()
+    mock_recipe.runtime = "vllm"
+    mock_recipe.model = "test-model"
+    mock_recipe.validate.return_value = []
+    mock_recipe.mode = "solo"
+    mock_recipe.build_config_chain.return_value = {"port": 8000}
+    monkeypatch.setattr("sparkrun.cli._run._load_recipe", lambda *args, **kwargs: (mock_recipe, "path", None))
+
+    mock_ret = MagicMock()
+    mock_ret.topology = None
+    mock_ret.resolve_transfer_config.return_value = (None, None, None, None)
+    monkeypatch.setattr("sparkrun.cli._run.resolve_cluster_config", lambda *args, **kwargs: mock_ret)
+
+    mock_runtime = MagicMock()
+    mock_runtime.runtime_name = "vllm"
+    mock_runtime.resolve_container.return_value = "img:latest"
+    mock_runtime.validate_recipe.return_value = []
+    monkeypatch.setattr("sparkrun.core.bootstrap.get_runtime", lambda *args, **kwargs: mock_runtime)
+    monkeypatch.setattr("sparkrun.cli._run.validate_and_prepare_hosts", lambda *args, **kwargs: (["localhost"], True))
+    monkeypatch.setattr("sparkrun.cli._run._display_vram_estimate", lambda *args, **kwargs: None)
+
+    result = runner.invoke(main, ["run", "test-recipe", "--name", "custom-cluster-id", "--solo"])
+
+    assert result.exit_code == 0
+    args, kwargs = mock_launch.call_args
+    assert kwargs.get("cluster_id_override") == "custom-cluster-id"
+
+

--- a/tests/test_name_alias.py
+++ b/tests/test_name_alias.py
@@ -1,4 +1,3 @@
-import pytest
 from click.testing import CliRunner
 from sparkrun.cli import main
 from unittest.mock import MagicMock
@@ -42,10 +41,8 @@ def test_run_with_name_override(monkeypatch):
     monkeypatch.setattr("sparkrun.cli._run.validate_and_prepare_hosts", lambda *args, **kwargs: (["localhost"], True))
     monkeypatch.setattr("sparkrun.cli._run._display_vram_estimate", lambda *args, **kwargs: None)
 
-    result = runner.invoke(main, ["run", "test-recipe", "--name", "custom-cluster-id", "--solo"])
+    result = runner.invoke(main, ["run", "test-recipe", "--container-name", "custom-cluster-id", "--solo"])
 
     assert result.exit_code == 0
     args, kwargs = mock_launch.call_args
     assert kwargs.get("cluster_id_override") == "custom-cluster-id"
-
-


### PR DESCRIPTION
This pull request introduces support for overriding the deterministic cluster/container name when running a recipe, and improves handling of executor-specific Docker options. It also adds a new test to ensure the override functionality works as expected.

**New feature: Cluster/container name override**
- Added a `--container-name` CLI option to the `run` command, allowing users to specify a custom cluster/container name by overriding the deterministic cluster ID. (`src/sparkrun/cli/_run.py`) [[1]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08R38-R44) [[2]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08R100) [[3]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08R353)

**Executor/Docker options handling**
- Improved the handling of executor-specific Docker options by extracting certain keys (such as `gpus`, `network`, `memory_limit`, etc.) from CLI overrides and passing them explicitly to the executor configuration. (`src/sparkrun/cli/_run.py`)

**Testing**
- Added a test (`test_run_with_name_override`) to verify that the `--container-name` option correctly overrides the cluster/container name when running a recipe. (`tests/test_name_alias.py`)