### PR TITLE
v0.2.27 more shell quoting fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.26"
+version = "0.2.27"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -510,7 +510,7 @@ class EugrBuilder(BuilderPlugin):
 
             # Add copy entry (docker cp source into container)
             copy_entry: dict[str, str] = {
-                "copy": quote(str(mod_path)),
+                "copy": str(mod_path),
                 "dest": dest,
             }
             if source_host is not None:

--- a/src/sparkrun/orchestration/hooks.py
+++ b/src/sparkrun/orchestration/hooks.py
@@ -382,10 +382,11 @@ def _run_copy_command(
 
     if source_host is not None:
         # Delegated mode: source files live on source_host, not locally.
+        # Pass the original path (not locally-expanded) so ~ resolves on the remote host.
         result = _run_delegated_copy(
             host,
             container_name,
-            str(source_path),
+            source,
             dest,
             source_host,
             ssh_kwargs=ssh_kwargs,
@@ -456,7 +457,7 @@ def _run_delegated_copy(
 
     if host == source_host:
         # Files already on this host — docker cp directly
-        script = ("set -e\ndocker exec --user root %(c)s mkdir -p %(dest)s\ndocker cp %(src)s/. %(c)s:%(dest)s/\n") % {
+        script = ('set -e\ndocker exec --user root %(c)s mkdir -p %(dest)s\ndocker cp "%(src)s"/. %(c)s:%(dest)s/\n') % {
             "c": container_name,
             "src": source,
             "dest": dest,
@@ -481,7 +482,7 @@ def _run_delegated_copy(
         script = (
             "set -e\n"
             "mkdir -p %(tmp)s\n"
-            "rsync -a --no-times %(rsync_ssh)s %(user)s%(src_host)s:%(src)s/ %(tmp)s/\n"
+            'rsync -a --no-times %(rsync_ssh)s %(user)s%(src_host)s:"%(src)s"/ %(tmp)s/\n'
             "docker exec --user root %(c)s mkdir -p %(dest)s\n"
             "docker cp %(tmp)s/. %(c)s:%(dest)s/\n"
             "rm -rf %(tmp)s\n"

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,6 +2,6 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.26
+sparkrun: 0.2.27
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1


### PR DESCRIPTION
This pull request updates the `sparkrun` package to version 0.2.27 and includes several improvements to the file copy orchestration logic, particularly for delegated copy operations involving remote hosts. The main changes improve path handling and quoting to ensure correct behavior when paths contain special characters or need to be resolved on remote hosts.

**Version bump:**

* Bumped `sparkrun` version from 0.2.26 to 0.2.27 in both `pyproject.toml` and `versions.yaml`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)

**File copy and path handling improvements:**

* In `_inject_mod_pre_exec`, stopped quoting `mod_path` when creating the copy entry, ensuring the path is passed as a plain string.
* In `_run_copy_command`, now passes the original `source` path (instead of the locally expanded path) to delegated copy operations, allowing `~` to resolve on the remote host.
* In `_run_delegated_copy`, added shell quoting to the `docker cp` and `rsync` commands to handle paths with spaces or special characters safely. [[1]](diffhunk://#diff-8a38a9a52e0e844ba826139071d45a742a8ab9079238cbc01456ec1d5f82c0ebL459-R460) [[2]](diffhunk://#diff-8a38a9a52e0e844ba826139071d45a742a8ab9079238cbc01456ec1d5f82c0ebL484-R485)