### PR TITLE
feat: add Atlas Spark runtime plugin

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -183,22 +183,24 @@ Explicit `runtime` always wins. Command-hint detection only fires when `runtime`
 | `llama-cpp`        | RPC (experimental)                                  | Workers run `rpc-server`, head uses `--rpc`    |
 | `trtllm`           | MPI (`mpirun` + rsh wrapper)                        | `sleep infinity` containers + `mpirun` on head |
 | `eugr-vllm`        | Ray (inherits vllm-ray)                             | eugr container builds + Ray cluster            |
+| `atlas`            | Native (`--rank`, `--world-size`, `--master-addr`)  | Atlas Spark (avarok/atlas-gb10) — pure-Rust LLM inference; each rank runs `atlas serve`, rank 0 only HTTP |
 
 ### Common Defaults Keys
 
-| Key                      | vLLM                       | SGLang                  | llama.cpp            | TRT-LLM               | Description                       |
-|--------------------------|----------------------------|-------------------------|----------------------|-----------------------|-----------------------------------|
-| `port`                   | `--port`                   | `--port`                | `--port`             | `--port`              | Serve port                        |
-| `host`                   | `--host`                   | `--host`                | `--host`             | `--host`              | Bind address                      |
-| `tensor_parallel`        | `-tp`                      | `--tp-size`             | `--split-mode row`   | `--tp_size`           | TP degree (= node count on Spark) |
-| `pipeline_parallel`      | `-pp`                      | `--pp-size`             | `--split-mode layer` | `--pp_size`           | PP degree                         |
-| `gpu_memory_utilization` | `--gpu-memory-utilization` | `--mem-fraction-static` | —                    | —                     | GPU memory fraction               |
-| `max_model_len`          | `--max-model-len`          | `--context-length`      | `--ctx-size`         | `--max_seq_len`       | Max sequence length               |
-| `served_model_name`      | `--served-model-name`      | `--served-model-name`   | `--alias`            | —                     | Model name in API                 |
-| `dtype`                  | `--dtype`                  | `--dtype`               | —                    | —                     | Model dtype                       |
-| `quantization`           | `--quantization`           | `--quantization`        | —                    | —                     | Quantization method               |
-| `trust_remote_code`      | `--trust-remote-code`      | `--trust-remote-code`   | —                    | `--trust_remote_code` | Allow remote code                 |
-| `kv_cache_dtype`         | `--kv-cache-dtype`         | `--kv-cache-dtype`      | —                    | via extra config      | KV cache dtype                    |
+| Key                      | vLLM                       | SGLang                  | llama.cpp            | TRT-LLM               | Atlas                 | Description                       |
+|--------------------------|----------------------------|-------------------------|----------------------|-----------------------|-----------------------|-----------------------------------|
+| `port`                   | `--port`                   | `--port`                | `--port`             | `--port`              | `--port`              | Serve port                        |
+| `host`                   | `--host`                   | `--host`                | `--host`             | `--host`              | `--host`              | Bind address                      |
+| `tensor_parallel`        | `-tp`                      | `--tp-size`             | `--split-mode row`   | `--tp_size`           | `--tp-size`           | TP degree (= node count on Spark) |
+| `pipeline_parallel`      | `-pp`                      | `--pp-size`             | `--split-mode layer` | `--pp_size`           | —                     | PP degree                         |
+| `ep_size`                | —                          | `--ep-size`             | —                    | —                     | `--ep-size`           | Expert-parallel degree            |
+| `gpu_memory_utilization` | `--gpu-memory-utilization` | `--mem-fraction-static` | —                    | —                     | `--gpu-memory-utilization` | GPU memory fraction          |
+| `max_model_len`          | `--max-model-len`          | `--context-length`      | `--ctx-size`         | `--max_seq_len`       | `--max-seq-len`       | Max sequence length               |
+| `served_model_name`      | `--served-model-name`      | `--served-model-name`   | `--alias`            | —                     | `--model-name`        | Model name in API                 |
+| `dtype`                  | `--dtype`                  | `--dtype`               | —                    | —                     | (auto)                | Model dtype                       |
+| `quantization`           | `--quantization`           | `--quantization`        | —                    | —                     | (auto)                | Quantization method               |
+| `trust_remote_code`      | `--trust-remote-code`      | `--trust-remote-code`   | —                    | `--trust_remote_code` | (no-op)               | Allow remote code                 |
+| `kv_cache_dtype`         | `--kv-cache-dtype`         | `--kv-cache-dtype`      | —                    | via extra config      | `--kv-cache-dtype`    | KV cache dtype                    |
 
 Any key can appear in `defaults` — there is no fixed schema. Runtime-specific keys (e.g. `tool_call_parser`, `ctx_size`,
 `n_gpu_layers`, `reasoning_parser`) are passed through to command template substitution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ sglang = "sparkrun.runtimes.sglang:SglangRuntime"
 eugr-vllm = "sparkrun.runtimes.eugr_vllm_ray:EugrVllmRayRuntime"
 llama-cpp = "sparkrun.runtimes.llama_cpp:LlamaCppRuntime"
 trtllm = "sparkrun.runtimes.trtllm:TrtllmRuntime"
