### PR TITLE
feat: add `extra_models` field to recipes for auxiliary model support

### DIFF
--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -252,6 +252,10 @@ def run(
     click.echo("Runtime:   %s" % runtime.runtime_name)
     click.echo("Image:     %s" % container_image)
     click.echo("Model:     %s" % recipe.model)
+    if recipe.extra_models:
+        for em in recipe.extra_models:
+            rev = " @ %s" % em.revision if em.revision else ""
+            click.echo("Extra:     %s%s" % (em.name, rev))
     if is_solo:
         click.echo("Mode:      solo")
     else:

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -41,6 +41,7 @@ _KNOWN_KEYS = {
     "description",
     "model",
     "model_revision",
+    "extra_models",
     "runtime",
     "runtime_version",
     "mode",
@@ -157,13 +158,13 @@ class DistributionConfig:
             externally_provided=data.get("externally_provided", True),
         )
 
-    def add_model(self, model: str):
+    def add_model(self, model: str, revision: str | None = None):
         """Add a model distribution config to the distribution config."""
         # scan through existing models and make sure that we don't add a duplicate
         for existing_model in self.models.entries:
             if existing_model.name == model:
                 return
-        self.models.entries.append(DistributionModelEntry(name=model))
+        self.models.entries.append(DistributionModelEntry(name=model, revision=revision))
 
     def add_container(self, model_container_config: DistributionContainerEntry):
         self.containers.entries.append(model_container_config)
@@ -211,6 +212,36 @@ def _default_distribution_config(model: str = "{model}", container: str = "{cont
         ),
         externally_provided=False,
     )
+
+
+def _parse_extra_models(raw: list | None) -> list[DistributionModelEntry]:
+    """Parse ``extra_models`` from raw recipe YAML data.
+
+    Each entry is a string (model ID) or a dict with ``model`` + optional ``revision`` keys.
+    """
+    if not raw or not isinstance(raw, list):
+        return []
+    entries: list[DistributionModelEntry] = []
+    for item in raw:
+        if isinstance(item, str):
+            entries.append(DistributionModelEntry(name=item))
+        elif isinstance(item, dict):
+            entries.append(DistributionModelEntry(
+                name=item.get("model", ""),
+                revision=item.get("revision"),
+            ))
+    return entries
+
+
+def _serialize_extra_models(entries: list[DistributionModelEntry]) -> list[dict[str, str | None]]:
+    """Serialize extra_models to a list of plain dicts for export."""
+    result: list[dict[str, str | None]] = []
+    for e in entries:
+        d: dict[str, str | None] = {"model": e.name}
+        if e.revision:
+            d["revision"] = e.revision
+        result.append(d)
+    return result
 
 
 def _parse_distribution_config(data: dict[str, Any]) -> DistributionConfig:
@@ -582,6 +613,7 @@ class Recipe:
         self.description: str = data.get("description", "")
         self.model: str = data.get("model", "")
         self.model_revision: str | None = data.get("model_revision")
+        self.extra_models: list[DistributionModelEntry] = _parse_extra_models(data.get("extra_models", []))
         self.runtime: str = data.get("runtime", "")  # init to empty string if not provided
         self.runtime_version: str = data.get("runtime_version", "")
 
@@ -652,6 +684,8 @@ class Recipe:
 
         # Distribution config (auto-generated default, mutable by runtimes)
         self.distribution_config: DistributionConfig = _parse_distribution_config(data)
+        for em in self.extra_models:
+            self.distribution_config.add_model(em.name, em.revision)
 
         # Applied overrides (populated by resolve())
         self._applied_overrides: dict[str, Any] = {}
@@ -1066,6 +1100,7 @@ class Recipe:
             "description": self.description,
             "model": self.model,
             "model_revision": self.model_revision,
+            "extra_models": [{"model": e.name, "revision": e.revision} for e in self.extra_models],
             "runtime": self.runtime,
             "runtime_version": self.runtime_version,
             "mode": self.mode,
@@ -1102,6 +1137,7 @@ class Recipe:
         self.description = state.get("description", "")
         self.model = state.get("model", "")
         self.model_revision = state.get("model_revision")
+        self.extra_models = _parse_extra_models(state.get("extra_models", []))
         self.runtime = state.get("runtime", "")
         self.runtime_version = state.get("runtime_version", "")
         self.mode = state.get("mode", "auto")
@@ -1153,7 +1189,8 @@ class Recipe:
         return cls._deserialize(data)
 
     def __repr__(self) -> str:
