### PR TITLE
v0.2.26 ray heterogeneous ports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.25"
+version = "0.2.26"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/orchestration/comm_env.py
+++ b/src/sparkrun/orchestration/comm_env.py
@@ -53,6 +53,19 @@ class ClusterCommEnv:
             keys.update(override.keys())
         return keys
 
+    def per_host_keys(self) -> set[str]:
+        """Return env-var names that have per-host overrides.
+
+        These are keys that appear in *per_host* (i.e. differ across
+        hosts or are only present on some hosts).  Useful for determining
+        which variables should NOT be propagated uniformly across a
+        cluster — e.g. by Ray's env-var copying mechanism.
+        """
+        keys: set[str] = set()
+        for override in self.per_host.values():
+            keys.update(override.keys())
+        return keys
+
     def hosts(self) -> list[str]:
         """Hosts with per-host overrides (not necessarily all cluster hosts)."""
         return list(self.per_host.keys())

--- a/src/sparkrun/runtimes/vllm_ray.py
+++ b/src/sparkrun/runtimes/vllm_ray.py
@@ -106,6 +106,71 @@ class VllmRayRuntime(VllmMixin, RuntimePlugin):
             "RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0",
         }
 
+    # --- Ray env propagation fix (issue #135) ---
+
+    @staticmethod
+    def _write_ray_non_carry_over(
+        head_host: str,
+        head_container: str,
+        comm_env: "ClusterCommEnv",
+        ssh_kwargs: dict,
+        dry_run: bool,
+    ) -> None:
+        """Write ``ray_non_carry_over_env_vars.json`` in the head container.
+
+        vLLM's Ray executor copies ``NCCL_*`` / ``UCX_*`` env vars from
+        the head process to worker Ray actors.  When hosts have different
+        IB configurations (e.g. cables on different CX-7 ports), this
+        overwrites the workers' correct per-host values and causes NCCL
+        initialization failures.
+
+        vLLM reads ``/tmp/.config/vllm/ray_non_carry_over_env_vars.json``
+        (a JSON array of env-var names) and skips those vars during
+        propagation — so each worker keeps its own Docker-level env.
+
+        Only called when ``comm_env`` has per-host overrides; when all
+        hosts share identical IB config the file is unnecessary.
+        """
+        import json
+        from sparkrun.orchestration.ssh import run_remote_script
+        from sparkrun.utils.shell import quote
+
+        exclude_vars = sorted(comm_env.per_host_keys())
+        if not exclude_vars:
+            return
+
+        json_content = json.dumps(exclude_vars)
+
+        # Build a docker exec that writes the exclusion file
+        inner_cmd = (
+            "mkdir -p /tmp/.config/vllm && "
+            "printf '%%s\\n' '%s' > /tmp/.config/vllm/ray_non_carry_over_env_vars.json" % json_content.replace("'", "'\\''")
+        )
+        # TODO: should be via executor
+        script = "docker exec %s bash -c %s" % (
+            quote(head_container),
+            quote(inner_cmd),
+        )
+
+        logger.info(
+            "Excluding %d per-host env var(s) from Ray propagation: %s",
+            len(exclude_vars),
+            ", ".join(exclude_vars),
+        )
+
+        result = run_remote_script(
+            head_host,
+            script,
+            timeout=30,
+            dry_run=dry_run,
+            **ssh_kwargs,
+        )
+        if not dry_run and not result.success:
+            logger.warning(
+                "Failed to write ray_non_carry_over_env_vars.json: %s",
+                (result.stderr or "")[:200],
+            )
+
     # --- Log following hooks ---
 
     def _cluster_log_mode(self) -> str:
@@ -347,6 +412,19 @@ class VllmRayRuntime(VllmMixin, RuntimePlugin):
         for worker in ctx.worker_hosts:
             all_containers.append((worker, worker_container))
         run_pre_serve_hooks(self, ctx, all_containers, recipe, overrides)
+
+        # Prevent vLLM Ray from propagating per-host NCCL/transport env
+        # vars from head to workers (GitHub issue #135).  Must run BEFORE
+        # the serve command so the exclusion file is in place when vLLM
+        # initializes the Ray executor.
+        if comm_env and comm_env.per_host:
+            self._write_ray_non_carry_over(
+                ctx.head_host,
+                head_container,
+                comm_env,
+                ctx.ssh_kwargs,
+                ctx.dry_run,
+            )
 
         # Step 5: Execute serve command on head
         t0 = time.monotonic()

--- a/tests/test_infiniband.py
+++ b/tests/test_infiniband.py
@@ -468,3 +468,64 @@ class TestClusterCommEnv:
         )
         assert cce.all_keys() == {"A", "B", "C"}
         assert len(cce) == 3
