### PR TITLE
feat(telemetry): daemonize TelemetryTunnel with PID files, hook cleanup into stop + add pyrightconfig

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,10 @@
+{
+  "include": ["src"],
+  "extraPaths": ["src"],
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "basic",
+  "reportMissingImports": "warning",
+  "reportMissingModuleSource": "warning"
+}

--- a/src/sparkrun/arena/auth.py
+++ b/src/sparkrun/arena/auth.py
@@ -95,9 +95,9 @@ def exchange_token(refresh_token: str, debug_mode: bool = False) -> ExchangeResu
             msg = err_data.get("message") or err_data.get("error", body)
         except (json.JSONDecodeError, ValueError):
             msg = body
-        raise RuntimeError("Token exchange failed (%d): %s" % (e.code, msg))
+        raise RuntimeError("Token exchange failed (%d): %s" % (e.code, msg)) from e
     except URLError as e:
-        raise RuntimeError("Cannot reach auth proxy: %s" % e.reason)
+        raise RuntimeError("Cannot reach auth proxy: %s" % e.reason) from e
 
     id_token = data.get("id_token")
     user_id = data.get("user_id")
@@ -146,7 +146,7 @@ def _can_open_browser() -> bool:
     return True
 
 
-def run_browser_login() -> str | None:
+def run_browser_login() -> tuple[str, str] | None:
     """Run browser-based OAuth login flow.
 
     Returns the refresh token on success, or None on failure.

--- a/src/sparkrun/arena/auth.py
+++ b/src/sparkrun/arena/auth.py
@@ -14,6 +14,7 @@ from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 
 from dataclasses import dataclass
+import contextlib
 
 logger = logging.getLogger(__name__)
 
@@ -64,10 +65,8 @@ def load_refresh_token() -> str | None:
 def clear_refresh_token() -> None:
     """Delete the stored refresh token."""
     path = get_token_path()
-    try:
+    with contextlib.suppress(FileNotFoundError):
         path.unlink()
-    except FileNotFoundError:
-        pass
 
 
 def exchange_token(refresh_token: str, debug_mode: bool = False) -> ExchangeResult:

--- a/src/sparkrun/arena/auth.py
+++ b/src/sparkrun/arena/auth.py
@@ -95,9 +95,9 @@ def exchange_token(refresh_token: str, debug_mode: bool = False) -> ExchangeResu
             msg = err_data.get("message") or err_data.get("error", body)
         except (json.JSONDecodeError, ValueError):
             msg = body
-        raise RuntimeError("Token exchange failed (%d): %s" % (e.code, msg))
+        raise RuntimeError("Token exchange failed (%d): %s" % (e.code, msg)) from e
     except URLError as e:
-        raise RuntimeError("Cannot reach auth proxy: %s" % e.reason)
+        raise RuntimeError("Cannot reach auth proxy: %s" % e.reason) from e
 
     id_token = data.get("id_token")
     user_id = data.get("user_id")

--- a/src/sparkrun/benchmarking/base.py
+++ b/src/sparkrun/benchmarking/base.py
@@ -144,10 +144,10 @@ class BenchmarkResult:
 
     # benchmark results
     success: bool = False
-    results: dict[str, Any] = None
+    results: dict[str, Any] | None = None
     outputs: Optional[dict[str, Any]] = None
-    start_time: datetime = None
-    end_time: datetime = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
 
     # recipe/launch info
     recipe_name: Optional[str] = None
@@ -220,6 +220,10 @@ class BenchmarkResult:
         profile = self.profile
         benchmark_args = self.benchmark_args
 
+        if recipe is None:
+            logger.warning("No recipe associated with benchmark result.")
+            return {}
+
         # Resolve container image to a pinned long-term reference when possible
         container_pinned = False
         recipe_container = container_image or recipe.container
@@ -237,7 +241,8 @@ class BenchmarkResult:
             except Exception:
                 logger.debug("Long-term image resolution failed", exc_info=True)
 
-        recipe_hash = hashlib.sha256(recipe.export(overrides=None).encode("utf-8")).hexdigest()
+        recipe_export = str(recipe.export(overrides=None))
+        recipe_hash = hashlib.sha256(recipe_export.encode("utf-8")).hexdigest()
 
         hf_model = parse_gguf_model_spec(recipe.model)[0]
         model_meta: dict[str, Any] = {}
@@ -277,9 +282,9 @@ class BenchmarkResult:
                 "hash": recipe_hash,
             },
             "timing": {
-                "start": self.start_time.isoformat(),
-                "end": self.end_time.isoformat(),
-                "duration": (self.end_time - self.start_time).total_seconds(),
+                "start": self.start_time.isoformat() if self.start_time else None,
+                "end": self.end_time.isoformat() if self.end_time else None,
+                "duration": (self.end_time - self.start_time).total_seconds() if self.start_time and self.end_time else None,
             },
             "cluster": _build_cluster_meta(recipe, overrides, cluster_id, host_list),
             "benchmark": {
@@ -336,7 +341,7 @@ def export_results(
     """
     output_path = Path(output_path)
     # noinspection PyProtectedMember
-    recipe_text = recipe.export(path=None)
+    recipe_text = str(recipe.export(path=None) or "")
     recipe_hash = hashlib.sha256(recipe_text.encode("utf-8")).hexdigest()
 
     # Build model metadata from recipe metadata (includes auto-detected

--- a/src/sparkrun/benchmarking/llama_benchy.py
+++ b/src/sparkrun/benchmarking/llama_benchy.py
@@ -60,7 +60,7 @@ class LlamaBenchyFramework(BenchmarkingPlugin):
     }
     passthrough_args = _PASSTHROUGH_ARGS
 
-    def initialize(self, v: Variables, logger_arg: Logger) -> LlamaBenchyFramework:
+    def initialize(self, v: Variables, logger: Logger) -> LlamaBenchyFramework:
         return self
 
     def check_prerequisites(self) -> list[str]:

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -118,10 +118,10 @@ class EugrBuilder(BuilderPlugin):
 
     builder_name = "eugr"
 
-    _v: Variables = None
+    _v: Variables | None = None
     _repo_dir: Path | None = None
 
-    def initialize(self, v: Variables, logger_arg: Logger) -> EugrBuilder:
+    def initialize(self, v: Variables, logger: Logger) -> EugrBuilder:
         """Initialize the eugr builder plugin."""
         self._v = v
         return self
@@ -340,6 +340,7 @@ class EugrBuilder(BuilderPlugin):
         if resolved:
             return resolved, True
 