-        return "Recipe(name=%r, runtime=%r, model=%r)" % (self.name, self.runtime, self.model)
+        extra = ", extra_models=%r" % [e.name for e in self.extra_models] if self.extra_models else ""
+        return "Recipe(name=%r, runtime=%r, model=%r%s)" % (self.name, self.runtime, self.model, extra)
 
     # Preferred key ordering for export.  Entries are either exact key names
     # or fnmatch-style patterns (e.g. "model*" matches "model", "model_revision").
@@ -1198,6 +1235,8 @@ class Recipe:
         # -- Core fields (always present) --
         if self.model_revision:
             d["model_revision"] = self.model_revision
+        if self.extra_models:
+            d["extra_models"] = _serialize_extra_models(self.extra_models)
         d["runtime"] = self._raw.get("runtime", self.runtime)  # use bare original if given
         if self.runtime_version:
             d["runtime_version"] = self.runtime_version

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -2513,3 +2513,142 @@ class TestRecipeSerialization:
         restored = Recipe._deserialize(original.__getstate__())
         restored.resolve({"distributed_executor_backend": "ray"})
         assert restored.runtime == "vllm-ray"
+
+
+class TestExtraModels:
+    """Tests for the extra_models field."""
+
+    # --- parsing ------------------------------------------------------------------
+
+    def test_no_extra_models(self, sample_v2_recipe_data: dict):
+        """When extra_models is not present, it defaults to an empty list."""
+        recipe = Recipe.from_dict(sample_v2_recipe_data)
+        assert recipe.extra_models == []
+
+    def test_empty_extra_models(self, sample_v2_recipe_data: dict):
+        """Empty list when explicitly set to []."""
+        data = {**sample_v2_recipe_data, "extra_models": []}
+        recipe = Recipe.from_dict(data)
+        assert recipe.extra_models == []
+
+    def test_simple_string_entries(self, sample_v2_recipe_data: dict):
+        """Each string entry becomes a DistributionModelEntry with just a name."""
+        data = {**sample_v2_recipe_data, "extra_models": ["google/gemma-4-9b-draft"]}
+        recipe = Recipe.from_dict(data)
+        assert len(recipe.extra_models) == 1
+        assert recipe.extra_models[0].name == "google/gemma-4-9b-draft"
+        assert recipe.extra_models[0].revision is None
+
+    def test_dict_entries_with_revision(self, sample_v2_recipe_data: dict):
+        """Dict entries preserve the revision."""
+        data = {
+            **sample_v2_recipe_data,
+            "extra_models": [
+                {"model": "google/gemma-4-9b-mtp", "revision": "main"},
+            ],
+        }
+        recipe = Recipe.from_dict(data)
+        assert len(recipe.extra_models) == 1
+        assert recipe.extra_models[0].name == "google/gemma-4-9b-mtp"
+        assert recipe.extra_models[0].revision == "main"
+
+    def test_dict_entry_without_revision(self, sample_v2_recipe_data: dict):
+        """Revision is optional in dict form."""
+        data = {
+            **sample_v2_recipe_data,
+            "extra_models": [{"model": "google/gemma-4-9b-draft"}],
+        }
+        recipe = Recipe.from_dict(data)
+        assert recipe.extra_models[0].revision is None
+
+    def test_mixed_formats(self, sample_v2_recipe_data: dict):
+        """String and dict entries can coexist."""
+        data = {
+            **sample_v2_recipe_data,
+            "extra_models": [
+                "google/gemma-4-9b-draft",
+                {"model": "google/gemma-4-9b-mtp", "revision": "main"},
+            ],
+        }
+        recipe = Recipe.from_dict(data)
+        assert len(recipe.extra_models) == 2
+        assert recipe.extra_models[0].name == "google/gemma-4-9b-draft"
+        assert recipe.extra_models[1].name == "google/gemma-4-9b-mtp"
+
+    # --- distribution_config integration ------------------------------------------
+
+    def test_extra_models_added_to_distribution_config(self, sample_v2_recipe_data: dict):
+        """extra_models are injected as additional DistributionModelEntry items."""
+        data = {**sample_v2_recipe_data, "extra_models": ["draft-model"]}
+        recipe = Recipe.from_dict(data)
+        model_names = [e.name for e in recipe.distribution_config.models.entries]
+        assert model_names == ["{model}", "draft-model"]
+
+    def test_extra_model_literal_duplicate_skipped(self, sample_v2_recipe_data: dict):
+        """Literal duplicates in extra_models are deduplicated by add_model()."""
+        data = {**sample_v2_recipe_data, "extra_models": ["draft-model", "draft-model"]}
+        recipe = Recipe.from_dict(data)
+        model_names = [e.name for e in recipe.distribution_config.models.entries]
+        assert model_names == ["{model}", "draft-model"]
+
+    def test_extra_model_revision_preserved_in_distribution(self, sample_v2_recipe_data: dict):
+        """Revision from extra_models flows into the distribution entry."""
+        data = {
+            **sample_v2_recipe_data,
+            "extra_models": [{"model": "draft-model", "revision": "abc123"}],
+        }
+        recipe = Recipe.from_dict(data)
+        draft_entry = next(
+            e for e in recipe.distribution_config.models.entries if e.name == "draft-model"
+        )
+        assert draft_entry.revision == "abc123"
+
+    # --- serialization ------------------------------------------------------------
+
+    def test_round_trip_extra_models(self, sample_v2_recipe_data: dict):
+        """extra_models survive __getstate__/__setstate__ round-trip."""
+        data = {
+            **sample_v2_recipe_data,
+            "extra_models": [
+                "draft-model",
+                {"model": "mtp-model", "revision": "main"},
+            ],
+        }
+        original = Recipe.from_dict(data)
+        restored = Recipe._deserialize(original.__getstate__())
+        assert len(restored.extra_models) == 2
+        assert restored.extra_models[0].name == "draft-model"
+        assert restored.extra_models[1].name == "mtp-model"
+        assert restored.extra_models[1].revision == "main"
+
+    def test_round_trip_yaml_extra_models(self, sample_v2_recipe_data: dict):
+        """extra_models survive _serialize_yaml / _deserialize_yaml round-trip."""
+        data = {
+            **sample_v2_recipe_data,
+            "extra_models": ["draft-model"],
+        }
+        original = Recipe.from_dict(data)
+        restored = Recipe._deserialize_yaml(original._serialize_yaml())
+        assert len(restored.extra_models) == 1
+        assert restored.extra_models[0].name == "draft-model"
+
+    # --- export -------------------------------------------------------------------
+
+    def test_export_includes_extra_models(self, sample_v2_recipe_data: dict):
+        """Export dict includes extra_models when present."""
+        data = {
+            **sample_v2_recipe_data,
+            "extra_models": [
+                {"model": "draft-model", "revision": "abc123"},
+            ],
+        }
+        recipe = Recipe.from_dict(data)
+        exported = recipe.to_dict()
+        assert "extra_models" in exported
+        assert exported["extra_models"] == [{"model": "draft-model", "revision": "abc123"}]
+
+    def test_export_omits_empty_extra_models(self, sample_v2_recipe_data: dict):
+        """Export dict omits extra_models when empty."""
+        recipe = Recipe.from_dict(sample_v2_recipe_data)
+        exported = recipe.to_dict()
+        assert "extra_models" not in exported