+atlas = "sparkrun.runtimes.atlas:AtlasRuntime"
 
 [project.entry-points."sparkrun.benchmarking"]
 llama-benchy = "sparkrun.benchmarking.llama_benchy:LlamaBenchyFramework"

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -1,0 +1,420 @@
+"""Native Atlas Spark runtime for sparkrun.
+
+Atlas (https://github.com/avarok-tech/atlas) is a pure-Rust LLM inference
+server. It bootstraps multi-rank deployments via NCCL using
+``--rank``/``--world-size``/``--master-addr``/``--master-port`` flags,
+without Ray. This runtime therefore uses the ``"native"`` clustering
+strategy, identical in shape to the SGLang and vllm-distributed
+runtimes.
+
+Atlas composes tensor parallelism (``--tp-size``) and expert parallelism
+(``--ep-size``) on the same physical ranks (see
+``crates/spark-server/src/cli.rs``):
+
+* ``world_size == tp_size * ep_size``  — orthogonal mesh
+* ``world_size == tp_size == ep_size`` — overlapping groups (used by the
+  validated MiniMax M2.7 EP=2 + TP=2 config on two GB10 nodes)
+
+The runtime auto-derives ``world_size`` from ``tensor_parallel`` and
+``ep_size`` so users only set the two parallelism dims and sparkrun
+maps them to physical hosts.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TYPE_CHECKING
+
+from sparkrun.runtimes._util import default_env_hf_offline
+from sparkrun.runtimes.base import RuntimePlugin
+
+if TYPE_CHECKING:
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.orchestration.comm_env import ClusterCommEnv
+
+logger = logging.getLogger(__name__)
+
+
+# Standardized sparkrun config keys → Atlas CLI flags.
+# Keys here follow the conventions documented in RECIPES.md "Common
+# Defaults Keys" so that recipes are portable across runtimes where
+# possible.
+_ATLAS_FLAG_MAP = {
+    # Sparkrun standard keys
+    "port": "--port",
+    "host": "--host",  # Atlas exposes --bind with `--host` as an alias
+    "tensor_parallel": "--tp-size",
+    "gpu_memory_utilization": "--gpu-memory-utilization",
+    "max_model_len": "--max-seq-len",
+    "max_num_seqs": "--max-num-seqs",
+    "max_num_batched_tokens": "--max-prefill-tokens",
+    "served_model_name": "--model-name",
+    "kv_cache_dtype": "--kv-cache-dtype",
+    # Atlas-specific keys (passed through as-is)
+    "ep_size": "--ep-size",
+    "max_batch_size": "--max-batch-size",
+    "block_size": "--block-size",
+    "kv_high_precision_layers": "--kv-high-precision-layers",
+    "tool_call_parser": "--tool-call-parser",
+    "tool_max_tokens": "--tool-max-tokens",
+    "scheduling_policy": "--scheduling-policy",
+    "tbt_deadline_ms": "--tbt-deadline-ms",
+    "max_prefill_tokens": "--max-prefill-tokens",
+    "oom_guard_mb": "--oom-guard-mb",
+    "ssm_cache_slots": "--ssm-cache-slots",
+    "ssm_checkpoint_interval": "--ssm-checkpoint-interval",
+    "mtp_quantization": "--mtp-quantization",
+    "mtp_vocab": "--mtp-vocab",
+    "num_drafts": "--num-drafts",
+    "draft_model": "--draft-model",
+    "dflash_gamma": "--dflash-gamma",
+    "dflash_window_size": "--dflash-window-size",
+    "max_thinking_budget": "--max-thinking-budget",
+    "model_from_path": "--model-from-path",
+    "cache_dir": "--cache-dir",
+    "gpu_ordinal": "--gpu-ordinal",
+}
+
+# Boolean flags — present when truthy, omitted otherwise.
+_ATLAS_BOOL_FLAGS = {
+    "enable_prefix_caching",
+    "speculative",
+    "self_speculative",
+    "ngram_speculative",
+    "dflash",
+    "disable_thinking",
+    "high_speed_swap",
+    "require_auth",
+    # `trust_remote_code` is accepted as a no-op so cross-runtime recipes
+    # don't need to special-case Atlas. Atlas always loads from the local
+    # HF cache and doesn't execute remote code.
+}
+
+_ATLAS_BOOL_TO_FLAG = {
+    "enable_prefix_caching": "--enable-prefix-caching",
+    "speculative": "--speculative",
+    "self_speculative": "--self-speculative",
+    "ngram_speculative": "--ngram-speculative",
+    "dflash": "--dflash",
+    "disable_thinking": "--disable-thinking",
+    "high_speed_swap": "--high-speed-swap",
+    "require_auth": "--require-auth",
+}
+
+
+class AtlasRuntime(RuntimePlugin):
+    """Native Atlas Spark runtime using the public ``avarok/atlas-gb10`` image.
+
+    Atlas handles its own multi-rank bootstrap via NCCL — each node runs
+    the full ``atlas serve`` command with node-specific ``--rank``,
+    ``--world-size``, ``--master-addr``, and ``--master-port`` flags.
+    The non-head ranks bind their HTTP listener to ``--port 0`` so only
+    rank 0 exposes the OpenAI API.
+    """
+
+    runtime_name = "atlas"
+    default_image_prefix = "avarok/atlas-gb10"
+
+    def cluster_strategy(self) -> str:
+        """Atlas handles its own multi-rank distribution via NCCL, not Ray."""
+        return "native"
+
+    def get_common_env(self):
+        return default_env_hf_offline()
+
+    # --- Command generation ---
+
+    def generate_command(
+        self,
+        recipe: Recipe,
+        overrides: dict[str, Any],
+        is_cluster: bool,
+        num_nodes: int = 1,
+        head_ip: str | None = None,
+        skip_keys: set[str] | frozenset[str] = frozenset(),
+    ) -> str:
+        """Generate the ``atlas serve`` command for solo or cluster mode.
+
+        For cluster mode this is the head-node (rank 0) command. Worker
+        ranks are produced by :meth:`generate_node_command`.
+        """
+        config = recipe.build_config_chain(overrides)
+
+        rendered = recipe.render_command(config)
+        if rendered:
+            rendered = self._augment_served_model_name(
+                rendered,
+                config,
+                "--model-name",
+                skip_keys,
+            )
+            if skip_keys:
+                rendered = self.strip_flags_from_command(
+                    rendered,
+                    skip_keys,
+                    _ATLAS_FLAG_MAP,
+                    frozenset(_ATLAS_BOOL_TO_FLAG.keys()),
+                )
+            return rendered
+
+        return self._build_command(recipe, config, is_cluster, num_nodes, head_ip, node_rank=0, skip_keys=skip_keys)
+
+    def generate_node_command(
+        self,
+        recipe: Recipe,
+        overrides: dict[str, Any],
+        head_ip: str,
+        num_nodes: int,
+        node_rank: int,
+        init_port: int = 25000,
+        skip_keys: set[str] | frozenset[str] = frozenset(),
+        hosts: list[str] | None = None,
+    ) -> str:
+        """Generate the per-rank ``atlas serve`` command.
+
+        Non-head ranks override ``--port 0`` so they don't try to bind
+        the HTTP listener — only rank 0 exposes the OpenAI API.
+        """
+        config = recipe.build_config_chain(overrides)
+
+        rendered = recipe.render_command(config)
+        if rendered:
+            rendered = self._augment_served_model_name(
+                rendered,
+                config,
+                "--model-name",
+                skip_keys,
+            )
+            if skip_keys:
+                rendered = self.strip_flags_from_command(
+                    rendered,
+                    skip_keys,
+                    _ATLAS_FLAG_MAP,
+                    frozenset(_ATLAS_BOOL_TO_FLAG.keys()),
+                )
+            base = rendered
+        else:
+            base = self._build_base_command(recipe, config, node_rank=node_rank, skip_keys=skip_keys)
+
+        parts = [
+            base,
+            "--rank %d" % node_rank,
+            "--world-size %d" % num_nodes,
+            "--master-addr %s" % head_ip,
+            "--master-port %d" % init_port,
+        ]
+        return " ".join(parts)
+
+    # --- Internal helpers ---
+
+    def _build_base_command(
+        self,
+        recipe: Recipe,
+        config,
+        node_rank: int = 0,
+        skip_keys: set[str] | frozenset[str] = frozenset(),
+    ) -> str:
+        """Build the ``atlas serve`` command without cluster-coordination flags.
+
+        Worker ranks (node_rank > 0) override ``--port 0`` to suppress HTTP
+        binding; only the head exposes the OpenAI API.
+        """
+        parts = ["atlas", "serve", recipe.model]
+
+        skip = set(skip_keys)
+        # Worker ranks always bind --port 0 regardless of the recipe value.
+        if node_rank > 0:
+            skip.add("port")
+            parts.extend(["--port", "0"])
+
+        parts.extend(
+            self.build_flags_from_map(
+                config,
+                _ATLAS_FLAG_MAP,
+                bool_keys=frozenset(),
+                skip_keys=skip,
+            )
+        )
+
+        # Boolean toggles use a separate map so we control flag spelling.
+        for key, flag in _ATLAS_BOOL_TO_FLAG.items():
+            if key in skip:
+                continue
+            value = config.get(key)
+            if value is None:
+                continue
+            if _coerce_bool(value):
+                parts.append(flag)
+
+        return " ".join(parts)
+
+    def _build_command(
+        self,
+        recipe: Recipe,
+        config,
+        is_cluster: bool,
+        num_nodes: int,
+        head_ip: str | None = None,
+        node_rank: int = 0,
+        skip_keys: set[str] | frozenset[str] = frozenset(),
+    ) -> str:
+        """Build the head-rank command, including coordination flags in cluster mode."""
+        base = self._build_base_command(recipe, config, node_rank=node_rank, skip_keys=skip_keys)
+
+        if is_cluster and head_ip:
+            base += " --rank 0 --world-size %d --master-addr %s --master-port 29500" % (num_nodes, head_ip)
+
+        return base
+
+    # --- Parallelism ---
+
+    def compute_required_nodes(self, recipe: Recipe, overrides: dict[str, Any] | None = None) -> int | None:
+        """Atlas world_size = max(tp*ep, tp, ep).
+
+        Atlas supports overlapping ``tp == ep`` topology (both groups
+        live on the same physical ranks) as well as the orthogonal
+        ``tp * ep`` mesh. Sparkrun's stock ``compute_required_nodes``
+        only considers ``tensor_parallel * pipeline_parallel *
+        data_parallel``, so we override to factor in ``ep_size``.
+        """
+        config = recipe.build_config_chain(overrides or {})
+        tp = _coerce_int(config.get("tensor_parallel"), default=1)
+        ep = _coerce_int(config.get("ep_size"), default=1)
+
+        if tp <= 1 and ep <= 1:
+            return None
+
+        if tp == ep and tp > 1:
+            # Overlapping groups: both TP and EP share the same ranks.
+            return tp
+        return tp * ep
+
+    # --- Cluster env ---
+
+    def get_cluster_env(self, head_ip: str, num_nodes: int) -> dict[str, str]:
+        """NCCL settings validated for GB10 RoCEv2 fabrics.
+
+        Mirrors ``scripts/start-minimax-ep2.sh`` from the Atlas repo —
+        the same env that's in production use for the MiniMax M2.7 EP=2
+        and Qwen3.5-122B EP=2 deployments. Recipe ``env`` overrides any
+        of these values.
+        """
+        return {
+            **RuntimePlugin.get_cluster_env(self, head_ip, num_nodes),
+            "NCCL_SOCKET_IFNAME": "enp1s0f0np0",
+            "NCCL_IB_DISABLE": "0",
+            "NCCL_IB_HCA": "rocep1s0f0",
+            "NCCL_IB_ROCE_VERSION_NUM": "2",
+            "NCCL_IB_ADDR_FAMILY": "AF_INET",
+            "NCCL_IB_TIMEOUT": "22",
+            "NCCL_IB_RETRY_CNT": "7",
+            "NCCL_NET_GDR_LEVEL": "0",
+            "NCCL_NET_GDR_C2C": "0",
+            "NCCL_DMABUF_ENABLE": "0",
+            "NCCL_NVLS_ENABLE": "0",
+            "NCCL_CUMEM_HOST_ENABLE": "0",
+            "NCCL_PROTO": "Simple",
+            "NCCL_ALGO": "Ring",
+            "NCCL_BUFFSIZE": "33554432",
+            "NCCL_MIN_NCHANNELS": "1",
+            "NCCL_MAX_NCHANNELS": "2",
+        }
+
+    def get_extra_docker_opts(self) -> list[str]:
+        """RDMA device + capabilities required by Atlas's NCCL/io_uring paths.
+
+        ``--high-speed-swap`` uses ``IORING_SETUP_SQPOLL`` (kernel ≥ 5.13)
+        and Docker's default seccomp profile blocks ``io_uring_*``, so we
+        run the storage path unconfined. ``IPC_LOCK`` + ``memlock=-1``
+        unblock ``ibv_reg_mr``; ``SYS_NICE`` is needed by the SQPOLL
+        kernel thread.
+        """
+        return [
+            "--device=/dev/infiniband",
+            "--cap-add=IPC_LOCK",
+            "--cap-add=SYS_NICE",
+            "--ulimit",
+            "memlock=-1",
+            "--security-opt",
+            "seccomp=unconfined",
+        ]
+
+    # --- Version reporting ---
+
+    def version_commands(self) -> dict[str, str]:
+        cmds = super().version_commands()
+        cmds["atlas"] = "atlas --version 2>/dev/null || echo unknown"
+        return cmds
+
+    # --- Cluster lifecycle ---
+
+    def _stop_cluster(
+        self,
+        hosts: list[str],
+        cluster_id: str,
+        config=None,
+        dry_run: bool = False,
+    ) -> int:
+        """Stop an Atlas native cluster."""
+        return self._stop_native_cluster(hosts, cluster_id, config=config, dry_run=dry_run)
+
+    def _run_cluster(
+        self,
+        hosts: list[str],
+        image: str,
+        serve_command: str = "",
+        recipe=None,
+        overrides=None,
+        *,
+        cluster_id: str = "sparkrun0",
+        env: dict[str, str] | None = None,
+        cache_dir: str | None = None,
+        config=None,
+        dry_run: bool = False,
+        detached: bool = True,
+        comm_env: "ClusterCommEnv | None" = None,
+        init_port: int = 29500,
+        skip_keys: set[str] | frozenset[str] = frozenset(),
+        **kwargs,
+    ) -> int:
+        """Orchestrate a multi-rank Atlas cluster using native NCCL distribution."""
+        return self._run_native_cluster(
+            hosts=hosts,
+            image=image,
+            serve_command=serve_command,
+            recipe=recipe,
+            overrides=overrides,
+            cluster_id=cluster_id,
+            env=env,
+            cache_dir=cache_dir,
+            config=config,
+            dry_run=dry_run,
+            detached=detached,
+            comm_env=comm_env,
+            init_port=init_port,
+            skip_keys=skip_keys,
+            banner_title="Atlas Cluster Launcher",
+            port_label="NCCL Master Port",
+            node_label="atlas rank",
+            **kwargs,
+        )
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Match SAF's truthy semantics for recipe defaults coming from YAML."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "y", "t"}
+    return bool(value)
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -1,0 +1,238 @@
+"""Unit tests for the Atlas runtime plugin."""
+
+from sparkrun.core.recipe import Recipe
+from sparkrun.runtimes.atlas import AtlasRuntime
+
+
+def _recipe(**overrides) -> Recipe:
+    base = {
+        "name": "test-recipe",
+        "model": "Sehyo/Qwen3.5-35B-A3B-NVFP4",
+        "runtime": "atlas",
+    }
+    base.update(overrides)
+    return Recipe.from_dict(base)
+
+
+# --- Identity / container ---
+
+
+def test_atlas_runtime_name():
+    runtime = AtlasRuntime()
+    assert runtime.runtime_name == "atlas"
+    assert runtime.cluster_strategy() == "native"
+
+
+def test_atlas_resolve_container_default():
+    """No container field → public Docker Hub image."""
+    runtime = AtlasRuntime()
+    assert runtime.resolve_container(_recipe()) == "avarok/atlas-gb10:latest"
+
+
+def test_atlas_resolve_container_from_recipe():
+    """Recipe container field wins."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(container="avarok/atlas-gb10:custom-tag")
+    assert runtime.resolve_container(recipe) == "avarok/atlas-gb10:custom-tag"
+
+
+# --- Solo command generation ---
+
+
+def test_atlas_generate_command_structured():
+    """Generates `atlas serve <model>` with mapped flags."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(
+        defaults={
+            "port": 8888,
+            "max_model_len": 8192,
+            "kv_cache_dtype": "nvfp4",
+            "gpu_memory_utilization": 0.88,
+            "scheduling_policy": "slai",
+        },
+    )
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert cmd.startswith("atlas serve Sehyo/Qwen3.5-35B-A3B-NVFP4")
+    assert "--port 8888" in cmd
+    assert "--max-seq-len 8192" in cmd
+    assert "--kv-cache-dtype nvfp4" in cmd
+    assert "--gpu-memory-utilization 0.88" in cmd
+    assert "--scheduling-policy slai" in cmd
+
+
+def test_atlas_generate_command_bool_flags():
+    """Boolean flags are present when truthy and absent when false."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(
+        defaults={
+            "speculative": True,
+            "enable_prefix_caching": True,
+            "high_speed_swap": False,
+        },
+    )
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--speculative" in cmd
+    assert "--enable-prefix-caching" in cmd
+    assert "--high-speed-swap" not in cmd
+
+
+def test_atlas_generate_command_from_template():
+    """Recipe with explicit command template renders it verbatim."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(
+        command="atlas serve {model} --port {port}",
+        defaults={"port": 9000},
+    )
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert cmd == "atlas serve Sehyo/Qwen3.5-35B-A3B-NVFP4 --port 9000"
+
+
+def test_atlas_cli_overrides_defaults():
+    """CLI overrides take priority over recipe defaults."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"port": 8888})
+    cmd = runtime.generate_command(recipe, {"port": 9000}, is_cluster=False)
+    assert "--port 9000" in cmd
+    assert "--port 8888" not in cmd
+
+
+# --- Atlas-specific flags ---
+
+
+def test_atlas_mtp_and_speculative_flags():
+    """MTP speculative-decoding flags pass through correctly."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(
+        defaults={
+            "speculative": True,
+            "mtp_quantization": "nvfp4",
+            "num_drafts": 2,
+        },
+    )
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--speculative" in cmd
+    assert "--mtp-quantization nvfp4" in cmd
+    assert "--num-drafts 2" in cmd
+
+
+def test_atlas_ep_size_first_class():
+    """`ep_size` maps to --ep-size (Atlas-specific but standardized in this runtime)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"ep_size": 2})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--ep-size 2" in cmd
+
+
+def test_atlas_skip_served_model_name():
+    """`skip_keys` suppresses --model-name (used by benchmark flow)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"served_model_name": "my-alias", "port": 8888})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False, skip_keys={"served_model_name"})
+    assert "--model-name" not in cmd
+
+
+# --- Cluster command generation ---
+
+
+def test_atlas_generate_command_cluster_head():
+    """Cluster mode head command includes --rank 0 / --master-addr / --master-port."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 1, "ep_size": 2, "port": 8888})
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=True, num_nodes=2, head_ip="10.0.0.1")
+    assert "--rank 0" in cmd
+    assert "--world-size 2" in cmd
+    assert "--master-addr 10.0.0.1" in cmd
+    assert "--master-port 29500" in cmd
+    assert "--ep-size 2" in cmd
+    assert "--port 8888" in cmd
+
+
+def test_atlas_generate_node_command_worker_binds_port_zero():
+    """Workers must bind --port 0 — only rank 0 exposes the OpenAI API."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"ep_size": 2, "port": 8888})
+
+    head = runtime.generate_node_command(recipe, {}, head_ip="10.0.0.1", num_nodes=2, node_rank=0, init_port=29500)
+    worker = runtime.generate_node_command(recipe, {}, head_ip="10.0.0.1", num_nodes=2, node_rank=1, init_port=29500)
+
+    assert "--port 8888" in head
+    assert "--rank 0" in head
+    assert "--master-addr 10.0.0.1" in head
+    assert "--master-port 29500" in head
+
+    assert "--port 0" in worker
+    assert "--port 8888" not in worker
+    assert "--rank 1" in worker
+
+
+# --- compute_required_nodes ---
+
+
+def test_atlas_compute_required_nodes_solo():
+    """No parallelism → None (= use whatever hosts the user provided)."""
+    runtime = AtlasRuntime()
+    assert runtime.compute_required_nodes(_recipe()) is None
+
+
+def test_atlas_compute_required_nodes_pure_ep():
+    """ep_size=2, tp=1 → 2 nodes."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"ep_size": 2})
+    assert runtime.compute_required_nodes(recipe) == 2
+
+
+def test_atlas_compute_required_nodes_overlapping_tp_ep():
+    """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
+    assert runtime.compute_required_nodes(recipe) == 2
+
+
+def test_atlas_compute_required_nodes_orthogonal_tp_ep():
+    """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
+    assert runtime.compute_required_nodes(recipe) == 8
+
+
+# --- Cluster env / docker opts ---
+
+
+def test_atlas_cluster_env_includes_rdma():
+    """Cluster env mirrors the validated GB10 RoCEv2 NCCL settings."""
+    runtime = AtlasRuntime()
+    env = runtime.get_cluster_env(head_ip="10.0.0.1", num_nodes=2)
+    assert env["NCCL_IB_HCA"] == "rocep1s0f0"
+    assert env["NCCL_IB_ROCE_VERSION_NUM"] == "2"
+    assert env["NCCL_PROTO"] == "Simple"
+
+
+def test_atlas_extra_docker_opts_include_infiniband():
+    """RDMA + io_uring + IPC_LOCK opts required by Atlas's storage and NCCL paths."""
+    runtime = AtlasRuntime()
+    opts = runtime.get_extra_docker_opts()
+    joined = " ".join(opts)
+    assert "/dev/infiniband" in joined
+    assert "IPC_LOCK" in joined
+    assert "memlock=-1" in joined
+    assert "seccomp=unconfined" in joined
+
+
+# --- validate_recipe ---
+
+
+def test_atlas_validate_recipe_valid():
+    runtime = AtlasRuntime()
+    assert runtime.validate_recipe(_recipe()) == []
+
+
+def test_atlas_validate_recipe_no_model():
+    runtime = AtlasRuntime()
+    recipe = Recipe.from_dict({"name": "test", "runtime": "atlas"})
+    issues = runtime.validate_recipe(recipe)
+    assert len(issues) == 1
+    assert "model is required" in issues[0]