+
+    def test_per_host_keys_returns_override_keys_only(self):
+        from sparkrun.orchestration.comm_env import ClusterCommEnv
+
+        cce = ClusterCommEnv(
+            shared={"NCCL_NET": "IB", "NCCL_IB_HCA": "mlx5_0"},
+            per_host={
+                "head": {"GLOO_SOCKET_IFNAME": "enP7s7", "NCCL_IB_HCA": "rocep1s0f0"},
+                "worker": {"GLOO_SOCKET_IFNAME": "wlP9s9", "NCCL_IB_HCA": "rocep1s0f1"},
+            },
+        )
+        assert cce.per_host_keys() == {"GLOO_SOCKET_IFNAME", "NCCL_IB_HCA"}
+
+    def test_per_host_keys_empty_when_no_overrides(self):
+        from sparkrun.orchestration.comm_env import ClusterCommEnv
+
+        cce = ClusterCommEnv(shared={"NCCL_NET": "IB"})
+        assert cce.per_host_keys() == set()
+
+
+def test_cross_port_cabling_produces_per_host_nccl_vars():
+    """Issue #135: head port 1 (f0) + worker port 2 (f1) → per-host NCCL vars.
+
+    When DGX Sparks are cabled on different CX-7 ports, the HCA names,
+    network interfaces, and UCX devices differ per host.  These must
+    stay in ``per_host`` so each container receives its own values.
+    """
+    from sparkrun.orchestration.comm_env import ClusterCommEnv
+    from sparkrun.orchestration.infiniband import generate_nccl_env
+
+    head_ib = {
+        "IB_DETECTED": "1",
+        "DETECTED_HCA_LIST": "rocep1s0f0,roceP2p1s0f0",
+        "DETECTED_SOCKET_IFNAME": "enP7s7",
+        "DETECTED_NET_LIST": "enp1s0f0np0,enP2p1s0f0np0",
+        "DETECTED_UCX_LIST": "rocep1s0f0:1,roceP2p1s0f0:1",
+        "DETECTED_MGMT_IP": "192.168.0.192",
+    }
+    worker_ib = {
+        "IB_DETECTED": "1",
+        "DETECTED_HCA_LIST": "rocep1s0f1,roceP2p1s0f1",
+        "DETECTED_SOCKET_IFNAME": "enP7s7",
+        "DETECTED_NET_LIST": "enp1s0f1np1,enP2p1s0f1np1",
+        "DETECTED_UCX_LIST": "rocep1s0f1:1,roceP2p1s0f1:1",
+        "DETECTED_MGMT_IP": "192.168.1.116",
+    }
+
+    head_env = generate_nccl_env(head_ib)
+    worker_env = generate_nccl_env(worker_ib)
+    cce = ClusterCommEnv.from_per_host({"head": head_env, "worker": worker_env})
+
+    per_host = cce.per_host_keys()
+    assert "NCCL_IB_HCA" in per_host
+    assert "UCX_NET_DEVICES" in per_host
+    assert "NCCL_SOCKET_IFNAME" in per_host
+    # NODE_IP also differs (different mgmt IPs)
+    assert "NODE_IP" in per_host
+
+    # Verify each host gets its own values back
+    assert cce.get_env("head")["NCCL_IB_HCA"] == "rocep1s0f0,roceP2p1s0f0"
+    assert cce.get_env("worker")["NCCL_IB_HCA"] == "rocep1s0f1,roceP2p1s0f1"

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,6 +2,6 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.25
+sparkrun: 0.2.26
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1


### PR DESCRIPTION
This pull request addresses a critical issue with Ray environment variable propagation in vLLM clusters, particularly when hosts have different InfiniBand (IB) configurations. It introduces logic to prevent per-host environment variables (like NCCL and UCX settings) from being incorrectly propagated from the head node to workers, which previously led to initialization failures. The update also adds a new method to identify per-host-specific environment variables and expands the test suite to cover these scenarios. (sparkrun would correctly distribute environment variables and then ray would overwrite them with values from the head node as part of ray worker.)

Intended to address #135 

Key changes:

**Ray Environment Propagation Fixes:**

* Added a static method `_write_ray_non_carry_over` to `vllm_ray.py` that writes a JSON file listing per-host environment variables to exclude from Ray's propagation mechanism, preventing overwrites of host-specific NCCL/UCX settings. This is invoked before serving starts if per-host overrides are detected. [[1]](diffhunk://#diff-f82772d51e1d4276da2e5922ab2de05a904e7e2683e697f53de6cabb037c9684R109-R173) [[2]](diffhunk://#diff-f82772d51e1d4276da2e5922ab2de05a904e7e2683e697f53de6cabb037c9684R416-R428)

**Cluster Communication Environment Improvements:**

* Introduced the `per_host_keys` method in `ClusterCommEnv` to return environment variable names that have per-host overrides, enabling precise identification of variables that should not be propagated cluster-wide.

**Testing Enhancements:**

* Added tests for `per_host_keys`, including cases with and without overrides, and a test simulating cross-port cabling to ensure per-host NCCL/UCX variables remain correctly isolated.

**Version Updates:**

* Bumped the `sparkrun` version to `0.2.26` in both `pyproject.toml` and `versions.yaml` to reflect the new changes. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)