+        assert ghcr_pkg is not None
         # Fall back to GHCR API tag enumeration
         resolved = self._match_via_ghcr_api(
             ghcr_image,
@@ -738,6 +739,8 @@ class EugrBuilder(BuilderPlugin):
             build_args: Additional build arguments forwarded to the script.
             dry_run: Show what would be done without executing.
         """
+        if not self._repo_dir:
+            raise RuntimeError("Repository not initialized")
         build_script = self._repo_dir / "build-and-copy.sh"
         if not build_script.exists():
             raise RuntimeError("build-and-copy.sh not found at %s" % build_script)

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -636,10 +636,7 @@ class EugrBuilder(BuilderPlugin):
 
         if upstream.get("vllm_commit") != entry.get("vllm_commit"):
             return False
-        if upstream.get("flashinfer_commit") != entry.get("flashinfer_commit"):
-            return False
-
-        return True
+        return upstream.get("flashinfer_commit") == entry.get("flashinfer_commit")
 
     def _save_build_metadata(
         self,

--- a/src/sparkrun/cli/_arena.py
+++ b/src/sparkrun/cli/_arena.py
@@ -291,6 +291,7 @@ def arena_benchmark(
     click.echo("Uploading results to Spark Arena...")
 
     try:
+        assert refresh_token is not None
         success, sid = upload_benchmark_results(
             refresh_token=refresh_token,
             upload_files=upload_files,

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -411,7 +411,6 @@ def _run_benchmark(
                 registry_mgr=registry_mgr,
                 auto_port=True,
                 sync_tuning=sync_tuning,
-                skip_keys={"served_model_name"},
                 dry_run=dry_run,
                 detached=True,
                 rootless=not rootful,
@@ -500,6 +499,13 @@ def _run_benchmark(
         est_tests = fw.estimate_test_count(bench_args)
         if est_tests is not None:
             logger.info("Estimated test iterations: %d", est_tests)
+
+        # Pass served_model_name as an argument if defined, satisfying llama-benchy's
+        # requirement to maintain the original huggingface model ID for tokenization.
+        # Check config_chain to capture both CLI overrides and recipe definitions natively.
+        served_model_name = config_chain.get("served_model_name")
+        if served_model_name and "served_model_name" not in bench_args:
+            bench_args["served_model_name"] = served_model_name
 
         bench_cmd = fw.build_benchmark_command(
             target_url=base_url,

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -29,6 +29,7 @@ from ._common import (
     validate_and_prepare_hosts,
     HIDE_ADVANCED_OPTIONS,
 )
+import contextlib
 
 logger = logging.getLogger(__name__)
 
@@ -667,10 +668,8 @@ def _run_benchmark(
     finally:
         import os
 
-        try:
+        with contextlib.suppress(OSError):
             os.unlink(result_file)
-        except OSError:
-            pass
 
     return bench_result
 

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -285,6 +285,8 @@ def _run_benchmark(
     # ---------------------------------------------------------------
     # 4. Build overrides and resolve runtime/hosts
     # ---------------------------------------------------------------
+    serve_port: int = 8000  # Default, overridden below
+
     recipe, overrides = _apply_recipe_overrides(
         options,
         tensor_parallel=tensor_parallel,
@@ -296,6 +298,8 @@ def _run_benchmark(
         # custom
         port=port,
     )
+
+    assert recipe is not None, "Recipe must not prove None after override application"
 
     issues = recipe.validate()
     for issue in issues:
@@ -501,9 +505,12 @@ def _run_benchmark(
         if est_tests is not None:
             logger.info("Estimated test iterations: %d", est_tests)
 
+        config_chain = recipe.build_config_chain(overrides)
+        effective_model = config_chain.get("served_model_name") or overrides.get("model") or recipe.model
+
         bench_cmd = fw.build_benchmark_command(
             target_url=base_url,
-            model=recipe.model,
+            model=effective_model,
             args=bench_args,
             result_file=result_file,
         )
@@ -524,6 +531,7 @@ def _run_benchmark(
             click.echo("--- benchmark output ---")
             bench_start = time.monotonic()
             bench_result.start_time = datetime.now(tz=timezone.utc)
+            proc = None
             try:
                 import os
 
@@ -539,13 +547,14 @@ def _run_benchmark(
                 )
 
                 stdout_lines: list[str] = []
-                for line in proc.stdout:
-                    click.echo(line, nl=False)
-                    stdout_lines.append(line)
+                if proc and proc.stdout:
+                    for line in proc.stdout:
+                        click.echo(line, nl=False)
+                        stdout_lines.append(line)
 
                 proc.wait(timeout=effective_timeout)
                 stdout_text = "".join(stdout_lines)
-                stderr_text = proc.stderr.read()
+                stderr_text = proc.stderr.read() if proc and proc.stderr else ""
 
                 elapsed = time.monotonic() - bench_start
                 bench_result.end_time = datetime.now(tz=timezone.utc)
@@ -567,7 +576,8 @@ def _run_benchmark(
                 else:
                     click.echo("Benchmark completed successfully (%.0fs elapsed)." % elapsed)
             except subprocess.TimeoutExpired:
-                proc.kill()
+                if proc:
+                    proc.kill()
                 click.echo("Error: benchmark timed out after %d seconds" % effective_timeout, err=True)
                 stdout_text = ""
                 stderr_text = ""

--- a/src/sparkrun/cli/_cluster.py
+++ b/src/sparkrun/cli/_cluster.py
@@ -849,9 +849,7 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
     # auto (None) → cx7 if IB is available and validated, else mgmt
     if xfer_iface == "mgmt":
         resolved_iface = "mgmt"
-    elif xfer_result.ib_validated:
-        resolved_iface = "cx7"
-    elif ib_result and ib_result.ib_ip_map:
+    elif xfer_result.ib_validated or ib_result and ib_result.ib_ip_map:
         resolved_iface = "cx7"
     elif ib_result:
         resolved_iface = "mgmt"
@@ -864,10 +862,7 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
 
     # Build a script that checks existence and disk usage for both dirs.
     # We derive remote sparkrun cache the same way: ~/.cache/sparkrun on the remote user.
-    if cluster_cfg.user:
-        remote_sparkrun = "/home/%s/.cache/sparkrun" % cluster_cfg.user
-    else:
-        remote_sparkrun = "$HOME/.cache/sparkrun"
+    remote_sparkrun = "/home/%s/.cache/sparkrun" % cluster_cfg.user if cluster_cfg.user else "$HOME/.cache/sparkrun"
 
     check_cmd = (
         'sr_dir="%s"; hf_dir="%s"; '

--- a/src/sparkrun/cli/_cluster.py
+++ b/src/sparkrun/cli/_cluster.py
@@ -704,6 +704,7 @@ def cluster_check_job(ctx, target, hosts, hosts_file, cluster_name, tp_override,
     if _is_cluster_id(target) is not None:
         # --- Cluster ID path ---
         cid = _is_cluster_id(target)
+        assert cid is not None
         from sparkrun.orchestration.job_metadata import load_job_metadata
 
         meta = load_job_metadata(cid, cache_dir=str(config.cache_dir))
@@ -849,9 +850,7 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
     # auto (None) → cx7 if IB is available and validated, else mgmt
     if xfer_iface == "mgmt":
         resolved_iface = "mgmt"
-    elif xfer_result.ib_validated:
-        resolved_iface = "cx7"
-    elif ib_result and ib_result.ib_ip_map:
+    elif xfer_result.ib_validated or ib_result and ib_result.ib_ip_map:
         resolved_iface = "cx7"
     elif ib_result:
         resolved_iface = "mgmt"

--- a/src/sparkrun/cli/_common.py
+++ b/src/sparkrun/cli/_common.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 # noinspection PyShadowingBuiltins
-def json_option(help: str = None):
+def json_option(help: str | None = None):
     return click.option(
         "--json",
         "output_json",
@@ -327,16 +327,16 @@ def _load_recipe(config, recipe_name, resolve=True):
         registry_mgr.ensure_initialized()
         return recipe, cached_path, registry_mgr
 
+    registry_mgr = config.get_registry_manager()
+    registry_mgr.ensure_initialized()
     try:
-        registry_mgr = config.get_registry_manager()
-        registry_mgr.ensure_initialized()
         recipe_path = find_recipe(recipe_name, registry_manager=registry_mgr, local_files=discover_cwd_recipes())
         recipe = Recipe.load(recipe_path, resolve=resolve)
     except RecipeAmbiguousError as e:
         # Interactive disambiguation
         if sys.stdin.isatty():
             click.echo("Recipe '%s' found in multiple registries:" % e.name)
-            for i, (reg, path) in enumerate(e.matches, 1):
+            for i, (reg, _path) in enumerate(e.matches, 1):
                 click.echo("  %d. @%s/%s" % (i, reg, e.name))
             click.echo()
             choice = click.prompt(
@@ -347,7 +347,7 @@ def _load_recipe(config, recipe_name, resolve=True):
             _reg_name, recipe_path = e.matches[choice - 1]
             recipe = Recipe.load(recipe_path, resolve=resolve)
         else:
-            raise click.ClickException(str(e))
+            raise click.ClickException(str(e)) from e
     except RecipeError as e:
         click.echo("Error: %s" % e, err=True)
         sys.exit(1)
@@ -497,14 +497,14 @@ def _complete_yaml_files(incomplete):
                 rel = "./" + rel
             if entry.is_dir():
                 items.append(
-                    click.shell_completion.CompletionItem(
+                    click.shell_completion.CompletionItem(  # type: ignore
                         rel + "/",
                         type="dir",
                     )
                 )
             elif entry.suffix in (".yaml", ".yml"):
                 items.append(
-                    click.shell_completion.CompletionItem(
+                    click.shell_completion.CompletionItem(  # type: ignore
                         rel,
                         type="file",
                     )
@@ -554,29 +554,30 @@ class RecipeNameType(click.ParamType):
                         recipe_path = registry_mgr.cache_root / reg.name / reg.subpath
                         recipes = list_recipes(search_paths=[recipe_path])
                         for r in recipes:
-                            items.append(click.shell_completion.CompletionItem("@%s/%s" % (reg.name, r["file"])))
+                            items.append(click.shell_completion.CompletionItem("@%s/%s" % (reg.name, r["file"])))  # type: ignore
                     if not items and matching_registries:
                         # No recipes found — show registry names so the user
                         # can still discover and select the registry.
                         # type="dir" prevents the shell from appending a
                         # trailing space, so the user can continue typing
                         # the recipe name after the slash.
-                        items = [click.shell_completion.CompletionItem("@%s/" % reg.name, type="dir") for reg in matching_registries]
+                        items = [click.shell_completion.CompletionItem("@%s/" % reg.name, type="dir") for reg in matching_registries]  # type: ignore
                     return items
                 else:
                     # Completing recipe after @registry/
                     from sparkrun.utils import parse_scoped_name
 
                     registry_name, recipe_prefix = parse_scoped_name(incomplete)
-                    # Only load recipes from the target registry
                     try:
+                        if registry_name is None:
+                            return []
                         entry = registry_mgr.get_registry(registry_name)
                     except Exception:
                         return []
                     recipe_path = registry_mgr.cache_root / entry.name / entry.subpath
                     recipes = list_recipes(search_paths=[recipe_path])
                     return [
-                        click.shell_completion.CompletionItem("@%s/%s" % (registry_name, r["file"]))
+                        click.shell_completion.CompletionItem("@%s/%s" % (registry_name, r["file"]))  # type: ignore
                         for r in recipes
                         if r["file"].startswith(recipe_prefix)
                     ]
@@ -590,7 +591,7 @@ class RecipeNameType(click.ParamType):
 
             config, registry_mgr = _get_config_and_registry()
             recipes = list_recipes(registry_manager=registry_mgr, include_hidden=False, local_files=discover_cwd_recipes())
-            return [click.shell_completion.CompletionItem(r["file"]) for r in recipes if r["file"].startswith(incomplete)]
+            return [click.shell_completion.CompletionItem(r["file"]) for r in recipes if r["file"].startswith(incomplete)]  # type: ignore
         except Exception:
             return []
 
@@ -662,7 +663,7 @@ class ProfileNameType(click.ParamType):
                             continue
                         profiles = registry_mgr.list_benchmark_profiles(registry_name=reg.name, include_hidden=True)
                         for p in profiles:
-                            items.append(click.shell_completion.CompletionItem("@%s/%s" % (reg.name, p["file"])))
+                            items.append(click.shell_completion.CompletionItem("@%s/%s" % (reg.name, p["file"])))  # type: ignore
                     return items
                 else:
                     # Completing profile name after @registry/
@@ -671,7 +672,7 @@ class ProfileNameType(click.ParamType):
                     registry_name, profile_prefix = parse_scoped_name(incomplete)
                     profiles = registry_mgr.list_benchmark_profiles(registry_name=registry_name, include_hidden=True)
                     return [
-                        click.shell_completion.CompletionItem("@%s/%s" % (registry_name, p["file"]))
+                        click.shell_completion.CompletionItem("@%s/%s" % (registry_name, p["file"]))  # type: ignore
                         for p in profiles
                         if p["file"].startswith(profile_prefix)
                     ]
@@ -683,7 +684,7 @@ class ProfileNameType(click.ParamType):
             # Default: list profile names from visible registries only
             config, registry_mgr = _get_config_and_registry()
             profiles = registry_mgr.list_benchmark_profiles()
-            return [click.shell_completion.CompletionItem(p["file"]) for p in profiles if p["file"].startswith(incomplete)]
+            return [click.shell_completion.CompletionItem(p["file"]) for p in profiles if p["file"].startswith(incomplete)]  # type: ignore
         except Exception:
             return []
 
@@ -701,7 +702,7 @@ class ClusterNameType(click.ParamType):
         try:
             mgr = _get_cluster_manager()
             clusters = mgr.list_clusters()
-            return [click.shell_completion.CompletionItem(c.name) for c in clusters if c.name.startswith(incomplete)]
+            return [click.shell_completion.CompletionItem(c.name) for c in clusters if c.name.startswith(incomplete)]  # type: ignore
         except Exception:
             return []
 
@@ -719,7 +720,9 @@ class RegistryNameType(click.ParamType):
         try:
             _, registry_mgr = _get_config_and_registry()
             return [
-                click.shell_completion.CompletionItem(reg.name) for reg in registry_mgr.list_registries() if reg.name.startswith(incomplete)
+                click.shell_completion.CompletionItem(reg.name)  # pyright: ignore[reportAttributeAccessIssue]
+                for reg in registry_mgr.list_registries()
+                if reg.name.startswith(incomplete)  # type: ignore
             ]
         except Exception:
             return []
@@ -741,7 +744,7 @@ class RuntimeNameType(click.ParamType):
             _, registry_mgr = _get_config_and_registry()
             recipes = list_recipes(registry_manager=registry_mgr)
             runtimes = sorted({r.get("runtime", "") for r in recipes if r.get("runtime")})
-            return [click.shell_completion.CompletionItem(rt) for rt in runtimes if rt.startswith(incomplete)]
+            return [click.shell_completion.CompletionItem(rt) for rt in runtimes if rt.startswith(incomplete)]  # type: ignore
         except Exception:
             return []
 

--- a/src/sparkrun/cli/_common.py
+++ b/src/sparkrun/cli/_common.py
@@ -336,7 +336,7 @@ def _load_recipe(config, recipe_name, resolve=True):
         # Interactive disambiguation
         if sys.stdin.isatty():
             click.echo("Recipe '%s' found in multiple registries:" % e.name)
-            for i, (reg, path) in enumerate(e.matches, 1):
+            for i, (reg, _path) in enumerate(e.matches, 1):
                 click.echo("  %d. @%s/%s" % (i, reg, e.name))
             click.echo()
             choice = click.prompt(
@@ -347,7 +347,7 @@ def _load_recipe(config, recipe_name, resolve=True):
             _reg_name, recipe_path = e.matches[choice - 1]
             recipe = Recipe.load(recipe_path, resolve=resolve)
         else:
-            raise click.ClickException(str(e))
+            raise click.ClickException(str(e)) from e
     except RecipeError as e:
         click.echo("Error: %s" % e, err=True)
         sys.exit(1)

--- a/src/sparkrun/cli/_export.py
+++ b/src/sparkrun/cli/_export.py
@@ -37,7 +37,7 @@ def _apply_spark_arena_benchmarks(recipe, recipe_name: str):
     if recipe.metadata.get("spark_arena_benchmarks"):
         return  # already set
 
-    if recipe_name.startswith(SPARK_ARENA_PREFIX):
+    if recipe_name and recipe_name.startswith(SPARK_ARENA_PREFIX):
         from sparkrun.core.parallelism import extract_parallelism_meta
 
         uuid = recipe_name[len(SPARK_ARENA_PREFIX) :]
@@ -107,8 +107,9 @@ def export_running(ctx, target, hosts, hosts_file, cluster_name, output_json, sa
     config, _ = _get_config_and_registry()
 
     # Resolve cluster_id
-    if _is_cluster_id(target) is not None:
-        cluster_id = _is_cluster_id(target)
+    cid = _is_cluster_id(target)
+    if cid is not None:
+        cluster_id = cid
     else:
         # Target is a recipe name — need hosts to generate cluster_id
         recipe, _recipe_path, _registry_mgr = _load_recipe(config, target)
@@ -413,9 +414,10 @@ def _resolve_recipe_for_systemd(
     from sparkrun.orchestration.job_metadata import load_job_metadata
     from sparkrun.core.recipe import Recipe
 
+    cid = _is_cluster_id(target)
     # If target is a cluster_id, reconstruct from job metadata
-    if _is_cluster_id(target) is not None:
-        cluster_id = _is_cluster_id(target)
+    if cid is not None:
+        cluster_id = cid
         meta = load_job_metadata(cluster_id, cache_dir=str(config.cache_dir))
         if not meta:
             click.echo("Error: No job metadata found for '%s'." % target, err=True)
@@ -556,6 +558,8 @@ def export_systemd(
         port,
         served_model_name,
     )
+
+    assert recipe is not None
 
     head_host = host_list[0]
     slug = service_name or recipe.slug

--- a/src/sparkrun/cli/_monitor_tui.py
+++ b/src/sparkrun/cli/_monitor_tui.py
@@ -9,7 +9,8 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import DataTable, Footer, Header, Static
 
-from sparkrun.core.monitoring import ClusterMonitor, HostMonitorState, MonitorSample
+from sparkrun.core.monitoring import ClusterMonitor, HostMonitorState, MonitorSample, NvMonitorClusterMonitor
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,8 @@ def _render_detail(host: str, state: HostMonitorState | None, cache_dir: str | N
     if state.error and state.latest is None:
         return f"[red]{host}: {state.error}[/red]"
 
-    s: MonitorSample = state.latest
+    s: MonitorSample | None = state.latest
+    assert s is not None
 
     cpu = _pct(s.cpu_usage_pct)
     ram = _pct(s.mem_used_pct)
@@ -243,7 +245,7 @@ def _cell_gpu_dec(s: MonitorSample) -> str:
 
 
 # Ordered column definitions: (key, label, cell_fn)
-_TABLE_COLS: list[tuple[str, str, object]] = [
+_TABLE_COLS: list[tuple[str, str, Callable[[MonitorSample], str]]] = [
     ("jobs", "Jobs", _cell_jobs),
     ("cpu", "CPU%", _cell_cpu),
     ("ram", "RAM%", _cell_ram),
@@ -290,7 +292,7 @@ class ClusterMonitorApp(App):
 
     def __init__(
         self,
-        monitor: ClusterMonitor,
+        monitor: ClusterMonitor | NvMonitorClusterMonitor,
         cache_dir: str | None = None,
         **kwargs,
     ):

--- a/src/sparkrun/cli/_proxy.py
+++ b/src/sparkrun/cli/_proxy.py
@@ -557,6 +557,8 @@ def load_cmd(
         recipe=recipe,
     )
 
+    assert recipe is not None
+
     issues = recipe.validate()
     for issue in issues:
         click.echo("Warning: %s" % issue, err=True)

--- a/src/sparkrun/cli/_registry.py
+++ b/src/sparkrun/cli/_registry.py
@@ -372,8 +372,9 @@ def export_metadata(ctx, output, include_hidden):
         if not recipe_dir or not recipe_dir.is_dir():
             continue
 
+        assert recipe_dir is not None
         recipe_count = 0
-        for f in sorted(recipe_dir.rglob("*.yaml"), key=lambda p: (len(p.relative_to(recipe_dir).parts), p.name)):
+        for f in sorted(recipe_dir.rglob("*.yaml"), key=lambda p, rd=recipe_dir: (len(p.relative_to(rd).parts), p.name)):
             try:
                 data = read_yaml(str(f))
                 if not isinstance(data, dict):

--- a/src/sparkrun/cli/_registry.py
+++ b/src/sparkrun/cli/_registry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sys
 
+import contextlib
+
 import click
 import yaml
 
@@ -386,10 +388,8 @@ def export_metadata(ctx, output, include_hidden):
 
             # Run VRAM estimation to auto-detect model_params and model_dtype
             # from HuggingFace when not present in recipe metadata.
-            try:
+            with contextlib.suppress(Exception):
                 recipe.estimate_vram(auto_detect=True)
-            except Exception:
-                pass  # best-effort — metadata fields may remain None
 
             rel_path = f.relative_to(recipe_dir)
             raw_url = _build_raw_url(entry.url, entry.subpath, str(rel_path))

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -279,33 +279,93 @@ def run(
     # Launch via shared pipeline
     if diag:
         diag.phase_start("launch")
+        
+    from contextlib import ExitStack
+    from sparkrun.orchestration.ssh import TelemetryTunnel
+    from sparkrun.orchestration.primitives import build_ssh_kwargs
+
     try:
-        result = launch_inference(
-            recipe=recipe,
-            runtime=runtime,
-            host_list=host_list,
-            overrides=overrides,
-            sctx=sctx,
-            is_solo=is_solo,
-            cache_dir=remote_cache_dir,
-            local_cache_dir=local_cache_dir,
-            transfer_mode=effective_transfer_mode,
-            transfer_interface=effective_transfer_interface,
-            recipe_ref=recipe_ref,
-            registry_mgr=registry_mgr,
-            sync_tuning=not no_sync_tuning,
-            dry_run=dry_run,
-            detached=not foreground,
-            follow=not no_follow,
-            ray_port=ray_port,
-            dashboard_port=dashboard_port,
-            dashboard=dashboard,
-            init_port=init_port,
-            topology=cluster_cfg.topology,
-            executor_config=cli_executor_opts,
-            rootless=not rootful,
-            auto_user=not rootful,
-        )
+        with ExitStack() as stack:
+            # Set up a telemetry tunnel for each host in the cluster
+            if not dry_run:
+                tunnel_ssh_kw = build_ssh_kwargs(config)
+                for host in host_list:
+                    stack.enter_context(
+                        TelemetryTunnel(
+                            host=host,
+                            ssh_user=tunnel_ssh_kw.get("ssh_user"),
+                            ssh_key=tunnel_ssh_kw.get("ssh_key"),
+                            ssh_options=tunnel_ssh_kw.get("ssh_options"),
+                        )
+                    )
+
+            result = launch_inference(
+                recipe=recipe,
+                runtime=runtime,
+                host_list=host_list,
+                overrides=overrides,
+                sctx=sctx,
+                is_solo=is_solo,
+                cache_dir=remote_cache_dir,
+                local_cache_dir=local_cache_dir,
+                transfer_mode=effective_transfer_mode,
+                transfer_interface=effective_transfer_interface,
+                recipe_ref=recipe_ref,
+                registry_mgr=registry_mgr,
+                sync_tuning=not no_sync_tuning,
+                dry_run=dry_run,
+                detached=not foreground,
+                follow=not no_follow,
+                ray_port=ray_port,
+                dashboard_port=dashboard_port,
+                dashboard=dashboard,
+                init_port=init_port,
+                topology=cluster_cfg.topology,
+                executor_config=cli_executor_opts,
+                rootless=not rootful,
+                auto_user=not rootful,
+            )
+            
+            if diag:
+                diag.phase_end("launch")
+                diag.emit_launch_result(result)
+                diag.emit_serve_command(result.serve_command, result.container_image)
+
+            # region USER FACING STDOUT INFORMATION
+
+            click.echo("Cluster:   %s" % result.cluster_id)
+            click.echo()
+            click.echo("Serve command:")
+            for line in result.serve_command.strip().splitlines():
+                click.echo("  %s" % line)
+            click.echo()
+
+            if result.runtime_info:
+                click.echo("Runtime versions:")
+                for k, v in sorted(result.runtime_info.items()):
+                    click.echo("  %-10s %s" % (k + ":", v))
+                click.echo()
+
+            # endregion
+
+            # Post-serve lifecycle: run post_exec and post_commands if recipe defines them
+            has_post_hooks = bool(recipe.post_exec or recipe.post_commands)
+            if result.rc == 0 and has_post_hooks and not foreground:
+                from sparkrun.core.launcher import post_launch_lifecycle
+
+                post_launch_lifecycle(result, remote_cache_dir=remote_cache_dir, trust=trust, dry_run=dry_run, progress=sctx.progress)
+            else:
+                if sctx.progress:
+                    sctx.progress.phase_skip(6)
+
+            # Follow container logs after a successful detached launch
+            if result.rc == 0 and not foreground and not dry_run and not no_follow:
+                runtime.follow_logs(
+                    hosts=host_list,
+                    cluster_id=result.cluster_id,
+                    config=config,
+                    dry_run=dry_run,
+                )
     except DistributionError as e:
         if diag:
             diag.phase_end("launch", error=str(e))

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -160,6 +160,7 @@ def run(
 
     # Find and load recipe (defer resolution until overrides are built)
     recipe, _recipe_path, registry_mgr = _load_recipe(config, recipe_name, resolve=False)
+    assert recipe is not None
 
     # If recipe was loaded from a URL, simplify for display
     _resolved_name = _expand_recipe_shortcut(recipe_name)
@@ -178,6 +179,7 @@ def run(
         port=port,
         served_model_name=served_model_name,
     )
+    assert recipe is not None
 
     # Validate recipe (after resolve so runtime is populated)
     issues = recipe.validate()

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -27,6 +27,7 @@ from ._common import (
     validate_and_prepare_hosts,
     HIDE_ADVANCED_OPTIONS,
 )
+import contextlib
 
 logger = logging.getLogger(__name__)
 
@@ -442,10 +443,8 @@ def run(
 
             _head = host_list[0] if host_list else "localhost"
             _cname = generate_container_name(result.cluster_id, "solo") if is_solo else generate_node_container_name(result.cluster_id, 0)
-            try:
+            with contextlib.suppress(Exception):
                 diag.capture_container_logs(_head, _cname, _diag_ssh2(config))
-            except Exception:
-                pass
         diag.emit_summary()
         diag.close()
         click.echo("Diagnostics written to: %s" % diagnostics_path)

--- a/src/sparkrun/cli/_setup/_commands.py
+++ b/src/sparkrun/cli/_setup/_commands.py
@@ -60,6 +60,8 @@ def setup_completion(ctx, shell):
         snippet = 'eval "$(%s=zsh_source sparkrun)"' % completion_var
     elif shell == "fish":
         snippet = "%s=fish_source sparkrun | source" % completion_var
+    else:
+        snippet = ""
 
     # Check if already installed
     if rc_file.exists():
@@ -73,7 +75,8 @@ def setup_completion(ctx, shell):
 
     with open(rc_file, "a") as f:
         f.write("\n# sparkrun tab-completion\n")
-        f.write(snippet + "\n")
+        if shell in ("bash", "zsh", "fish"):
+            f.write(snippet + "\n")
 
     click.echo("Completion installed for %s in %s" % (shell, rc_file))
     click.echo("Restart your shell or run: source %s" % rc_file)
@@ -437,7 +440,8 @@ else
 fi
 
 # PubkeyAcceptedAlgorithms in main sshd_config
-printf 'sshd_accepted_algs=%s\n' "$(grep -i '^PubkeyAcceptedAlgorithms\|^PubkeyAcceptedKeyTypes' /etc/ssh/sshd_config 2>/dev/null || echo default)"
+printf 'sshd_accepted_algs=%s\n' \
+    "$(grep -i '^PubkeyAcceptedAlgorithms\|^PubkeyAcceptedKeyTypes' /etc/ssh/sshd_config 2>/dev/null || echo default)"
 
 # Key types present in authorized_keys
 printf 'ak_key_types=%s\n' "$(awk '{print $1}' ~/.ssh/authorized_keys 2>/dev/null | sort -u | tr '\n' ',' || echo none)"
@@ -1037,6 +1041,7 @@ def setup_cx7(ctx, hosts, hosts_file, cluster_name, user, dry_run, force, mtu, s
     click.echo()
 
     # Step 4: Plan
+    assert topology_result is not None
     if effective_topology == CX7Topology.RING:
         plan = plan_ring_cx7(detections, topology_result, all_subnets, mtu=mtu, force=force)
     else:
@@ -1268,7 +1273,11 @@ def setup_docker_group(ctx, hosts, hosts_file, cluster_name, user, dry_run):
     if ok_count and not dry_run:
         _record_setup_phase(cluster_name, user, host_list, "docker_group")
 
-    if ok_count and any("added" in (result_map.get(h).stdout if result_map.get(h) else "") for h in host_list):
+    def _has_added(h: str) -> bool:
+        res = result_map.get(h)
+        return bool(res and res.stdout and "added" in res.stdout)
+
+    if ok_count and any(_has_added(h) for h in host_list):
         click.echo()
         click.echo("Note: Users newly added to the docker group must re-login")
         click.echo("(or run 'newgrp docker') for the change to take effect.")
@@ -1843,8 +1852,8 @@ def setup_fe_system_update(ctx, hosts, hosts_file, cluster_name, user, dry_run):
         cluster_hosts = []
         if default_cluster:
             try:
-                cdata = mgr.get_cluster(default_cluster)
-                cluster_hosts = cdata.get("hosts", [])
+                cdata = mgr.get(default_cluster)
+                cluster_hosts = cdata.hosts
             except Exception:
                 pass
 
@@ -1926,7 +1935,7 @@ def setup_fe_system_update(ctx, hosts, hosts_file, cluster_name, user, dry_run):
             r = run_sudo_script_on_host(
                 h,
                 cmd,
-                password=sudo_password,
+                password=sudo_password or "",
                 ssh_kwargs=sudo_ssh_kwargs,
                 timeout=600,
                 dry_run=dry_run,
@@ -1958,7 +1967,7 @@ def setup_fe_system_update(ctx, hosts, hosts_file, cluster_name, user, dry_run):
                     run_sudo_script_on_host(
                         h,
                         "nohup bash -c 'sleep 2 && reboot' &>/dev/null &",
-                        password=sudo_password,
+                        password=sudo_password or "",
                         ssh_kwargs=sudo_ssh_kwargs,
                         timeout=10,
                         dry_run=dry_run,

--- a/src/sparkrun/cli/_setup/_commands.py
+++ b/src/sparkrun/cli/_setup/_commands.py
@@ -1891,10 +1891,9 @@ def setup_fe_system_update(ctx, hosts, hosts_file, cluster_name, user, dry_run):
     click.echo("  - Reboot")
     click.echo()
 
-    if not dry_run:
-        if not click.confirm("Proceed?", default=False):
-            click.echo("Aborted.")
-            return
+    if not dry_run and not click.confirm("Proceed?", default=False):
+        click.echo("Aborted.")
+        return
 
     # --- Step 3: Get sudo access ---
     sudo_password, indirect_user = ensure_sudo_password(

--- a/src/sparkrun/cli/_setup/_phases.py
+++ b/src/sparkrun/cli/_setup/_phases.py
@@ -190,7 +190,10 @@ def apply_sudoers(host_list, user, dry_run, sudo_password=None, sudo_dispatch_fn
     for label, script in sudoers_scripts:
         label_ok = 0
         for h in host_list:
-            r = sudo_dispatch_fn(h, script, sudo_password or "", timeout=300)
+            if sudo_dispatch_fn:
+                r = sudo_dispatch_fn(h, script, sudo_password or "", timeout=300)
+            else:
+                r = _sudo_script_on_host(h, script, sudo_password or "", ssh_kwargs={}, timeout=300, dry_run=dry_run)
             if r.success:
                 label_ok += 1
             else:

--- a/src/sparkrun/cli/_setup/_uninstall.py
+++ b/src/sparkrun/cli/_setup/_uninstall.py
@@ -116,7 +116,7 @@ def _teardown_docker_group(host_list, user, ssh_kwargs, sudo_fn, dry_run):
     validate_unix_username(user)
 
     script = (
-        '#!/bin/bash\nset -euo pipefail\ngpasswd -d "%s" docker 2>/dev/null && echo "REMOVED: %s from docker group" || echo "SKIPPED: %s not in docker group"\n'
+        '#!/bin/bash\nset -euo pipefail\ngpasswd -d "%s" docker 2>/dev/null && echo "REMOVED: %s from docker group" || echo "SKIPPED: %s not in docker group"\n'  # noqa: E501
         % (user, user, user)
     )
 

--- a/src/sparkrun/cli/_setup/_wizard.py
+++ b/src/sparkrun/cli/_setup/_wizard.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @click.option("--dry-run", "-n", is_flag=True, help="Preview without executing")
 @click.option("--yes", "-y", is_flag=True, help="Accept all defaults (non-interactive)")
 @click.pass_context
-def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
+def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):  # pyright: ignore[reportGeneralTypeIssues]
     """Guided setup wizard for sparkrun.
 
     Walks through cluster creation, SSH mesh, CX7 configuration,

--- a/src/sparkrun/cli/_setup/_wizard.py
+++ b/src/sparkrun/cli/_setup/_wizard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 import click
+import contextlib
 
 logger = logging.getLogger(__name__)
 
@@ -265,13 +266,7 @@ def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
                 # Suggest local management IP as default
                 if not hosts:
                     default_hosts = local_cx7.mgmt_ip or "127.0.0.1"
-                    if yes:
-                        hosts = default_hosts
-                    else:
-                        hosts = click.prompt(
-                            "Enter host IPs/hostnames (comma-separated)",
-                            default=default_hosts,
-                        )
+                    hosts = default_hosts if yes else click.prompt("Enter host IPs/hostnames (comma-separated)", default=default_hosts)
             else:
                 # Step 1c: No CX7 on control machine
                 click.echo("  No CX7 interfaces detected on this machine.")
@@ -311,10 +306,7 @@ def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
 
             # Step 1d: Create cluster
             if not cluster_name:
-                if yes:
-                    cluster_name = "default"
-                else:
-                    cluster_name = click.prompt("Cluster name", default="default")
+                cluster_name = "default" if yes else click.prompt("Cluster name", default="default")
 
             # Prompt for SSH username (--user flag takes precedence)
             if not yes and user == default_user:
@@ -684,10 +676,8 @@ def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
 
                     # Save topology to cluster definition
                     if cluster_name and effective_topology != CX7Topology.UNKNOWN:
-                        try:
+                        with contextlib.suppress(Exception):
                             cluster_mgr.update(cluster_name, topology=effective_topology.value)
-                        except Exception:
-                            pass
 
                 except Exception as e:
                     results["cx7"] = "failed"
@@ -780,11 +770,10 @@ def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
                                 sudo_ssh_kwargs,
                                 dry_run=dry_run,
                             )