### PR DESCRIPTION
## Summary

Adds `atlas` as a first-class sparkrun runtime, mirroring the shape of `vllm-distributed` and `sglang`. Atlas Spark is a pure-Rust LLM inference server distributed via the public `avarok/atlas-gb10:latest` 
Source: https://github.com/Avarok-Cybersecurity/atlas

Requested across the Atlas-Inference release channels and unblocks DGX Spark users who want to run Atlas through the same `sparkrun run …` flow they use for vLLM / SGLang / TRT-LLM.

## What's in this PR

- **`src/sparkrun/runtimes/atlas.py`** (~420 LOC) — `AtlasRuntime(RuntimePlugin)`:
  - `cluster_strategy = "native"` — Atlas bootstraps multi-rank deployments via NCCL using `--rank` / `--world-size` / `--master-addr` / `--master-port`; no Ray.
  - **EP** support via `ep_size` defaults key. `compute_required_nodes()` honors orthogonal (`world_size = tp * ep`) and overlapping (`world_size = tp == ep`) that Atlas's CLI accepts — the latter is what Atlas's MiniMax M2.7 EP=2 + TP=2 production config uses on two GB10 nodes.
  - Standardized sparkrun config keys (`port`, `host`, `tensor_parallel`, `gpu_memory_utilization`, `max_model_len`, `served_model_name`, `kv_cache_dtype`, `enable_prefix_caching`, …) map cleanly to Atlas flags. Atlas-native extras (`mtp_quantization`, `kv_high_precision_layers`, `scheduling_policy`, `tool_call_parser`, `high_speed_swap`, `oom_guard_mb`, `ssm_cache_slots`, …) are passed through.
  - `get_cluster_env()` ships the validated GB10 RoCEv2 NCCL settings used by Atlas's production EP=2 scripts.
  - `get_extra_docker_opts()` carries the RDMA + io_uring + IPC_LOCK requirements (`--device=/dev/infiniband`, `--cap-add=IPC_LOCK,SYS_NICE`, `--ulimit memlock=-1`, `--security-opt seccomp=unconfined`).
  - Worker ranks (rank > 0) bind `--port 0` automatically so only rank 0 exposes the OpenAI API.
