### PR TITLE
fix(benchmark): support served_model_name aliasing in proxy and client

### DIFF
--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -411,7 +411,6 @@ def _run_benchmark(
                 registry_mgr=registry_mgr,
                 auto_port=True,
                 sync_tuning=sync_tuning,
-                skip_keys={"served_model_name"},
                 dry_run=dry_run,
                 detached=True,
                 rootless=not rootful,
@@ -500,6 +499,13 @@ def _run_benchmark(
         est_tests = fw.estimate_test_count(bench_args)
         if est_tests is not None:
             logger.info("Estimated test iterations: %d", est_tests)
+
+        # Pass served_model_name as an argument if defined, satisfying llama-benchy's
+        # requirement to maintain the original huggingface model ID for tokenization.
+        # Check config_chain to capture both CLI overrides and recipe definitions natively.
+        served_model_name = config_chain.get("served_model_name")
+        if served_model_name and "served_model_name" not in bench_args:
+            bench_args["served_model_name"] = served_model_name
 
         bench_cmd = fw.build_benchmark_command(
             target_url=base_url,


### PR DESCRIPTION
Stop suppressing the `served_model_name` argument from the underlying inference server in the benchmark runner and explicitly instruct `llama-benchy` to respect both the tokenization model ID and the proxy routing alias.

### Addressing PR #124 Feedback
In PR #124, attempting to overwrite the `--model` flag with the serving alias was rejected because `llama-benchy` relies on the canonical Hugging Face ID (e.g. `google/gemma-4-31B-it`) to fetch the correct remote tokenizer for accurate context bounds computations. Without it, the client falls back to incorrect approximations (like the `gpt2` tokenizer) and fails tokenization precisely.

To strictly adhere to this architectural requirement, this patch:
1. **Preserves Tokenizer Integrity**: `recipe.model` is left completely intact and explicitly continues to map to `llama-benchy`'s `--model` argument.
2. **Dynamic Alias Resolution**: The backend alias (`served_model_name`) is dynamically extracted from the complete `config_chain` (capturing both root recipe configs and explicit CLI overrides) and securely injected into `llama-benchy`'s dedicated `--served-model-name` HTTP routing flag.

By propagating both flags natively, this completely fixes the 400 Model Not Found routing errors when benchmarking proxied deployments, without corrupting the token counting engine.