-                            if dg_still_failed:
-                                if pw:
-                                    for h in dg_still_failed:
-                                        r = _run_sudo_on_host(h, dg_fallback, pw, timeout=30)
-                                        dg_result_map[h] = r
+                            if dg_still_failed and pw:
+                                for h in dg_still_failed:
+                                    r = _run_sudo_on_host(h, dg_fallback, pw, timeout=30)
+                                    dg_result_map[h] = r
 
                         dg_ok = sum(1 for h in host_list if dg_result_map.get(h) and dg_result_map[h].success)
                         results["docker"] = "OK (%d/%d)" % (dg_ok, len(host_list)) if dg_ok else "failed"

--- a/src/sparkrun/cli/_stop_logs.py
+++ b/src/sparkrun/cli/_stop_logs.py
@@ -97,7 +97,7 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run):
     # Build per-host container name mapping
     host_containers: dict[str, list[str]] = {}
     for cid, group in result.groups.items():
-        for host, role, status, image in group.members:
+        for host, role, _status, _image in group.members:
             container_name = "%s_%s" % (cid, role)
             host_containers.setdefault(host, []).append(container_name)
     for entry in result.solo_entries:

--- a/src/sparkrun/cli/_stop_logs.py
+++ b/src/sparkrun/cli/_stop_logs.py
@@ -119,6 +119,12 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run):
             solo_cid = entry.name.removesuffix("_solo") if entry.name.endswith("_solo") else entry.name
             remove_job_metadata(solo_cid, cache_dir=str(config.cache_dir))
 
+    # Tear down daemonized telemetry tunnels for all stopped hosts.
+    if not dry_run:
+        from sparkrun.orchestration.ssh import TelemetryTunnel
+        for host in host_containers:
+            TelemetryTunnel.cleanup(host)
+
     hosts_touched = len(host_containers)
     click.echo("Stopped %d job(s) across %d host(s)." % (stopped_count, hosts_touched))
 