- **`tests/test_atlas_runtime.py`** — 20 unit tests covering identity, structured + template command generation, CLI overrides, bool flags, EP/TP node counting, worker port-zero binding, RDMA env, validate_recipe.
- **`pyproject.toml`** — entry-point registration: `atlas = "sparkrun.runtimes.atlas:AtlasRuntime"`.
- **`RECIPES.md`** — Atlas added to the runtime tables and given a column in "Common Defaults Keys".

## Test plan

- [x] `pytest tests/test_atlas_runtime.py tests/test_runtimes.py` — **181 passed, 0 failed**
- [x] `ruff check src/sparkrun/runtimes/atlas.py tests/test_atlas_runtime.py` — clean
- [x] `ruff format --check` — clean
- [x] Entry point loads via `importlib.metadata.entry_points(group="sparkrun.runtimes")`
- [x] All 13 sibling recipes (see below) parse and render to commands matching Atlas's published QUICKSTART configs

## Sibling PR — recipes

Recipes for the supported model lineup (Qwen3.5 dense + 35B/122B + 80B Coder-Next + 122B EP=2, Qwen3-Next-80B, Qwen3-VL-30B, Gemma-4 26B/31B, Nemotron-3 Nano-30B + Super-120B, Mistral-Small-4-119B, MiniMax-M2.7 EP=2) are filed against `spark-arena/recipe-registry` in a sibling PR.