### PR TITLE
fix(vram): map generic awq dtype to 0.5 bytes

### DIFF
--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -21,6 +21,7 @@ _DTYPE_BYTES: dict[str, float] = {
     "fp8_e5m2": 1.0,
     "fp8_e4m3": 1.0,
     "int4": 0.5,
+    "awq": 0.5,
     "nvfp4": 0.5,
     "awq4": 0.5,
     "w4a16_awq": 0.5,


### PR DESCRIPTION
Fixes VRAM calculation missing key error when parsing models that define their quantization type as generic `awq` rather than `awq4`.