### PR DESCRIPTION
Recipes can now declare additional models (e.g. draft models for speculative decoding) via `extra_models`, a list of strings or `{model, revision}` dicts. These are injected into the distribution config so they get synced alongside the main model to target hosts.

Example recipe:

recipe_version: '2'
model: Qwen/Qwen3.6-35B-A3B
extra_models:
  - z-lab/Qwen3.6-35B-A3B-DFlash
runtime: sglang
container: tonibagur/dgx-spark-sglang:0.5.11c
metadata:
  description: Qwen3.6 27B (upstream, FP8 quant) SGLang
  maintainer: scitrera.ai <open-source-team@scitrera.com>
defaults:
  port: 8000
  host: 0.0.0.0
  tensor_parallel: 8
  gpu_memory_utilization: 0.85
  max_model_len: 256000
  served_model_name: qwen3.6-27b
  attention_backend: triton
  reasoning_parser: qwen3
  tool_call_parser: qwen3_coder
  speculative_algo: NEXTN
  speculative_num_steps: 3
  speculative_eagle_topk: 1
  speculative_num_draft_tokens: 4
  fp8_gemm_backend: cutlass
command: |
  SGLANG_ENABLE_SPEC_V2=1 SGLANG_ENABLE_DFLASH_SPEC_V2=1 SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1 python3 -m sglang.launch_server \
      --model-path {model} \
      --served-model-name {served_model_name} \
      --context-length {max_model_len} \
      --mem-fraction-static {gpu_memory_utilization} \
      --tp-size {tensor_parallel} \
      --host {host} \
      --port {port} \
      --attention-backend {attention_backend} \
      --reasoning-parser {reasoning_parser} \
      --tool-call-parser {tool_call_parser} \
      --fp8-gemm-backend {fp8_gemm_backend} \
      --speculative-algorithm DFLASH \
      --speculative-draft-model-path z-lab/Qwen3.6-35B-A3B-DFlash \
      --speculative-num-draft-tokens 16 \
      --mamba-scheduler-strategy extra_buffer \
      --mem-fraction-static {gpu_memory_utilization} \
      --trust-remote-code
