### PR TITLE
runtimes: support environment overrides and automatic vLLM OTel flags

### DIFF
--- a/src/sparkrun/runtimes/_cluster_ops.py
+++ b/src/sparkrun/runtimes/_cluster_ops.py
@@ -58,6 +58,7 @@ class ClusterContext:
         config: SparkrunConfig | None,
         dry_run: bool,
         topology: str | None = None,
+        overrides: dict[str, Any] | None = None,
     ) -> ClusterContext:
         """Build context from runtime hooks and config.
 
@@ -65,7 +66,7 @@ class ClusterContext:
         runtime's ``_run_cluster`` method.
         """
         from sparkrun.orchestration.primitives import build_ssh_kwargs, build_volumes
-        from sparkrun.utils import merge_env
+        from sparkrun.utils import merge_env, extract_env_overrides
 
         num_nodes = len(hosts)
         ssh_kwargs = build_ssh_kwargs(config)
@@ -76,6 +77,7 @@ class ClusterContext:
             runtime_env,
             env,
             runtime.get_extra_env(),
+            extract_env_overrides(overrides),
         )
         return cls(
             hosts=hosts,

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -53,6 +53,8 @@ VLLM_FLAG_MAP = {
     "distributed_executor_backend": "--distributed-executor-backend",
     "pipeline_parallel": "-pp",
     "kv_cache_dtype": "--kv-cache-dtype",
+    "otlp_traces_endpoint": "--otlp-traces-endpoint",
+    "collect_detailed_traces": "--collect-detailed-traces",
 }
 
 # Boolean flags (present = True, absent = False)

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -768,7 +768,7 @@ class RuntimePlugin(Plugin):
             run_script_on_host,
             should_run_locally,
         )
-        from sparkrun.utils import merge_env
+        from sparkrun.utils import merge_env, extract_env_overrides
 
         ssh_kwargs = build_ssh_kwargs(config)
         is_local = should_run_locally(host, ssh_kwargs.get("ssh_user"))
@@ -779,6 +779,7 @@ class RuntimePlugin(Plugin):
             self.get_solo_env(),  # solo-specific
             env,  # recipe
             self.get_extra_env(),  # tuning/other overrides
+            extract_env_overrides(overrides),  # CLI overrides (env.*)
         )
 
         combined_docker_opts = (self.get_extra_docker_opts() or []) + (extra_docker_opts or [])

--- a/src/sparkrun/runtimes/llama_cpp.py
+++ b/src/sparkrun/runtimes/llama_cpp.py
@@ -423,7 +423,7 @@ class LlamaCppRuntime(RuntimePlugin):
 
         progress = kwargs.pop("progress", None)
 
-        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run)
+        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run, overrides=overrides)
         head_container = self._container_name(cluster_id, "head")
         worker_container_name = self._container_name(cluster_id, "worker")
 

--- a/src/sparkrun/runtimes/trtllm.py
+++ b/src/sparkrun/runtimes/trtllm.py
@@ -447,7 +447,7 @@ class TrtllmRuntime(RuntimePlugin):
 
         progress = kwargs.pop("progress", None)
 
-        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run)
+        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run, overrides=overrides)
         extra_docker_opts = self.get_extra_docker_opts()
 
         self._print_cluster_banner(

--- a/src/sparkrun/runtimes/vllm_distributed.py
+++ b/src/sparkrun/runtimes/vllm_distributed.py
@@ -64,6 +64,14 @@ class VllmDistributedRuntime(VllmMixin, RuntimePlugin):
                 "--served-model-name",
                 skip_keys,
             )
+            # Augment OTel flags if present in config but missing from rendered command
+            for key in ["otlp_traces_endpoint", "collect_detailed_traces"]:
+                if key in skip_keys:
+                    continue
+                val = config.get(key)
+                if val is not None and VLLM_FLAG_MAP[key] not in rendered:
+                    rendered += f" {VLLM_FLAG_MAP[key]} {val}"
+
             if skip_keys:
                 rendered = self.strip_flags_from_command(
                     rendered,
@@ -103,6 +111,14 @@ class VllmDistributedRuntime(VllmMixin, RuntimePlugin):
                 "--served-model-name",
                 skip_keys,
             )
+            # Augment OTel flags if present in config but missing from rendered command
+            for key in ["otlp_traces_endpoint", "collect_detailed_traces"]:
+                if key in skip_keys:
+                    continue
+                val = config.get(key)
+                if val is not None and VLLM_FLAG_MAP[key] not in rendered:
+                    rendered += f" {VLLM_FLAG_MAP[key]} {val}"
+
             if skip_keys:
                 rendered = self.strip_flags_from_command(
                     rendered,

--- a/src/sparkrun/runtimes/vllm_ray.py
+++ b/src/sparkrun/runtimes/vllm_ray.py
@@ -246,7 +246,7 @@ class VllmRayRuntime(VllmMixin, RuntimePlugin):
         progress = kwargs.pop("progress", None)
         combined_docker_opts = (self.get_extra_docker_opts() or []) + (extra_docker_opts or [])
 
-        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run)
+        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run, overrides=overrides)
         head_container = self.executor.container_name(cluster_id, "head")
         worker_container = self.executor.container_name(cluster_id, "worker")
 

--- a/src/sparkrun/utils/__init__.py
+++ b/src/sparkrun/utils/__init__.py
@@ -6,6 +6,7 @@ Keeping them here avoids circular imports and reduces duplication.
 
 from __future__ import annotations
 import logging
+from typing import Any
 
 # Loggers that produce excessive output at DEBUG/INFO level.
 _NOISY_LOGGERS = (
@@ -104,6 +105,19 @@ def merge_env(*env_dicts: dict[str, str] | None) -> dict[str, str]:
         if d:
             merged.update(d)
     return merged
+
+
+def extract_env_overrides(overrides: dict[str, Any] | None) -> dict[str, str]:
+    """Extract env.* items from overrides into a plain env dict."""
+    env: dict[str, str] = {}
+    if not overrides:
+        return env
+    for key, value in overrides.items():
+        if key.startswith("env."):
+            var_name = key[4:]
+            if var_name:
+                env[var_name] = str(value)
+    return env
 
 
 def is_local_host(host: str) -> bool:


### PR DESCRIPTION
This PR adds support for passing OpenTelemetry tracing flags to vLLM and a generic mechanism for environment variable overrides.

Key changes:
- Added `extract_env_overrides` to parse `env.*` keys from SparkrunConfig.
- Added `otlp_traces_endpoint` and `collect_detailed_traces` to VLLM flag mappings.
- Updated `VllmDistributedRuntime` to automatically augment rendered commands with OTel flags if present in the config.