### PR TITLE
fix(quality): Resolve flake8-bugbear defects in sparkrun

### DIFF
--- a/src/sparkrun/arena/auth.py
+++ b/src/sparkrun/arena/auth.py
@@ -95,9 +95,9 @@ def exchange_token(refresh_token: str, debug_mode: bool = False) -> ExchangeResu
             msg = err_data.get("message") or err_data.get("error", body)
         except (json.JSONDecodeError, ValueError):
             msg = body
-        raise RuntimeError("Token exchange failed (%d): %s" % (e.code, msg))
+        raise RuntimeError("Token exchange failed (%d): %s" % (e.code, msg)) from e
     except URLError as e:
-        raise RuntimeError("Cannot reach auth proxy: %s" % e.reason)
+        raise RuntimeError("Cannot reach auth proxy: %s" % e.reason) from e
 
     id_token = data.get("id_token")
     user_id = data.get("user_id")

--- a/src/sparkrun/cli/_common.py
+++ b/src/sparkrun/cli/_common.py
@@ -336,7 +336,7 @@ def _load_recipe(config, recipe_name, resolve=True):
         # Interactive disambiguation
         if sys.stdin.isatty():
             click.echo("Recipe '%s' found in multiple registries:" % e.name)
-            for i, (reg, path) in enumerate(e.matches, 1):
+            for i, (reg, _path) in enumerate(e.matches, 1):
                 click.echo("  %d. @%s/%s" % (i, reg, e.name))
             click.echo()
             choice = click.prompt(
@@ -347,7 +347,7 @@ def _load_recipe(config, recipe_name, resolve=True):
             _reg_name, recipe_path = e.matches[choice - 1]
             recipe = Recipe.load(recipe_path, resolve=resolve)
         else:
-            raise click.ClickException(str(e))
+            raise click.ClickException(str(e)) from e
     except RecipeError as e:
         click.echo("Error: %s" % e, err=True)
         sys.exit(1)

--- a/src/sparkrun/cli/_stop_logs.py
+++ b/src/sparkrun/cli/_stop_logs.py
@@ -97,7 +97,7 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run):
     # Build per-host container name mapping
     host_containers: dict[str, list[str]] = {}
     for cid, group in result.groups.items():
-        for host, role, status, image in group.members:
+        for host, role, _status, _image in group.members:
             container_name = "%s_%s" % (cid, role)
             host_containers.setdefault(host, []).append(container_name)
     for entry in result.solo_entries:

--- a/src/sparkrun/containers/distribute.py
+++ b/src/sparkrun/containers/distribute.py
@@ -297,7 +297,7 @@ def distribute_image_from_head(
             # Filter workers list and corresponding transfer hosts
             workers = hosts[1:]
             wt = worker_transfer_hosts or workers
-            filtered = [(w, t) for w, t in zip(workers, wt) if w in needs_transfer]
+            filtered = [(w, t) for w, t in zip(workers, wt, strict=False) if w in needs_transfer]
             if filtered:
                 hosts = [head] + [w for w, _ in filtered]
                 worker_transfer_hosts = [t for _, t in filtered]

--- a/src/sparkrun/core/monitoring.py
+++ b/src/sparkrun/core/monitoring.py
@@ -106,7 +106,7 @@ def parse_monitor_line(line: str) -> MonitorSample | None:
         return None
 
     kwargs = {}
-    for col_name, value in zip(MONITOR_COLUMNS, parts):
+    for col_name, value in zip(MONITOR_COLUMNS, parts, strict=False):
         kwargs[col_name] = value.strip()
 
     return MonitorSample(**kwargs)
@@ -299,7 +299,7 @@ class ClusterMonitor:
 
     def stop(self) -> None:
         """Terminate all SSH subprocesses."""
-        for host, state in self.states.items():
+        for _host, state in self.states.items():
             if state.process is not None:
                 try:
                     state.process.terminate()
@@ -513,7 +513,7 @@ class NvMonitorClusterMonitor:
 
     def stop(self) -> None:
         """Terminate all SSH processes."""
-        for host, state in self.states.items():
+        for _host, state in self.states.items():
             if state.process is not None:
                 try:
                     state.process.terminate()

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -336,8 +336,8 @@ def fetch_and_cache_recipe(url: str) -> Path:
             )
             return cache_path
         if isinstance(e, HTTPError):
-            raise RecipeError("Failed to fetch recipe from %s: HTTP %d" % (url, e.code))
-        raise RecipeError("Failed to fetch recipe from %s: %s" % (url, e.reason if isinstance(e, URLError) else e))
+            raise RecipeError("Failed to fetch recipe from %s: HTTP %d" % (url, e.code)) from e
+        raise RecipeError("Failed to fetch recipe from %s: %s" % (url, e.reason if isinstance(e, URLError) else e)) from e
 
 
 # Backward-compat aliases (old underscore names)

--- a/src/sparkrun/orchestration/primitives.py
+++ b/src/sparkrun/orchestration/primitives.py
@@ -136,7 +136,7 @@ def map_transfer_failures(
     Returns:
         List of management hostnames where transfer failed.
     """
-    xfer_to_host = dict(zip(transfer_hosts, management_hosts))
+    xfer_to_host = dict(zip(transfer_hosts, management_hosts, strict=False))
     failed = [xfer_to_host.get(r.host, r.host) for r in results if not r.success]
     return failed
 


### PR DESCRIPTION
Resolve flake8-bugbear defects in sparkrun submodule

This pull request addresses several Python defects identified by `flake8-bugbear` (via Ruff) across the `sparkrun` codebase to improve code robustness and satisfy static analysis requirements.

Specifically, this resolves:
- **B904 (Swallowed exceptions):** Added `from e` to `raise ...` inside exception handlers in `auth.py`, `_common.py`, and `recipe.py`, preventing the loss of the original traceback context.
- **B007 (Unused loop control variables):** Renamed unused loop variables to start with an underscore (e.g., `_path`, `_status`, `_image`, `_host`) in `_common.py`, `_stop_logs.py`, and `monitoring.py` to clarify intent.
- **B905 (Unsafe `zip()` operations):** Added the explicit `strict=False` parameter to `zip()` calls in `distribute.py`, `monitoring.py`, and `primitives.py` where iterating over lists of potentially unequal length.

These fixes have been verified by running `ruff check --select B src/` ensuring no further Bugbear warnings are present.

Fixes spark-arena/sparkrun#143