### PR TITLE
chore: add Pyright config to pyproject.toml for correct src/ layout and venv discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,13 @@ dev = [
     "pytest>=9.0.2",
     "ruff>=0.15.9",
 ]
+
+[tool.pyright]
+include = ["src"]
+extraPaths = ["src"]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.12"
+typeCheckingMode = "basic"
+reportMissingImports = "warning"
+reportMissingModuleSource = "warning"


### PR DESCRIPTION
## Problem

Pyright has no configuration in this repo, so when an IDE's workspace root is a parent directory (e.g. when using git worktrees inside a monorepo), it fails to find the `src/` layout and emits false `undefined name` errors for standard library modules and package imports.

## Solution

Add `[tool.pyright]` to `pyproject.toml` — the idiomatic location for `uv`-managed projects — rather than a separate `pyrightconfig.json`.

```toml
[tool.pyright]
include = ["src"]
extraPaths = ["src"]
venvPath = "."
venv = ".venv"
pythonVersion = "3.12"
typeCheckingMode = "basic"
reportMissingImports = "warning"
reportMissingModuleSource = "warning"
```

- **`extraPaths = ["src"]`** — teaches Pyright about the `src/` layout so all `sparkrun.*` imports resolve correctly
- **`venvPath = "."` + `venv = ".venv"`** — points to the local `.venv` created by `uv sync`, self-contained for both standalone clones and git worktrees