### PR TITLE
fix(tracing): inject OTLP config via env overrides

### DIFF
--- a/src/sparkrun/cli/_common.py
+++ b/src/sparkrun/cli/_common.py
@@ -869,6 +869,13 @@ def _apply_recipe_overrides(
         if v is not None:
             overrides[k] = v
 
+    # Apply env.* overrides to recipe.env directly
+    if recipe is not None:
+        for k, v in list(overrides.items()):
+            if k.startswith("env."):
+                recipe.env[k[4:]] = str(v)
+                del overrides[k]
+
     # Resolve runtime with overrides visible to resolvers
     if recipe is not None:
         recipe.resolve(overrides)

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -54,6 +54,7 @@ VLLM_FLAG_MAP = {
     "pipeline_parallel": "-pp",
     "data_parallel": "--data-parallel-size",
     "kv_cache_dtype": "--kv-cache-dtype",
+    "otlp_traces_endpoint": "--otlp-traces-endpoint",
 }
 
 # Boolean flags (present = True, absent = False)


### PR DESCRIPTION
fix(tracing): inject OTLP config via env overrides

This intercepts `-o env.KEY=VALUE` CLI arguments and applies them
directly to `recipe.env`, ensuring proper OTLP trace propagation into the
vLLM backend container. It also explicitly maps `--otlp-traces-endpoint`.

Previously, OTLP environment variables provided via the orchestrator were
placed in the generic `overrides` dictionary, where vLLM ignored them. By
extracting keys prefixed with `env.` into `recipe.env`, the `Executor`
natively exports them when spinning up the serve script.