### PR TITLE
ref(runtimes): Replace hardcoded docker execution

### DIFF
--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -1185,11 +1185,14 @@ class RuntimePlugin(Plugin):
 
         inner_script = "\n".join(inner_lines)
 
-        # Pipe the inner script into `docker exec <container> bash -s`
-        # via a here-document.  This avoids quoting issues that arise
-        # when embedding complex shell commands in bash -c '...'.
-        # TODO: using 'docker exec' implies executor should be involved
-        outer_script = ("docker exec -i %s bash -s <<'SPARKRUN_VER_EOF'\n%s\nSPARKRUN_VER_EOF") % (container_name, inner_script)
+        # Pass the inner script via the executor's exec context.
+        # This replaces the hardcoded `docker exec` and correctly utilizes
+        # b64_wrap_bash internally (for DockerExecutor) to avoid quoting issues.
+        outer_script = self.executor.exec_cmd(
+            container_name=container_name,
+            command=inner_script,
+            detach=False,
+        )
 
         try:
             from sparkrun.orchestration.primitives import run_script_on_host


### PR DESCRIPTION
Replace hardcoded docker shell scripts in \`sparkrun/runtimes/base.py\` with engine agnostic executable wrappers.

Currently, the orchestration hooks in \`_collect_runtime_info\` bypass the underlying \`DockerExecutor\` pipeline by injecting raw \`docker exec -i %s bash -s <<EOF\` strings into the SSH tunneling functions. This exposes the scripts to string quotation risks and breaks engine agnosticism if we ever migrate to podman or containerd. By calling \`self.executor.exec_cmd(command=..., detach=False)\`, we natively invoke the base64-wrapping security context within the Docker pipeline.

During the investigation, additional areas with hardcoded container engine semantics were discovered (\`eugr.py\` and \`hooks.py\`). I evaluated two broader scoped solutions that we could pivot to if the team desires deeper abstraction coverage:
1. Option 1: Pragmatic Extension - Extend \`Executor\` to support \`copy_cmd\`, \`image_id_cmd\`, and \`user\` kwargs natively, and invoke \`DockerExecutor()\` from inline hooks.
2. Option 2: Pure Dependency Injection - Refactor all hooks to accept an \`executor\` object reference top-down, maximizing architectural purity.

For now, this PR implements the safest and most critical scoped fix targeting only the active \`base.py\` runtime layer where the executor reference is already present.