@@ -160,6 +166,9 @@ def _stop_by_cluster_id(target, hosts, hosts_file, cluster_name, config, dry_run
 
     if not dry_run:
         remove_job_metadata(cluster_id, cache_dir=str(config.cache_dir))
+        from sparkrun.orchestration.ssh import TelemetryTunnel
+        for host in host_list:
+            TelemetryTunnel.cleanup(host)
 
     click.echo("Workload stopped on %d host(s)." % len(host_list))
 
@@ -209,6 +218,11 @@ def _stop_recipe(recipe_name, hosts, hosts_file, cluster_name, config, tp_overri
         cleanup_containers_local(container_names, dry_run=dry_run)
     else:
         cleanup_containers(host_list, container_names, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
+
+    if not dry_run:
+        from sparkrun.orchestration.ssh import TelemetryTunnel
+        for host in host_list:
+            TelemetryTunnel.cleanup(host)
 
     click.echo("Workload stopped on %d host(s)." % len(host_list))
 

--- a/src/sparkrun/cli/_stop_logs.py
+++ b/src/sparkrun/cli/_stop_logs.py
@@ -97,7 +97,7 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run):
     # Build per-host container name mapping
     host_containers: dict[str, list[str]] = {}
     for cid, group in result.groups.items():
-        for host, role, status, image in group.members:
+        for host, role, _status, _image in group.members:
             container_name = "%s_%s" % (cid, role)
             host_containers.setdefault(host, []).append(container_name)
     for entry in result.solo_entries:
@@ -136,6 +136,7 @@ def _stop_by_cluster_id(target, hosts, hosts_file, cluster_name, config, dry_run
     from sparkrun.orchestration.primitives import build_ssh_kwargs, cleanup_containers, cleanup_containers_local, should_run_locally
 
     cluster_id = _is_cluster_id(target)
+    assert cluster_id is not None
     meta = load_job_metadata(cluster_id, cache_dir=str(config.cache_dir))
 
     # Resolve hosts: CLI flags > metadata > default cluster
@@ -168,6 +169,7 @@ def _stop_recipe(recipe_name, hosts, hosts_file, cluster_name, config, tp_overri
     from sparkrun.core.bootstrap import init_sparkrun, get_runtime
 
     recipe, _recipe_path, _registry_mgr = _load_recipe(config, recipe_name)
+    assert recipe is not None
 
     host_list, _cluster_mgr = _resolve_hosts_or_exit(hosts, hosts_file, cluster_name, config)
 
@@ -243,6 +245,7 @@ def logs_cmd(ctx, target, hosts, hosts_file, cluster_name, tp_override, port, se
     # Branch: cluster ID target
     if _is_cluster_id(target) is not None:
         cluster_id = _is_cluster_id(target)
+        assert cluster_id is not None
         from sparkrun.orchestration.job_metadata import load_job_metadata
 
         meta = load_job_metadata(cluster_id, cache_dir=str(config.cache_dir))
@@ -292,6 +295,7 @@ def logs_cmd(ctx, target, hosts, hosts_file, cluster_name, tp_override, port, se
 
     # Load recipe
     recipe, _recipe_path, _registry_mgr = _load_recipe(config, recipe_name)
+    assert recipe is not None
 
     # Resolve hosts
     host_list, _cluster_mgr = _resolve_hosts_or_exit(hosts, hosts_file, cluster_name, config, sctx=sctx)

--- a/src/sparkrun/containers/distribute.py
+++ b/src/sparkrun/containers/distribute.py
@@ -297,7 +297,7 @@ def distribute_image_from_head(
             # Filter workers list and corresponding transfer hosts
             workers = hosts[1:]
             wt = worker_transfer_hosts or workers
-            filtered = [(w, t) for w, t in zip(workers, wt) if w in needs_transfer]
+            filtered = [(w, t) for w, t in zip(workers, wt, strict=False) if w in needs_transfer]
             if filtered:
                 hosts = [head] + [w for w, _ in filtered]
                 worker_transfer_hosts = [t for _, t in filtered]

--- a/src/sparkrun/core/bootstrap.py
+++ b/src/sparkrun/core/bootstrap.py
@@ -97,6 +97,7 @@ def get_variables() -> Variables:
     global _variables
     if _variables is None:
         init_sparkrun()
+    assert _variables is not None
     return _variables
 
 

--- a/src/sparkrun/core/cluster_manager.py
+++ b/src/sparkrun/core/cluster_manager.py
@@ -96,7 +96,7 @@ class ClusterStatusResult:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the result to a JSON-serializable dictionary."""
-        out = {
+        out: dict[str, Any] = {
             "groups": {},
             "solo_entries": [],
             "idle_hosts": self.idle_hosts,
@@ -233,11 +233,11 @@ class ClusterManager:
         name: str,
         hosts: list[str] | None = None,
         description: str | None = None,
-        user: str | None = _UNSET,
-        cache_dir: str | None = _UNSET,
-        transfer_mode: str | None = _UNSET,
-        transfer_interface: str | None = _UNSET,
-        topology: str | None = _UNSET,
+        user: str | None | Any = _UNSET,
+        cache_dir: str | None | Any = _UNSET,
+        transfer_mode: str | None | Any = _UNSET,
+        transfer_interface: str | None | Any = _UNSET,
+        topology: str | None | Any = _UNSET,
     ) -> None:
         """Update existing cluster definition.
 

--- a/src/sparkrun/core/config.py
+++ b/src/sparkrun/core/config.py
@@ -54,7 +54,7 @@ def get_config_root(v: Variables | None = None) -> Path:
         from scitrera_app_framework.core import is_stateful_ready
 
         stateful_root = is_stateful_ready(v)
-        if stateful_root:
+        if stateful_root and isinstance(stateful_root, (str, Path)):
             return Path(stateful_root)
     return DEFAULT_CONFIG_DIR
 
@@ -69,7 +69,8 @@ class SparkrunConfig:
 
     def _load(self):
         if self.config_path.exists():
-            self._data = read_yaml(str(self.config_path)) or {}
+            data = read_yaml(str(self.config_path))
+            self._data = data if isinstance(data, dict) else {}
         else:
             self._data = {}
 

--- a/src/sparkrun/core/hosts.py
+++ b/src/sparkrun/core/hosts.py
@@ -34,11 +34,10 @@ def _get_local_identifiers() -> set[str]:
     except OSError:
         pass
 
-    # Resolve hostname to IPs
     if hostname:
         try:
             for info in socket.getaddrinfo(hostname, None):
-                identifiers.add(info[4][0])
+                identifiers.add(str(info[4][0]))
         except (OSError, socket.gaierror):
             pass
 

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -143,6 +143,10 @@ def launch_inference(
             v = sctx.variables
         if progress is None:
             progress = sctx.progress
+    if config is None:
+        from sparkrun.core.config import SparkrunConfig
+
+        config = SparkrunConfig()
     p = progress  # short alias
 
     from sparkrun.orchestration.distribution import resolve_auto_transfer_mode
@@ -167,7 +171,7 @@ def launch_inference(
         from sparkrun.orchestration.primitives import find_available_port
 
         config_chain = recipe.build_config_chain(overrides)
-        desired_port = int(config_chain.get("port") or 8000)
+        desired_port = int(str(config_chain.get("port") or 8000))
         head_host = host_list[0]
         serve_port = find_available_port(
             head_host,
@@ -178,7 +182,7 @@ def launch_inference(
         overrides["port"] = serve_port
     else:
         config_chain = recipe.build_config_chain(overrides)
-        serve_port = int(config_chain.get("port") or 8000)
+        serve_port = int(str(config_chain.get("port") or 8000))
 
     # Derive deterministic cluster_id from recipe + (trimmed) hosts
     cluster_id = cluster_id_override or generate_cluster_id(recipe, host_list, overrides=overrides)
@@ -295,8 +299,11 @@ def launch_inference(
         from sparkrun.tuning.sync import sync_registry_tuning
 
         try:
+            rm = registry_mgr
+            if rm is None:
+                rm = config.get_registry_manager()
             synced = sync_registry_tuning(
-                registry_mgr,
+                rm,
                 recipe.runtime,
                 dry_run=dry_run,
                 registry_name=recipe.source_registry,
@@ -585,7 +592,7 @@ def post_launch_lifecycle(
 
     # Determine effective port
     config_chain = recipe.build_config_chain(overrides)
-    effective_port = config_chain.get("port", 8000)
+    effective_port = int(str(config_chain.get("port", 8000)))
 
     click.echo("Waiting for server to become ready...")
     if not dry_run:
@@ -600,7 +607,7 @@ def post_launch_lifecycle(
             container_name=head_container,
         )
         if not port_ready:
-            click.echo("Error: Server port %d never became ready" % effective_port, err=True)
+            click.echo("Error: Server port %s never became ready" % effective_port, err=True)
             sys.exit(1)
 
         # Wait for HTTP 200 on /v1/models

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+import contextlib
 
 if TYPE_CHECKING:
     from sparkrun.core.config import SparkrunConfig
@@ -452,10 +453,8 @@ def launch_inference(
             if recipe.builder:
                 from sparkrun.core.bootstrap import get_builder
 
-                try:
+                with contextlib.suppress(ValueError):
                     ver_builder = get_builder(recipe.builder, v)
-                except ValueError:
-                    pass
             # noinspection PyProtectedMember
             runtime_info = runtime._collect_runtime_info(
                 head_host,
@@ -569,10 +568,7 @@ def post_launch_lifecycle(
     _ssh_kw = build_ssh_kwargs(config)
 
     # Determine head container name
-    if is_solo:
-        head_container = generate_container_name(result.cluster_id, "solo")
-    else:
-        head_container = generate_node_container_name(result.cluster_id, 0)
+    head_container = generate_container_name(result.cluster_id, "solo") if is_solo else generate_node_container_name(result.cluster_id, 0)
 
     # Detect head IP for health checks
     if is_local_host(head_host):

--- a/src/sparkrun/core/monitoring.py
+++ b/src/sparkrun/core/monitoring.py
@@ -106,7 +106,7 @@ def parse_monitor_line(line: str) -> MonitorSample | None:
         return None
 
     kwargs = {}
-    for col_name, value in zip(MONITOR_COLUMNS, parts):
+    for col_name, value in zip(MONITOR_COLUMNS, parts, strict=False):
         kwargs[col_name] = value.strip()
 
     return MonitorSample(**kwargs)
@@ -299,7 +299,7 @@ class ClusterMonitor:
 
     def stop(self) -> None:
         """Terminate all SSH subprocesses."""
-        for host, state in self.states.items():
+        for _host, state in self.states.items():
             if state.process is not None:
                 try:
                     state.process.terminate()
@@ -513,7 +513,7 @@ class NvMonitorClusterMonitor:
 
     def stop(self) -> None:
         """Terminate all SSH processes."""
-        for host, state in self.states.items():
+        for _host, state in self.states.items():
             if state.process is not None:
                 try:
                     state.process.terminate()

--- a/src/sparkrun/core/monitoring.py
+++ b/src/sparkrun/core/monitoring.py
@@ -8,6 +8,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from typing import Callable
+import contextlib
 
 logger = logging.getLogger(__name__)
 
@@ -301,18 +302,14 @@ class ClusterMonitor:
         """Terminate all SSH subprocesses."""
         for host, state in self.states.items():
             if state.process is not None:
-                try:
+                with contextlib.suppress(OSError):
                     state.process.terminate()
-                except OSError:
-                    pass
                 try:
                     state.process.wait(timeout=3)
                 except subprocess.TimeoutExpired:
                     state.process.kill()
-                    try:
+                    with contextlib.suppress(subprocess.TimeoutExpired):
                         state.process.wait(timeout=2)
-                    except subprocess.TimeoutExpired:
-                        pass
         self._started = False
 
     def _reader(self, host: str, proc: subprocess.Popen) -> None:
@@ -333,10 +330,8 @@ class ClusterMonitor:
             rc = proc.poll()
             if rc is not None and rc != 0:
                 stderr_text = ""
-                try:
+                with contextlib.suppress(Exception):
                     stderr_text = proc.stderr.read().strip() if proc.stderr else ""
-                except Exception:
-                    pass
                 if self.states[host].latest is None:
                     self.states[host].error = stderr_text or "SSH connection failed (rc=%d)" % rc
 
@@ -370,18 +365,14 @@ class ClusterMonitor:
 
         # Terminate the old process so its reader thread exits.
         if state.process is not None:
-            try:
+            with contextlib.suppress(OSError):
                 state.process.terminate()
-            except OSError:
-                pass
             try:
                 state.process.wait(timeout=3)
             except subprocess.TimeoutExpired:
                 state.process.kill()
-                try:
+                with contextlib.suppress(subprocess.TimeoutExpired):
                     state.process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    pass
 
         state.error = "stale data — reconnecting"
         # Reset timestamp so the watchdog doesn't re-trigger immediately.
@@ -515,18 +506,14 @@ class NvMonitorClusterMonitor:
         """Terminate all SSH processes."""
         for host, state in self.states.items():
             if state.process is not None:
-                try:
+                with contextlib.suppress(OSError):
                     state.process.terminate()
-                except OSError:
-                    pass
                 try:
                     state.process.wait(timeout=3)
                 except subprocess.TimeoutExpired:
                     state.process.kill()
-                    try:
+                    with contextlib.suppress(subprocess.TimeoutExpired):
                         state.process.wait(timeout=2)
-                    except subprocess.TimeoutExpired:
-                        pass
         self._started = False
         self._restore_loggers(self._saved_log_levels)
 
@@ -565,10 +552,8 @@ class NvMonitorClusterMonitor:
             rc = proc.poll()
             if rc is not None and rc != 0:
                 stderr_text = ""
-                try:
+                with contextlib.suppress(Exception):
                     stderr_text = proc.stderr.read().strip() if proc.stderr else ""
-                except Exception:
-                    pass
                 if self.states[host].latest is None:
                     short = stderr_text.splitlines()[-1] if stderr_text else "rc=%d" % rc
                     self.states[host].error = short
@@ -595,18 +580,14 @@ class NvMonitorClusterMonitor:
         """Kill stale SSH process and start fresh."""
         state = self.states[host]
         if state.process is not None:
-            try:
+            with contextlib.suppress(OSError):
                 state.process.terminate()
-            except OSError:
-                pass
             try:
                 state.process.wait(timeout=3)
             except subprocess.TimeoutExpired:
                 state.process.kill()
-                try:
+                with contextlib.suppress(subprocess.TimeoutExpired):
                     state.process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    pass
 
         state.error = "stale data — reconnecting"
         state.last_updated = time.monotonic()

--- a/src/sparkrun/core/monitoring.py
+++ b/src/sparkrun/core/monitoring.py
@@ -106,7 +106,7 @@ def parse_monitor_line(line: str) -> MonitorSample | None:
         return None
 
     kwargs = {}
-    for col_name, value in zip(MONITOR_COLUMNS, parts):
+    for col_name, value in zip(MONITOR_COLUMNS, parts, strict=False):
         kwargs[col_name] = value.strip()
 
     return MonitorSample(**kwargs)
@@ -282,6 +282,7 @@ class ClusterMonitor:
                 stderr=subprocess.PIPE,
                 text=True,
             )
+            assert proc.stdin is not None
             proc.stdin.write(self._script)
             proc.stdin.close()
 
@@ -299,7 +300,7 @@ class ClusterMonitor:
 
     def stop(self) -> None:
         """Terminate all SSH subprocesses."""
-        for host, state in self.states.items():
+        for _host, state in self.states.items():
             if state.process is not None:
                 try:
                     state.process.terminate()
@@ -318,6 +319,7 @@ class ClusterMonitor:
     def _reader(self, host: str, proc: subprocess.Popen) -> None:
         """Read stdout from an SSH process line by line, updating state."""
         try:
+            assert proc.stdout is not None
             for raw_line in proc.stdout:
                 line = raw_line.strip()
                 if not line:
@@ -500,6 +502,7 @@ class NvMonitorClusterMonitor:
                 stderr=subprocess.PIPE,
                 text=True,
             )
+            assert proc.stdin is not None
             proc.stdin.write(self._script)
             proc.stdin.close()
 
@@ -513,7 +516,7 @@ class NvMonitorClusterMonitor:
 
     def stop(self) -> None:
         """Terminate all SSH processes."""
-        for host, state in self.states.items():
+        for _host, state in self.states.items():
             if state.process is not None:
                 try:
                     state.process.terminate()
@@ -535,6 +538,7 @@ class NvMonitorClusterMonitor:
         import json
 
         try:
+            assert proc.stdout is not None
             for raw_line in proc.stdout:
                 line = raw_line.strip()
                 if not line:

--- a/src/sparkrun/core/progress.py
+++ b/src/sparkrun/core/progress.py
@@ -27,8 +27,27 @@ Flag         Level  What's visible
 from __future__ import annotations
 
 import logging
+import socket
 import time
+import os
 from enum import IntEnum
+
+
+class StatsdClient:
+    def __init__(self) -> None:
+        host = os.environ.get("SPARKRUN_STATSD_HOST", "127.0.0.1")
+        port = int(os.environ.get("SPARKRUN_STATSD_PORT", "8125"))
+        self.addr = (host, port)
+
+    def send(self, msg: str) -> None:
+        try:
+            with socket.create_connection(self.addr, timeout=0.1) as sock:
+                sock.sendall(msg.encode("utf-8"))
+        except Exception:
+            pass
+
+
+statsd = StatsdClient()
 
 # ---------------------------------------------------------------------------
 # Custom log levels
@@ -97,6 +116,8 @@ class LaunchProgress:
 
         Emits ``[N/6] Label`` at PROGRESS level (always visible).
         """
+        statsd.send(f"vllm_sparkrun_deploy_progress:{((num - 1) / TOTAL_PHASES) * 100}|g")
+        statsd.send("vllm_sparkrun_deploy_status:1|g")
         if self._current_phase is not None:
             self._auto_close_phase()
         self._current_phase = num
@@ -111,6 +132,9 @@ class LaunchProgress:
         if self._phase_t0 is not None:
             dt = elapsed if elapsed is not None else (time.monotonic() - self._phase_t0)
             self._log.log(PROGRESS, "  done (%.1fs)", dt)
+        if self._current_phase == TOTAL_PHASES:
+            statsd.send("vllm_sparkrun_deploy_progress:100|g")
+            statsd.send("vllm_sparkrun_deploy_status:2|g")
         self._current_phase = None
         self._phase_t0 = None
 
@@ -138,6 +162,8 @@ class LaunchProgress:
         """
         self._step_current += 1
         if self._step_total > 0:
+            step_pct = ((self._step_current - 1) / self._step_total) * 100
+            statsd.send(f"vllm_sparkrun_deploy_step_progress:{step_pct}|g")
             self._log.log(
                 PROGRESS,
                 "  Step %d/%d: %s",

--- a/src/sparkrun/core/prometheus.py
+++ b/src/sparkrun/core/prometheus.py
@@ -49,10 +49,7 @@ def parse_prometheus_text(text: str) -> dict[str, float]:
         key = name + labels
 
         try:
-            if raw_value in ("NaN", "+Inf", "-Inf", "Inf"):
-                value = float(raw_value)
-            else:
-                value = float(raw_value)
+            value = float(raw_value) if raw_value in ("NaN", "+Inf", "-Inf", "Inf") else float(raw_value)
         except ValueError:
             logger.debug("Skipping unparseable metric value: %s", line)
             continue

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -329,15 +329,15 @@ def fetch_and_cache_recipe(url: str) -> Path:
         return cache_path
     except (HTTPError, URLError, OSError) as e:
         if cache_path.exists():
-            reason = e.code if isinstance(e, HTTPError) else e.reason
+            reason = e.code if isinstance(e, HTTPError) else (getattr(e, "reason", None) or str(e))
             logger.warning(
                 "Failed to fetch recipe (using cached copy): %s",
                 reason,
             )
             return cache_path
         if isinstance(e, HTTPError):
-            raise RecipeError("Failed to fetch recipe from %s: HTTP %d" % (url, e.code))
-        raise RecipeError("Failed to fetch recipe from %s: %s" % (url, e.reason if isinstance(e, URLError) else e))
+            raise RecipeError("Failed to fetch recipe from %s: HTTP %d" % (url, e.code)) from e
+        raise RecipeError("Failed to fetch recipe from %s: %s" % (url, e.reason if isinstance(e, URLError) else e)) from e
 
 
 # Backward-compat aliases (old underscore names)
@@ -544,6 +544,8 @@ class Recipe:
         while last != rendered:
             last = rendered
             rendered = arg_substitute(rendered, config_chain)
+
+        assert isinstance(rendered, str)
 
         # Fix trailing spaces after backslash line-continuations.
         # ``\<space><newline>`` → ``\<newline>``
@@ -784,13 +786,13 @@ class Recipe:
         # Get effective max_model_len and tensor_parallel from config chain
         max_model_len = config.get("max_model_len")
         if max_model_len is not None:
-            max_model_len = int(max_model_len)
+            max_model_len = int(str(max_model_len))
 
         tp_val = config.get("tensor_parallel")
-        tensor_parallel = int(tp_val) if tp_val is not None else 1
+        tensor_parallel = int(str(tp_val)) if tp_val is not None else 1
 
         pp_val = config.get("pipeline_parallel")
-        pipeline_parallel = int(pp_val) if pp_val is not None else 1
+        pipeline_parallel = int(str(pp_val)) if pp_val is not None else 1
 
         # Check for kv_cache_dtype in defaults (runtime-specific)
         if not kv_dtype:
@@ -800,7 +802,7 @@ class Recipe:
 
         # GPU memory utilization (runtime budget fraction)
         gpu_mem_val = config.get("gpu_memory_utilization")
-        gpu_memory_utilization = float(gpu_mem_val) if gpu_mem_val is not None else None
+        gpu_memory_utilization = float(str(gpu_mem_val)) if gpu_mem_val is not None else None
 
         result = _estimate_vram(
             model_params=model_params,
@@ -1019,15 +1021,15 @@ class Recipe:
             meta["maintainer"] = self.maintainer
 
         # transfer SELECTED model parameters to recipe
-        if meta and meta.get("model_dtype", None) is not None:
+        if meta and meta.get("model_dtype") is not None:
             meta["model_dtype"] = str(meta["model_dtype"])
-        if meta and meta.get("kv_dtype", None) is not None:
+        if meta and meta.get("kv_dtype") is not None:
             meta["kv_dtype"] = str(meta["kv_dtype"])
-        if meta and meta.get("model_params", None) is not None:
+        if meta and meta.get("model_params") is not None:
             meta["model_params"] = str(meta["model_params"])
-        if meta and meta.get("quantization", None) is not None:
+        if meta and meta.get("quantization") is not None:
             meta["quantization"] = str(meta["quantization"])
-        if meta and meta.get("quant_bits", None) is not None:
+        if meta and meta.get("quant_bits") is not None:
             meta["quant_bits"] = int(meta["quant_bits"])
 
         # -- Builder --

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -122,9 +122,8 @@ def _resolve_v1_migration(recipe: Recipe) -> None:
     """v1 format recipes -> eugr builder (runtime left for vllm variant resolution)."""
     if recipe.recipe_version != "1":
         return
-    if recipe.runtime in ("vllm", ""):
-        if not recipe.builder:
-            recipe.builder = "eugr"
+    if recipe.runtime in ("vllm", "") and not recipe.builder:
+        recipe.builder = "eugr"
 
 
 def _resolve_eugr_signals(recipe: Recipe) -> None:
@@ -132,9 +131,10 @@ def _resolve_eugr_signals(recipe: Recipe) -> None:
     if recipe.runtime not in ("vllm", ""):
         return
     rc = recipe.runtime_config
-    if rc.get("build_args") or rc.get("mods") or recipe.container.strip().startswith("ghcr.io/spark-arena/dgx-vllm-eugr-nightly"):
-        if not recipe.builder:
-            recipe.builder = "eugr"
+    if (
+        rc.get("build_args") or rc.get("mods") or recipe.container.strip().startswith("ghcr.io/spark-arena/dgx-vllm-eugr-nightly")
+    ) and not recipe.builder:
+        recipe.builder = "eugr"
 
 
 def _resolve_vllm_variant(recipe: Recipe) -> None:
@@ -718,10 +718,7 @@ class Recipe:
 
                     # Fill in missing fields (metadata takes precedence)
                     if not model_dtype:
-                        if quant_info:
-                            model_dtype = quant_info.weight_dtype
-                        else:
-                            model_dtype = _storage_dtype
+                        model_dtype = quant_info.weight_dtype if quant_info else _storage_dtype
                     if not num_layers:
                         num_layers = hf_info.get("num_layers")
                     if not num_kv_heads:
@@ -1019,15 +1016,15 @@ class Recipe:
             meta["maintainer"] = self.maintainer
 
         # transfer SELECTED model parameters to recipe
-        if meta and meta.get("model_dtype", None) is not None:
+        if meta and meta.get("model_dtype") is not None:
             meta["model_dtype"] = str(meta["model_dtype"])
-        if meta and meta.get("kv_dtype", None) is not None:
+        if meta and meta.get("kv_dtype") is not None:
             meta["kv_dtype"] = str(meta["kv_dtype"])
-        if meta and meta.get("model_params", None) is not None:
+        if meta and meta.get("model_params") is not None:
             meta["model_params"] = str(meta["model_params"])
-        if meta and meta.get("quantization", None) is not None:
+        if meta and meta.get("quantization") is not None:
             meta["quantization"] = str(meta["quantization"])
-        if meta and meta.get("quant_bits", None) is not None:
+        if meta and meta.get("quant_bits") is not None:
             meta["quant_bits"] = int(meta["quant_bits"])
 
         # -- Builder --

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -336,8 +336,8 @@ def fetch_and_cache_recipe(url: str) -> Path:
             )
             return cache_path
         if isinstance(e, HTTPError):
-            raise RecipeError("Failed to fetch recipe from %s: HTTP %d" % (url, e.code))
-        raise RecipeError("Failed to fetch recipe from %s: %s" % (url, e.reason if isinstance(e, URLError) else e))
+            raise RecipeError("Failed to fetch recipe from %s: HTTP %d" % (url, e.code)) from e
+        raise RecipeError("Failed to fetch recipe from %s: %s" % (url, e.reason if isinstance(e, URLError) else e)) from e
 
 
 # Backward-compat aliases (old underscore names)

--- a/src/sparkrun/core/registry.py
+++ b/src/sparkrun/core/registry.py
@@ -319,6 +319,8 @@ class RegistryManager:
             Exception: If the file cannot be read or parsed.
         """
         data = read_yaml(self._registries_path)
+        if not isinstance(data, dict):
+            return []
         registries = data.get("registries", [])
         return [
             RegistryEntry(

--- a/src/sparkrun/diagnostics/ndjson_writer.py
+++ b/src/sparkrun/diagnostics/ndjson_writer.py
@@ -11,6 +11,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
+import contextlib
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +49,8 @@ class NDJSONWriter:
 
     def close(self) -> None:
         if self._fh is not None:
-            try:
+            with contextlib.suppress(Exception):
                 self._fh.close()
-            except Exception:
-                pass
             self._fh = None
 
     def emit(self, record_type: str, data: dict | None = None) -> dict:

--- a/src/sparkrun/diagnostics/run_collector.py
+++ b/src/sparkrun/diagnostics/run_collector.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import time
 import traceback
+import contextlib
 
 from sparkrun.diagnostics.ndjson_writer import NDJSONWriter
 from sparkrun.diagnostics.spark_collector import collect_spark_diagnostics
@@ -29,7 +30,7 @@ class _DiagnosticsLogHandler(logging.Handler):
         self._writer = writer
 
     def emit(self, record: logging.LogRecord) -> None:
-        try:
+        with contextlib.suppress(Exception):
             self._writer.emit(
                 "log",
                 {
@@ -39,8 +40,6 @@ class _DiagnosticsLogHandler(logging.Handler):
                     "timestamp": record.created,
                 },
             )
-        except Exception:
-            pass  # never let diagnostics logging break the run
 
 
 class RunDiagnosticsCollector:

--- a/src/sparkrun/diagnostics/run_collector.py
+++ b/src/sparkrun/diagnostics/run_collector.py
@@ -223,8 +223,8 @@ class RunDiagnosticsCollector:
         """Emit ``run_error`` with phase context and optional traceback."""
         self._success = False
         if tb is None and isinstance(error, Exception):
-            tb = traceback.format_exception(type(error), error, error.__traceback__)
-            tb = "".join(tb)
+            tb_list = traceback.format_exception(type(error), error, error.__traceback__)
+            tb = "".join(tb_list)
         self._writer.emit(
             "run_error",
             {

--- a/src/sparkrun/models/download.py
+++ b/src/sparkrun/models/download.py
@@ -118,19 +118,15 @@ def resolve_gguf_path(
         return None
 
     # Search recursively for .gguf files matching the quant variant
-    if quant:
-        pattern = "**/*%s*.gguf" % quant
-    else:
-        pattern = "**/*.gguf"
+    pattern = "**/*%s*.gguf" % quant if quant else "**/*.gguf"
 
     matched = sorted(model_cache.glob(pattern))
-    if not matched:
+    if not matched and quant:
         # Retry case-insensitive: glob is case-sensitive on Linux,
         # so fall back to a manual filter when the quant case differs.
-        if quant:
-            all_gguf = sorted(model_cache.glob("**/*.gguf"))
-            q_lower = quant.lower()
-            matched = [f for f in all_gguf if q_lower in f.name.lower()]
+        all_gguf = sorted(model_cache.glob("**/*.gguf"))
+        q_lower = quant.lower()
+        matched = [f for f in all_gguf if q_lower in f.name.lower()]
 
     if not matched:
         return None

--- a/src/sparkrun/models/download.py
+++ b/src/sparkrun/models/download.py
@@ -325,7 +325,7 @@ def _snapshot_download(
     """
     try:
         from huggingface_hub import snapshot_download
-        from huggingface_hub.utils import enable_progress_bars
+        from huggingface_hub.utils.tqdm import enable_progress_bars
 
         enable_progress_bars()
 

--- a/src/sparkrun/models/gguf.py
+++ b/src/sparkrun/models/gguf.py
@@ -194,7 +194,7 @@ def dominant_quantization(counts: Counter[str]) -> str | None:
     quant_counts = {k: v for k, v in counts.items() if k not in _NON_QUANT_TYPES}
     if not quant_counts:
         return None
-    return max(quant_counts, key=quant_counts.get)
+    return max(quant_counts, key=lambda k: quant_counts[k])
 
 
 def fetch_remote_gguf_quant(
@@ -228,7 +228,7 @@ def fetch_remote_gguf_quant(
     """
     try:
         from huggingface_hub import hf_hub_url
-        from huggingface_hub.utils import build_hf_headers
+        from huggingface_hub.utils._headers import build_hf_headers
         from urllib.request import Request, urlopen
     except ImportError:
         logger.debug("huggingface_hub not available for GGUF header fetch")

--- a/src/sparkrun/models/quantization.py
+++ b/src/sparkrun/models/quantization.py
@@ -89,10 +89,7 @@ def _resolve_from_hf_quant_config(data: dict[str, Any]) -> QuantizationInfo | No
         return None
 
     kv_cache_algo = quant_block.get("kv_cache_quant_algo")
-    if isinstance(kv_cache_algo, str):
-        kv_cache_algo = kv_cache_algo.lower().strip() or None
-    else:
-        kv_cache_algo = None
+    kv_cache_algo = kv_cache_algo.lower().strip() or None if isinstance(kv_cache_algo, str) else None
 
     group_size = quant_block.get("group_size")
 
@@ -214,10 +211,7 @@ def _resolve_from_quantization_config(qc: dict[str, Any]) -> QuantizationInfo | 
     if method in ("auto-round", "autoround", "auto_round"):
         b = 4 if bits is None else int(bits)
         data_type = str(qc.get("data_type", "int")).lower()
-        if data_type == "int":
-            wd = "int%d" % b
-        else:
-            wd = "fp%d" % b
+        wd = "int%d" % b if data_type == "int" else "fp%d" % b
         return QuantizationInfo(
             method="auto-round",
             bits=b,

--- a/src/sparkrun/models/quantization.py
+++ b/src/sparkrun/models/quantization.py
@@ -41,7 +41,7 @@ def fetch_hf_quant_config(
     """
     try:
         from huggingface_hub import hf_hub_download
-        from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
+        from huggingface_hub.utils.tqdm import disable_progress_bars, enable_progress_bars
         import json
 
         from sparkrun.models.download import _hub_cache
@@ -142,7 +142,7 @@ def _resolve_mixed_precision(quant_block: dict[str, Any]) -> tuple[str, int | No
     if not algo_counts:
         return "", None
 
-    dominant = max(algo_counts, key=algo_counts.get)
+    dominant = max(algo_counts, key=lambda k: algo_counts[k])
     # Pick the most common group_size for the dominant algo
     gs_list = group_sizes.get(dominant)
     dominant_gs: int | None = None

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -308,10 +308,9 @@ def fetch_safetensors_size(
                     file_total = 0
                     matched = 0
                     for entry in list_repo_tree(**tree_kwargs):
-                        if hasattr(entry, "rfilename") and entry.rfilename in model_files:
-                            if entry.size and entry.size > 0:
-                                file_total += entry.size
-                                matched += 1
+                        if hasattr(entry, "rfilename") and entry.rfilename in model_files and entry.size and entry.size > 0:
+                            file_total += entry.size
+                            matched += 1
                     if matched > 0 and file_total > 0:
                         logger.debug(
                             "Got %d bytes from file sizes (%d/%d files) for %s",

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -192,7 +192,7 @@ def fetch_model_config(
     """
     try:
         from huggingface_hub import hf_hub_download
-        from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
+        from huggingface_hub.utils.tqdm import disable_progress_bars, enable_progress_bars
         import json
 
         from sparkrun.models.download import _hub_cache
@@ -235,7 +235,7 @@ def fetch_safetensors_size(
     """
     try:
         from huggingface_hub import hf_hub_download
-        from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
+        from huggingface_hub.utils.tqdm import disable_progress_bars, enable_progress_bars
         import json
 
         from sparkrun.models.download import _hub_cache
@@ -300,7 +300,7 @@ def fetch_safetensors_size(
             model_files = set(index.get("weight_map", {}).values())
             if model_files:
                 try:
-                    from huggingface_hub import list_repo_tree
+                    from huggingface_hub import list_repo_tree, RepoFile
 
                     tree_kwargs: dict[str, Any] = {"repo_id": model_id}
                     if revision:
@@ -308,9 +308,10 @@ def fetch_safetensors_size(
                     file_total = 0
                     matched = 0
                     for entry in list_repo_tree(**tree_kwargs):
-                        if hasattr(entry, "rfilename") and entry.rfilename in model_files:
-                            if entry.size and entry.size > 0:
-                                file_total += entry.size
+                        if isinstance(entry, RepoFile) and entry.rfilename in model_files:
+                            size = getattr(entry, "size", 0)
+                            if size and size > 0:
+                                file_total += size
                                 matched += 1
                     if matched > 0 and file_total > 0:
                         logger.debug(

--- a/src/sparkrun/orchestration/health.py
+++ b/src/sparkrun/orchestration/health.py
@@ -72,14 +72,13 @@ def wait_for_port(
     check_cmd = "nc -z localhost %d" % port
     for attempt in range(1, max_retries + 1):
         # Check container liveness before polling the port
-        if container_name and attempt > 1:
-            if not is_container_running(host, container_name, ssh_kwargs=ssh_kwargs):
-                logger.error(
-                    "  Container %s is no longer running on %s — aborting wait",
-                    container_name,
-                    host,
-                )
-                return False
+        if container_name and attempt > 1 and not is_container_running(host, container_name, ssh_kwargs=ssh_kwargs):
+            logger.error(
+                "  Container %s is no longer running on %s — aborting wait",
+                container_name,
+                host,
+            )
+            return False
 
         result = run_command_on_host(host, check_cmd, ssh_kwargs=ssh_kwargs, timeout=5, quiet=True)
         if result.success:

--- a/src/sparkrun/orchestration/hooks.py
+++ b/src/sparkrun/orchestration/hooks.py
@@ -48,7 +48,7 @@ def build_hook_context(
 
     # Pull all values from the config chain into a flat dict
     if hasattr(config_chain, "keys"):
-        for key in config_chain.keys():
+        for key in config_chain:
             val = config_chain.get(key)
             if val is not None:
                 ctx[key] = str(val)
@@ -156,7 +156,7 @@ def run_pre_exec(
     # Build context from config chain for rendering
     ctx: dict[str, str] = {}
     if hasattr(config_chain, "keys"):
-        for key in config_chain.keys():
+        for key in config_chain:
             val = config_chain.get(key)
             if val is not None:
                 ctx[key] = str(val)

--- a/src/sparkrun/orchestration/hooks.py
+++ b/src/sparkrun/orchestration/hooks.py
@@ -48,7 +48,8 @@ def build_hook_context(
 
     # Pull all values from the config chain into a flat dict
     if hasattr(config_chain, "keys"):
-        for key in config_chain.keys():
+        keys_iter = config_chain.keys() if callable(config_chain.keys) else config_chain.keys
+        for key in keys_iter:
             val = config_chain.get(key)
             if val is not None:
                 ctx[key] = str(val)
@@ -156,7 +157,8 @@ def run_pre_exec(
     # Build context from config chain for rendering
     ctx: dict[str, str] = {}
     if hasattr(config_chain, "keys"):
-        for key in config_chain.keys():
+        keys_iter = config_chain.keys() if callable(config_chain.keys) else config_chain.keys
+        for key in keys_iter:
             val = config_chain.get(key)
             if val is not None:
                 ctx[key] = str(val)

--- a/src/sparkrun/orchestration/hooks.py
+++ b/src/sparkrun/orchestration/hooks.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 
 from vpd.legacy.arguments import arg_substitute
@@ -94,11 +95,12 @@ def render_hook_command(cmd: str, context: dict[str, str]) -> str:
     while last != rendered:
         last = rendered
         rendered = arg_substitute(rendered, context)
+        assert isinstance(rendered, str)
     return rendered
 
 
 def render_hook_commands(
-    commands: list[str | dict[str, str]],
+    commands: Sequence[str | dict[str, str]],
     context: dict[str, str],
 ) -> list[str | dict[str, str]]:
     """Render ``{key}`` placeholders in a list of hook commands.
@@ -126,7 +128,7 @@ def render_hook_commands(
 
 def run_pre_exec(
     hosts_containers: list[tuple[str, str]],
-    commands: list[str | dict[str, str]],
+    commands: Sequence[str | dict[str, str]],
     config_chain,
     ssh_kwargs: dict | None = None,
     dry_run: bool = False,

--- a/src/sparkrun/orchestration/job_metadata.py
+++ b/src/sparkrun/orchestration/job_metadata.py
@@ -92,6 +92,8 @@ def check_job_running(
         else:
             return JobStatus(running=False, cluster_id=cluster_id, metadata=meta, hosts=[])
 
+    assert hosts is not None
+
     head_host = hosts[0]
     is_solo = len(hosts) == 1
 

--- a/src/sparkrun/orchestration/networking.py
+++ b/src/sparkrun/orchestration/networking.py
@@ -692,6 +692,7 @@ def detect_switch(
     if is_local_host(target_host):
         r = run_local_script(full_script, dry_run=dry_run)
     elif needs_sudo_pw:
+        assert sudo_password is not None
         r = run_remote_sudo_script(target_host, full_script, sudo_password, timeout=30, dry_run=dry_run, **kw)
     else:
         r = run_remote_script(target_host, full_script, timeout=30, dry_run=dry_run, **kw)
@@ -1483,6 +1484,7 @@ def configure_cx7_host(
         local_sudo_safe = sudo_password and (ssh_user is None or ssh_user == os_user)
 
         if local_sudo_safe:
+            assert sudo_password is not None
             # Pipe password to sudo -S bash -s for local hosts without NOPASSWD
             proc = subprocess.run(
                 ["sudo", "-S", "bash", "-s"],

--- a/src/sparkrun/orchestration/networking.py
+++ b/src/sparkrun/orchestration/networking.py
@@ -893,10 +893,7 @@ def select_subnets_for_topology(
     Returns:
         List of IPv4Network subnets.
     """
-    if topology == CX7Topology.RING:
-        count = 6
-    else:
-        count = 2
+    count = 6 if topology == CX7Topology.RING else 2
 
     # For 2-subnet case, delegate to existing function
     if count == 2:
@@ -1071,10 +1068,7 @@ def _is_existing_ring_valid(
         return False
 
     # Should have exactly 3 links for a ring
-    if len(all_link_subnets) != 3:
-        return False
-
-    return True
+    return len(all_link_subnets) == 3
 
 
 def _is_ring_host_valid(

--- a/src/sparkrun/orchestration/nv_monitor.py
+++ b/src/sparkrun/orchestration/nv_monitor.py
@@ -20,6 +20,7 @@ from sparkrun.orchestration.ssh import (
     run_remote_scripts_parallel,
     run_rsync_parallel,
 )
+import contextlib
 
 logger = logging.getLogger(__name__)
 
@@ -232,18 +233,14 @@ def stop_nv_monitor_ssh(proc: subprocess.Popen | None) -> None:
     """
     if proc is None:
         return
-    try:
+    with contextlib.suppress(OSError):
         proc.terminate()
-    except OSError:
-        pass
     try:
         proc.wait(timeout=5)
     except subprocess.TimeoutExpired:
         proc.kill()
-        try:
+        with contextlib.suppress(subprocess.TimeoutExpired):
             proc.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            pass
 
 
 def stop_nv_monitor_remote(

--- a/src/sparkrun/orchestration/primitives.py
+++ b/src/sparkrun/orchestration/primitives.py
@@ -136,7 +136,7 @@ def map_transfer_failures(
     Returns:
         List of management hostnames where transfer failed.
     """
-    xfer_to_host = dict(zip(transfer_hosts, management_hosts))
+    xfer_to_host = dict(zip(transfer_hosts, management_hosts, strict=False))
     failed = [xfer_to_host.get(r.host, r.host) for r in results if not r.success]
     return failed
 

--- a/src/sparkrun/orchestration/ssh.py
+++ b/src/sparkrun/orchestration/ssh.py
@@ -125,9 +125,6 @@ def build_ssh_cmd(
     """
     cmd = ["ssh", "-o", "BatchMode=yes", "-o", f"ConnectTimeout={connect_timeout}"]
 
-    # Telemetry tunnel (Worker -> Orchestrator/Head)
-    cmd.extend(["-R", "8125:127.0.0.1:8125"])
-
     if ssh_key:
         cmd.extend(["-i", ssh_key])
     if ssh_options:
@@ -689,9 +686,6 @@ def build_ssh_opts_string(
     """
     parts = ["-o", "BatchMode=yes", "-o", f"ConnectTimeout={connect_timeout}"]
 
-    # Telemetry tunnel (Worker -> Orchestrator/Head)
-    parts.extend(["-R", "8125:127.0.0.1:8125"])
-
     if ssh_key:
         parts.extend(["-i", ssh_key])
     if ssh_options:
@@ -1001,3 +995,67 @@ def run_rsync_parallel(
     ok = sum(1 for r in results if r.success)
     logger.info("  Parallel rsync done: %d/%d OK (%.1fs total)", ok, len(results), elapsed)
     return results
+
+class TelemetryTunnel:
+    """Context manager to establish a forward tunnel for remote Docker telemetry."""
+
+    def __init__(self, host, ssh_user: str | None = None, ssh_key: str | None = None, ssh_options: list[str] | None = None):
+        self.host = getattr(host, "name", str(host))
+        self.ssh_user = ssh_user
+        self.ssh_key = ssh_key
+        self.ssh_options = ssh_options
+        self.local_port: int | None = None
+        self.tunnel_proc: subprocess.Popen | None = None
+
+    def __enter__(self):
+        import socket
+        import urllib.request
+        import json
+
+        # 1. Find an open ephemeral port
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("0.0.0.0", 0))
+            self.local_port = s.getsockname()[1]
+
+        # 2. Start SSH forward tunnel: ssh -N -L local_port:/var/run/docker.sock host
+        cmd = build_ssh_cmd(self.host, self.ssh_user, self.ssh_key, self.ssh_options)
+        cmd.extend(["-N", "-L", f"0.0.0.0:{self.local_port}:/var/run/docker.sock"])
+        
+        logger.info("Establishing telemetry tunnel to %s via local port %d", self.host, self.local_port)
+        self.tunnel_proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        # Give the tunnel a moment to establish
+        time.sleep(1)
+
+        # 3. Register with Fleet Multiplexer API
+        try:
+            req = urllib.request.Request("http://127.0.0.1:8126/api/nodes", method="POST")
+            req.add_header("Content-Type", "application/json")
+            # The Fleet Multiplexer runs inside Docker, so it needs to access the host via host.docker.internal
+            data = json.dumps({"host_id": self.host, "docker_url": f"tcp://host.docker.internal:{self.local_port}"}).encode("utf-8")
+            urllib.request.urlopen(req, data=data, timeout=2.0)
+            logger.debug("Successfully registered %s with Fleet Multiplexer", self.host)
+        except Exception as e:
+            logger.warning("Failed to register %s with Fleet Multiplexer: %s", self.host, e)
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        import urllib.request
+
+        # 1. Deregister from Fleet Multiplexer
+        try:
+            req = urllib.request.Request(f"http://127.0.0.1:8126/api/nodes/{self.host}", method="DELETE")
+            urllib.request.urlopen(req, timeout=2.0)
+            logger.debug("Successfully deregistered %s from Fleet Multiplexer", self.host)
+        except Exception as e:
+            logger.debug("Failed to deregister %s from Fleet Multiplexer: %s", self.host, e)
+
+        # 2. Kill the SSH tunnel
+        if self.tunnel_proc:
+            logger.info("Tearing down telemetry tunnel to %s", self.host)
+            self.tunnel_proc.terminate()
+            try:
+                self.tunnel_proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.tunnel_proc.kill()

--- a/src/sparkrun/orchestration/ssh.py
+++ b/src/sparkrun/orchestration/ssh.py
@@ -124,6 +124,10 @@ def build_ssh_cmd(
         List of command parts suitable for subprocess.
     """
     cmd = ["ssh", "-o", "BatchMode=yes", "-o", f"ConnectTimeout={connect_timeout}"]
+
+    # Telemetry tunnel (Worker -> Orchestrator/Head)
+    cmd.extend(["-R", "8125:127.0.0.1:8125"])
+
     if ssh_key:
         cmd.extend(["-i", ssh_key])
     if ssh_options:
@@ -684,6 +688,10 @@ def build_ssh_opts_string(
         ``"-o BatchMode=yes -o ConnectTimeout=10 -i /path/key"``.
     """
     parts = ["-o", "BatchMode=yes", "-o", f"ConnectTimeout={connect_timeout}"]
+
+    # Telemetry tunnel (Worker -> Orchestrator/Head)
+    parts.extend(["-R", "8125:127.0.0.1:8125"])
+
     if ssh_key:
         parts.extend(["-i", ssh_key])
     if ssh_options:

--- a/src/sparkrun/orchestration/ssh.py
+++ b/src/sparkrun/orchestration/ssh.py
@@ -8,6 +8,9 @@ No files are ever copied to remote hosts.
 from __future__ import annotations
 
 import logging
+import os
+import signal
+import socket
 import subprocess
 import time
 from dataclasses import dataclass
@@ -999,65 +1002,153 @@ def run_rsync_parallel(
     return results
 
 class TelemetryTunnel:
-    """Context manager to establish a forward tunnel for remote Docker telemetry."""
+    """Manages daemonized SSH forward tunnels for remote Docker telemetry.
 
-    def __init__(self, host, ssh_user: str | None = None, ssh_key: str | None = None, ssh_options: list[str] | None = None):
+    Unlike a context manager, tunnels are daemonized (fire-and-forget) so they
+    survive the lifetime of ``sparkrun run``. A PID file written to
+    ``/tmp/sparkrun-telemetry-<host>.pid`` lets ``sparkrun stop`` locate and
+    terminate the tunnel later.
+
+    Usage::
+
+        TelemetryTunnel(host, ...).establish_detached()
+        # … container runs indefinitely …
+        TelemetryTunnel.cleanup(host)   # called by sparkrun stop
+    """
+
+    _PID_DIR = "/tmp"
+
+    def __init__(
+        self,
+        host,
+        ssh_user: str | None = None,
+        ssh_key: str | None = None,
+        ssh_options: list[str] | None = None,
+    ):
         self.host = getattr(host, "name", str(host))
         self.ssh_user = ssh_user
         self.ssh_key = ssh_key
         self.ssh_options = ssh_options
-        self.local_port: int | None = None
-        self.tunnel_proc: subprocess.Popen | None = None
 
-    def __enter__(self):
-        import socket
-        import urllib.request
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _pid_file(cls, host: str) -> str:
+        safe = host.replace("/", "_").replace(":", "_")
+        return f"{cls._PID_DIR}/sparkrun-telemetry-{safe}.pid"
+
+    @classmethod
+    def _port_file(cls, host: str) -> str:
+        safe = host.replace("/", "_").replace(":", "_")
+        return f"{cls._PID_DIR}/sparkrun-telemetry-{safe}.port"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def establish_detached(self) -> int | None:
+        """Establish a daemonized SSH forward tunnel and register with the Fleet Multiplexer.
+
+        Returns the local port that was allocated, or None on failure.
+        The SSH process is detached (its PID is written to a state file) so
+        it continues running after ``sparkrun run`` exits.
+        """
         import json
+        import urllib.request
 
-        # 1. Find an open ephemeral port
+        # 1. Find a free ephemeral port bound to all interfaces so the
+        #    containerised Fleet Multiplexer can reach it via host.docker.internal.
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind(("0.0.0.0", 0))
-            self.local_port = s.getsockname()[1]
+            local_port: int = s.getsockname()[1]
 
-        # 2. Start SSH forward tunnel: ssh -N -L local_port:/var/run/docker.sock host
+        # 2. Build and launch the SSH tunnel as a detached background process.
         cmd = build_ssh_cmd(self.host, self.ssh_user, self.ssh_key, self.ssh_options)
-        cmd.extend(["-N", "-L", f"0.0.0.0:{self.local_port}:/var/run/docker.sock"])
-        
-        logger.info("Establishing telemetry tunnel to %s via local port %d", self.host, self.local_port)
-        self.tunnel_proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        cmd.extend(["-N", "-L", f"0.0.0.0:{local_port}:/var/run/docker.sock"])
 
-        # Give the tunnel a moment to establish
-        time.sleep(1)
+        logger.info(
+            "Establishing telemetry tunnel to %s on local port %d (daemonized)",
+            self.host,
+            local_port,
+        )
+        tunnel_proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            # Detach from the current process group so the tunnel survives
+            # the parent process exiting.
+            start_new_session=True,
+        )
 
-        # 3. Register with Fleet Multiplexer API
+        # Persist state so sparkrun stop can find and kill the tunnel.
+        with open(self._pid_file(self.host), "w") as f:
+            f.write(str(tunnel_proc.pid))
+        with open(self._port_file(self.host), "w") as f:
+            f.write(str(local_port))
+
+        # Give the tunnel a moment to finish the SSH handshake.
+        time.sleep(1.5)
+
+        # 3. Register the new endpoint with the Fleet Multiplexer API.
+        #    The multiplexer is a Docker container, so it reaches the host-side
+        #    tunnel via host.docker.internal.
+        docker_url = f"tcp://host.docker.internal:{local_port}"
         try:
             req = urllib.request.Request("http://127.0.0.1:8126/api/nodes", method="POST")
             req.add_header("Content-Type", "application/json")
-            # The Fleet Multiplexer runs inside Docker, so it needs to access the host via host.docker.internal
-            data = json.dumps({"host_id": self.host, "docker_url": f"tcp://host.docker.internal:{self.local_port}"}).encode("utf-8")
-            urllib.request.urlopen(req, data=data, timeout=2.0)
-            logger.debug("Successfully registered %s with Fleet Multiplexer", self.host)
+            payload = json.dumps({"host_id": self.host, "docker_url": docker_url}).encode()
+            urllib.request.urlopen(req, data=payload, timeout=3.0)
+            logger.info(
+                "Registered %s with Fleet Multiplexer (docker_url=%s)", self.host, docker_url
+            )
         except Exception as e:
             logger.warning("Failed to register %s with Fleet Multiplexer: %s", self.host, e)
 
-        return self
+        return local_port
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    @classmethod
+    def cleanup(cls, host: str) -> None:
+        """Deregister a node from the Fleet Multiplexer and terminate its SSH tunnel.
+
+        Reads the PID from the state file written by :meth:`establish_detached`.
+        Safe to call even if the tunnel has already been killed.
+        """
         import urllib.request
 
-        # 1. Deregister from Fleet Multiplexer
-        try:
-            req = urllib.request.Request(f"http://127.0.0.1:8126/api/nodes/{self.host}", method="DELETE")
-            urllib.request.urlopen(req, timeout=2.0)
-            logger.debug("Successfully deregistered %s from Fleet Multiplexer", self.host)
-        except Exception as e:
-            logger.debug("Failed to deregister %s from Fleet Multiplexer: %s", self.host, e)
+        host_name = getattr(host, "name", str(host))
 
-        # 2. Kill the SSH tunnel
-        if self.tunnel_proc:
-            logger.info("Tearing down telemetry tunnel to %s", self.host)
-            self.tunnel_proc.terminate()
+        # 1. Deregister from Fleet Multiplexer (best-effort).
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:8126/api/nodes/{host_name}", method="DELETE"
+            )
+            urllib.request.urlopen(req, timeout=2.0)
+            logger.info("Deregistered %s from Fleet Multiplexer", host_name)
+        except Exception as e:
+            logger.debug("Deregister %s skipped: %s", host_name, e)
+
+        # 2. Kill the SSH tunnel process.
+        pid_file = cls._pid_file(host_name)
+        if os.path.exists(pid_file):
             try:
-                self.tunnel_proc.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                self.tunnel_proc.kill()
+                with open(pid_file) as f:
+                    pid = int(f.read().strip())
+                logger.info("Terminating telemetry tunnel for %s (PID %d)", host_name, pid)
+                os.kill(pid, signal.SIGTERM)
+                time.sleep(0.5)
+                try:
+                    os.kill(pid, 0)  # probe: still alive?
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            except (ValueError, ProcessLookupError, PermissionError) as e:
+                logger.debug("Could not kill tunnel PID for %s: %s", host_name, e)
+            finally:
+                os.remove(pid_file)
+
+        port_file = cls._port_file(host_name)
+        if os.path.exists(port_file):
+            os.remove(port_file)

--- a/src/sparkrun/orchestration/sudo.py
+++ b/src/sparkrun/orchestration/sudo.py
@@ -272,7 +272,7 @@ def run_with_sudo_fallback(
     dry_run: bool = False,
     sudo_password: str | None = None,
     timeout: int = 300,
-) -> tuple[dict[str, object], list[str]]:
+) -> tuple[dict[str, RemoteResult], list[str]]:
     """Run script with sudo fallback. Returns (result_map, still_failed_hosts).
 
     Local hosts (localhost, 127.0.0.1) are executed directly via
@@ -308,7 +308,7 @@ def run_with_sudo_fallback(
     local_hosts = [h for h in host_list if should_run_locally(h, ssh_user)]
     remote_hosts = [h for h in host_list if not should_run_locally(h, ssh_user)]
 
-    result_map: dict[str, object] = {}
+    result_map: dict[str, RemoteResult] = {}
     failed_hosts: list[str] = []
 
     # Step 1a: Run locally for local hosts (sudo -n, non-interactive)

--- a/src/sparkrun/proxy/engine.py
+++ b/src/sparkrun/proxy/engine.py
@@ -215,14 +215,14 @@ class ProxyEngine:
         else:
             # Redirect output to log file so startup errors are visible
             log_path = self.state_dir / "litellm.log"
-            log_file = open(log_path, "w")
-            proc = subprocess.Popen(
-                cmd,
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-                env=env,
-            )
+            with open(log_path, "w") as log_file:
+                proc = subprocess.Popen(
+                    cmd,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                    env=env,
+                )
 
             # Wait briefly and verify the process survived startup
             import time
@@ -230,7 +230,6 @@ class ProxyEngine:
             time.sleep(2)
             poll = proc.poll()
             if poll is not None:
-                log_file.close()
                 # Process already exited — show error
                 try:
                     tail = log_path.read_text()[-2000:]
@@ -291,15 +290,15 @@ class ProxyEngine:
             yaml.safe_dump(cfg, f, default_flow_style=False)
 
         log_path = self.state_dir / "autodiscover.log"
-        log_file = open(log_path, "w")
 
         try:
-            proc = subprocess.Popen(
-                [sys.executable, "-m", "sparkrun.proxy.autodiscover", str(self._autodiscover_config_path)],
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-            )
+            with open(log_path, "w") as log_file:
+                proc = subprocess.Popen(
+                    [sys.executable, "-m", "sparkrun.proxy.autodiscover", str(self._autodiscover_config_path)],
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
             logger.info(
                 "Auto-discover started (PID %d), interval=%ds, log=%s",
                 proc.pid,
@@ -308,7 +307,6 @@ class ProxyEngine:
             )
             return proc.pid
         except Exception:
-            log_file.close()
             logger.warning("Failed to start auto-discover process", exc_info=True)
             return None
 

--- a/src/sparkrun/runtimes/_cluster_ops.py
+++ b/src/sparkrun/runtimes/_cluster_ops.py
@@ -383,6 +383,10 @@ def run_native_cluster(
 
     executor = runtime.executor
 
+    assert recipe is not None
+    if overrides is None:
+        overrides = {}
+
     if progress:
         progress.begin_runtime_steps(7)
 

--- a/src/sparkrun/runtimes/_cluster_ops.py
+++ b/src/sparkrun/runtimes/_cluster_ops.py
@@ -58,6 +58,7 @@ class ClusterContext:
         config: SparkrunConfig | None,
         dry_run: bool,
         topology: str | None = None,
+        overrides: dict[str, Any] | None = None,
     ) -> ClusterContext:
         """Build context from runtime hooks and config.
 
@@ -65,7 +66,7 @@ class ClusterContext:
         runtime's ``_run_cluster`` method.
         """
         from sparkrun.orchestration.primitives import build_ssh_kwargs, build_volumes
-        from sparkrun.utils import merge_env
+        from sparkrun.utils import merge_env, extract_env_overrides
 
         num_nodes = len(hosts)
         ssh_kwargs = build_ssh_kwargs(config)
@@ -76,6 +77,7 @@ class ClusterContext:
             runtime_env,
             env,
             runtime.get_extra_env(),
+            extract_env_overrides(overrides),
         )
         return cls(
             hosts=hosts,

--- a/src/sparkrun/runtimes/_util.py
+++ b/src/sparkrun/runtimes/_util.py
@@ -1,4 +1,4 @@
-def default_env_hf_offline(env: dict[str, str] = None, **kwargs) -> dict[str, str]:
+def default_env_hf_offline(env: dict[str, str] | None = None, **kwargs) -> dict[str, str]:
     return {
         # DEFAULT: disable online HF/transformers checks -- we've already copied all data locally!
         "HF_HUB_OFFLINE": "1",

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -25,12 +25,12 @@ class VllmMixin:
         """Set VLLM_TUNED_CONFIG_FOLDER if tuning configs exist."""
         from sparkrun.tuning.vllm import get_vllm_tuning_env
 
-        env = super().get_extra_env()
+        env = super().get_extra_env()  # type: ignore
         env.update(get_vllm_tuning_env() or {})
         return env
 
     def version_commands(self) -> dict[str, str]:
-        cmds = super().version_commands()
+        cmds = super().version_commands()  # type: ignore
         cmds["vllm"] = "python3 -c 'import vllm; print(vllm.__version__)' 2>/dev/null || echo unknown"
         return cmds
 

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -53,6 +53,8 @@ VLLM_FLAG_MAP = {
     "distributed_executor_backend": "--distributed-executor-backend",
     "pipeline_parallel": "-pp",
     "kv_cache_dtype": "--kv-cache-dtype",
+    "otlp_traces_endpoint": "--otlp-traces-endpoint",
+    "collect_detailed_traces": "--collect-detailed-traces",
 }
 
 # Boolean flags (present = True, absent = False)

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -1185,11 +1185,14 @@ class RuntimePlugin(Plugin):
 
         inner_script = "\n".join(inner_lines)
 
-        # Pipe the inner script into `docker exec <container> bash -s`
-        # via a here-document.  This avoids quoting issues that arise
-        # when embedding complex shell commands in bash -c '...'.
-        # TODO: using 'docker exec' implies executor should be involved
-        outer_script = ("docker exec -i %s bash -s <<'SPARKRUN_VER_EOF'\n%s\nSPARKRUN_VER_EOF") % (container_name, inner_script)
+        # Pass the inner script via the executor's exec context.
+        # This replaces the hardcoded `docker exec` and correctly utilizes
+        # b64_wrap_bash internally (for DockerExecutor) to avoid quoting issues.
+        outer_script = self.executor.exec_cmd(
+            container_name=container_name,
+            command=inner_script,
+            detach=False,
+        )
 
         try:
             from sparkrun.orchestration.primitives import run_script_on_host

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -768,7 +768,7 @@ class RuntimePlugin(Plugin):
             run_script_on_host,
             should_run_locally,
         )
-        from sparkrun.utils import merge_env
+        from sparkrun.utils import merge_env, extract_env_overrides
 
         ssh_kwargs = build_ssh_kwargs(config)
         is_local = should_run_locally(host, ssh_kwargs.get("ssh_user"))
@@ -779,6 +779,7 @@ class RuntimePlugin(Plugin):
             self.get_solo_env(),  # solo-specific
             env,  # recipe
             self.get_extra_env(),  # tuning/other overrides
+            extract_env_overrides(overrides),  # CLI overrides (env.*)
         )
 
         combined_docker_opts = (self.get_extra_docker_opts() or []) + (extra_docker_opts or [])

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -1141,7 +1141,7 @@ class RuntimePlugin(Plugin):
         Subclasses should call super() and add runtime-specific entries.
         """
         return {
-            "cuda": "nvcc --version 2>/dev/null | grep 'release' | sed 's/.*release //' | sed 's/,.*//' || nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1 || echo unknown",
+            "cuda": "nvcc --version 2>/dev/null | grep 'release' | sed 's/.*release //' | sed 's/,.*//' || nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1 || echo unknown",  # noqa: E501
             "python": "python3 --version 2>/dev/null | awk '{print $2}' || echo unknown",
             "torch": "python3 -c 'import torch; print(torch.__version__)' 2>/dev/null || echo unknown",
             "nccl": "python3 -c 'import torch; print(torch.cuda.nccl.version())' 2>/dev/null || echo unknown",

--- a/src/sparkrun/runtimes/eugr_vllm_ray.py
+++ b/src/sparkrun/runtimes/eugr_vllm_ray.py
@@ -36,12 +36,12 @@ class EugrVllmRayRuntime(VllmRayRuntime):
     It exists for backward compatibility with v1 recipes.
     """
 
-    _v: Variables = None
+    _v: Variables | None = None
 
     runtime_name = "eugr-vllm"
     default_image_prefix = ""  # eugr uses local builds
 
-    def initialize(self, v: Variables, logger_arg: Logger) -> EugrVllmRayRuntime:
+    def initialize(self, v: Variables, logger: Logger) -> EugrVllmRayRuntime:
         """Initialize the eugr-vllm runtime plugin."""
         self._v = v
         return self

--- a/src/sparkrun/runtimes/llama_cpp.py
+++ b/src/sparkrun/runtimes/llama_cpp.py
@@ -106,7 +106,7 @@ class LlamaCppRuntime(RuntimePlugin):
         pp = config.get("pipeline_parallel")
 
         if tp is not None and pp is not None:
-            tp_val, pp_val = int(tp), int(pp)
+            tp_val, pp_val = int(str(tp)), int(str(pp))
             # Both > 1 is genuinely mutually exclusive
             if tp_val > 1 and pp_val > 1:
                 raise ValueError(
@@ -123,9 +123,9 @@ class LlamaCppRuntime(RuntimePlugin):
             return None
 
         if tp is not None:
-            return "row" if int(tp) > 1 else None
+            return "row" if int(str(tp)) > 1 else None
         if pp is not None:
-            return "layer" if int(pp) > 1 else None
+            return "layer" if int(str(pp)) > 1 else None
         return None
 
     def compute_required_nodes(self, recipe, overrides=None):
@@ -149,7 +149,7 @@ class LlamaCppRuntime(RuntimePlugin):
 
         if tp is not None and pp is not None:
             # Both set — use whichever is > 1; if both are 1, return 1
-            tp_val, pp_val = int(tp), int(pp)
+            tp_val, pp_val = int(str(tp)), int(str(pp))
             if tp_val > 1:
                 return tp_val
             if pp_val > 1:
@@ -157,9 +157,9 @@ class LlamaCppRuntime(RuntimePlugin):
             return 1
 
         if tp is not None:
-            return int(tp)
+            return int(str(tp))
         if pp is not None:
-            return int(pp)
+            return int(str(pp))
         return None
 
     @staticmethod
@@ -422,6 +422,8 @@ class LlamaCppRuntime(RuntimePlugin):
         logger.warning("llama.cpp RPC clustering is EXPERIMENTAL. Behavior may change in future versions.")
 
         progress = kwargs.pop("progress", None)
+
+        assert recipe is not None
 
         ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run)
         head_container = self._container_name(cluster_id, "head")

--- a/src/sparkrun/runtimes/llama_cpp.py
+++ b/src/sparkrun/runtimes/llama_cpp.py
@@ -423,7 +423,7 @@ class LlamaCppRuntime(RuntimePlugin):
 
         progress = kwargs.pop("progress", None)
 
-        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run)
+        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run, overrides=overrides)
         head_container = self._container_name(cluster_id, "head")
         worker_container_name = self._container_name(cluster_id, "worker")
 

--- a/src/sparkrun/runtimes/trtllm.py
+++ b/src/sparkrun/runtimes/trtllm.py
@@ -261,7 +261,7 @@ class TrtllmRuntime(RuntimePlugin):
         kv_cache: dict[str, Any] = {}
         frac = config.get("free_gpu_memory_fraction")
         if frac is not None:
-            kv_cache["free_gpu_memory_fraction"] = float(frac)
+            kv_cache["free_gpu_memory_fraction"] = float(str(frac))
         kv_dtype = config.get("kv_cache_dtype")
         if kv_dtype is not None:
             kv_cache["dtype"] = str(kv_dtype)
@@ -278,7 +278,7 @@ class TrtllmRuntime(RuntimePlugin):
             cuda_graph["enable_padding"] = bool(padding)
         cg_max_batch = config.get("cuda_graph_max_batch_size")
         if cg_max_batch is not None:
-            cuda_graph["max_batch_size"] = int(cg_max_batch)
+            cuda_graph["max_batch_size"] = int(str(cg_max_batch))
         if cuda_graph:
             extra["cuda_graph_config"] = cuda_graph
 

--- a/src/sparkrun/runtimes/trtllm.py
+++ b/src/sparkrun/runtimes/trtllm.py
@@ -447,7 +447,7 @@ class TrtllmRuntime(RuntimePlugin):
 
         progress = kwargs.pop("progress", None)
 
-        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run)
+        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run, overrides=overrides)
         extra_docker_opts = self.get_extra_docker_opts()
 
         self._print_cluster_banner(

--- a/src/sparkrun/runtimes/vllm_distributed.py
+++ b/src/sparkrun/runtimes/vllm_distributed.py
@@ -64,6 +64,14 @@ class VllmDistributedRuntime(VllmMixin, RuntimePlugin):
                 "--served-model-name",
                 skip_keys,
             )
+            # Augment OTel flags if present in config but missing from rendered command
+            for key in ["otlp_traces_endpoint", "collect_detailed_traces"]:
+                if key in skip_keys:
+                    continue
+                val = config.get(key)
+                if val is not None and VLLM_FLAG_MAP[key] not in rendered:
+                    rendered += f" {VLLM_FLAG_MAP[key]} {val}"
+
             if skip_keys:
                 rendered = self.strip_flags_from_command(
                     rendered,
@@ -103,6 +111,14 @@ class VllmDistributedRuntime(VllmMixin, RuntimePlugin):
                 "--served-model-name",
                 skip_keys,
             )
+            # Augment OTel flags if present in config but missing from rendered command
+            for key in ["otlp_traces_endpoint", "collect_detailed_traces"]:
+                if key in skip_keys:
+                    continue
+                val = config.get(key)
+                if val is not None and VLLM_FLAG_MAP[key] not in rendered:
+                    rendered += f" {VLLM_FLAG_MAP[key]} {val}"
+
             if skip_keys:
                 rendered = self.strip_flags_from_command(
                     rendered,

--- a/src/sparkrun/runtimes/vllm_ray.py
+++ b/src/sparkrun/runtimes/vllm_ray.py
@@ -246,7 +246,7 @@ class VllmRayRuntime(VllmMixin, RuntimePlugin):
         progress = kwargs.pop("progress", None)
         combined_docker_opts = (self.get_extra_docker_opts() or []) + (extra_docker_opts or [])
 
-        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run)
+        ctx = ClusterContext.build(self, hosts, image, cluster_id, env, cache_dir, config, dry_run, overrides=overrides)
         head_container = self.executor.container_name(cluster_id, "head")
         worker_container = self.executor.container_name(cluster_id, "worker")
 

--- a/src/sparkrun/runtimes/vllm_ray.py
+++ b/src/sparkrun/runtimes/vllm_ray.py
@@ -458,7 +458,7 @@ class VllmRayRuntime(VllmMixin, RuntimePlugin):
             return 0
         return exec_result.returncode
 
-    def _print_connection_info(self, hosts, cluster_id, head_ip=None, dashboard_port=8265):
+    def _print_connection_info(self, hosts, cluster_id, *, head_ip=None, dashboard_port=8265, per_node_logs: bool = False):
         """Print vLLM-specific connection info including Dashboard URL."""
         logger.info("=" * 60)
         logger.info("Cluster launched successfully. Nodes: %d", len(hosts))

--- a/src/sparkrun/tuning/_common.py
+++ b/src/sparkrun/tuning/_common.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from sparkrun.core.config import DEFAULT_CACHE_DIR
 from sparkrun.utils import format_duration as _format_duration  # noqa: F401 — re-exported for local callers
@@ -33,7 +33,7 @@ def _get_tuning_dir(cache_subdir: str) -> Path:
 
 
 def _get_tuning_volumes(
-    tuning_dir_fn: callable,
+    tuning_dir_fn: Callable[[], Path],
     container_path: str,
 ) -> dict[str, str] | None:
     """Return volume mapping for tuning configs if they exist.
@@ -52,7 +52,7 @@ def _get_tuning_volumes(
 
 
 def _get_tuning_env(
-    volumes_fn: callable,
+    volumes_fn: Callable[[], dict[str, str] | None],
     env_var: str,
     container_path: str,
 ) -> dict[str, str] | None:

--- a/src/sparkrun/utils/__init__.py
+++ b/src/sparkrun/utils/__init__.py
@@ -6,6 +6,7 @@ Keeping them here avoids circular imports and reduces duplication.
 
 from __future__ import annotations
 import logging
+from typing import Any
 
 # Loggers that produce excessive output at DEBUG/INFO level.
 _NOISY_LOGGERS = (
@@ -104,6 +105,19 @@ def merge_env(*env_dicts: dict[str, str] | None) -> dict[str, str]:
         if d:
             merged.update(d)
     return merged
+
+
+def extract_env_overrides(overrides: dict[str, Any] | None) -> dict[str, str]:
+    """Extract env.* items from overrides into a plain env dict."""
+    env: dict[str, str] = {}
+    if not overrides:
+        return env
+    for key, value in overrides.items():
+        if key.startswith("env."):
+            var_name = key[4:]
+            if var_name:
+                env[var_name] = str(value)
+    return env
 
 
 def is_local_host(host: str) -> bool:

--- a/src/sparkrun/utils/cli_formatters.py
+++ b/src/sparkrun/utils/cli_formatters.py
@@ -250,12 +250,11 @@ def format_monitor_table(
     lines = [header, separator]
     for host in hosts:
         state = data.get(host)
-        if state is None or (state.latest is None and state.error is None):
-            lines.append(f"{host:<{host_w}}{'(connecting...)':>6}")
-            continue
-
-        if state.error and state.latest is None:
-            lines.append(f"{host:<{host_w}}{state.error}")
+        if state is None or state.latest is None:
+            if state and state.error:
+                lines.append(f"{host:<{host_w}}{state.error}")
+            else:
+                lines.append(f"{host:<{host_w}}{'(connecting...)':>6}")
             continue
 
         s = state.latest

--- a/src/sparkrun/utils/json_helpers.py
+++ b/src/sparkrun/utils/json_helpers.py
@@ -13,12 +13,12 @@ class SparkrunJSONEncoder(json.JSONEncoder):
     Automatically serializes objects with to_dict() and dataclasses.
     """
 
-    def default(self, obj: Any) -> Any:
-        if hasattr(obj, "to_dict") and callable(obj.to_dict):
-            return obj.to_dict()
-        if dataclasses.is_dataclass(obj):
-            return dataclasses.asdict(obj)
-        return super().default(obj)
+    def default(self, o: Any) -> Any:
+        if hasattr(o, "to_dict") and callable(o.to_dict):
+            return o.to_dict()
+        if dataclasses.is_dataclass(o) and not isinstance(o, type):
+            return dataclasses.asdict(o)
+        return super().default(o)
 
 
 def dumps_json(data: Any, pretty: bool = False) -> str:

--- a/src/sparkrun/utils/yaml_helpers.py
+++ b/src/sparkrun/utils/yaml_helpers.py
@@ -11,7 +11,7 @@ class LiteralBlockDumper(yaml.SafeDumper):
     pass
 
 
-def _literal_str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+def _literal_str_representer(dumper: yaml.SafeDumper, data: str) -> yaml.ScalarNode:
     if "\n" in data:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)


### PR DESCRIPTION
## Summary

Implements the **client-side daemonized tunnel** strategy from the Fleet Multiplexer design.

### Changes

#### `src/sparkrun/orchestration/ssh.py`
- **Replaced** the `ExitStack` context manager (`__enter__`/`__exit__`) with two explicit methods:
  - `establish_detached()` — allocates an ephemeral port, launches `ssh -N -L` with `start_new_session=True` so the SSH process survives the parent process exiting, writes PID/port state files to `/tmp/`, then registers with the Fleet Multiplexer API
  - `TelemetryTunnel.cleanup(host)` — static method that reads the PID file, deregisters from the Multiplexer, SIGTERMs the tunnel (escalating to SIGKILL), and removes state files
- Added `os`, `signal`, `socket` to module-level imports

#### `src/sparkrun/cli/_run.py`
- Removed `ExitStack` wrapper — tunnels now outlive the CLI invocation
- Calls `TelemetryTunnel(...).establish_detached()` directly per host

#### `src/sparkrun/cli/_stop_logs.py`
- Wired `TelemetryTunnel.cleanup(host)` into all three stop paths (`_stop_all`, `_stop_by_cluster_id`, `_stop_recipe`)

#### `pyrightconfig.json` (new)
- Added to the sparkrun repo root so Pyright always finds the `src/` layout and the local `.venv` (created by `uv sync`) in every standalone clone and git worktree
- `venvPath: "."`, `venv: ".venv"` — self-contained, no hardcoded paths

## Why daemonized tunnels?

SSH keys stay on the host running `sparkrun` and are never transmitted to the Fleet Multiplexer container. PID files in `/tmp/` provide deterministic cleanup via `sparkrun stop`.