### PR TITLE
v0.2.32 mods!

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,15 @@ dependencies = [
     "scitrera-app-framework==0.0.69",
     "vpd==0.9.13",
     "six==1.17.0", # transitive dependency of vpd but we pin the version for security reasons
-    "click==8.3.1",
+    "click==8.3.3",
     "pyyaml==6.0.3",
     "huggingface-hub==1.8.0",
-    "textual==8.1.1",
+    "textual==8.2.5",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest==9.0.2",
+    "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-asyncio==1.3.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.31"
+version = "0.2.32"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -1,325 +1,80 @@
 #!/usr/bin/env python3
-"""
-Synchronize version numbers across all sparkrun subprojects.
+"""Drop-in shim for scitrera-repo-tools `sync-versions`.
 
-Reads versions.yaml as the single source of truth and updates:
-  - pyproject.toml    (Python package)
-  - plugin.json       (Claude Code plugin)
-  - marketplace.json  (Claude Code marketplace registry)
+Copy this file into any repo's `scripts/` directory (or run it from anywhere)
+to sync versions defined in that repo's `versions.yaml`.
+
+Resolution order:
+
+  1. Package already importable in the current Python  ->  call directly
+     (fast path; exact version is whatever the current env has installed).
+
+  2. `uvx` (or `uv`) on PATH  ->  run via uvx with no persistent install.
+     Set `REPO_TOOLS_SOURCE` to override the package source. Default:
+     `git+https://github.com/scitrera/repo-tools.git`. Pin to a tag or
+     PyPI version, e.g.:
+         REPO_TOOLS_SOURCE='scitrera-repo-tools==0.1.0'
+
+  3. Otherwise  ->  print install instructions and exit 1.
 
 Usage:
-    python scripts/update-versions.py           # sync all versions
-    python scripts/update-versions.py --check   # dry-run: exit 1 if out of sync
-    python scripts/update-versions.py --verbose # show every file touched
+    python scripts/update-versions.py            # sync
+    python scripts/update-versions.py --check    # CI-friendly dry-run
+    python scripts/update-versions.py --verbose
+
+All flags pass through to `sync-versions`.
 """
 
 from __future__ import annotations
 
-import argparse
-import json
-import logging
-import re
+import os
+import shutil
 import sys
-from pathlib import Path
+from typing import List
 
-try:
-    import yaml
-except ImportError:
-    sys.exit("PyYAML is required.  Install it with:\n  pip install pyyaml\n  uv pip install pyyaml")
-
-logger = logging.getLogger("update-versions")
-
-# ---------------------------------------------------------------------------
-# Resolve paths
-# ---------------------------------------------------------------------------
-
-SCRIPT_DIR = Path(__file__).resolve().parent  # scripts/
-PROJECT_ROOT = SCRIPT_DIR.parent  # oss-sparkrun/
-VERSIONS_YAML = PROJECT_ROOT / "versions.yaml"
-
-# ---------------------------------------------------------------------------
-# Per-project update rules
-#
-# Each entry maps a versions.yaml key to the files that must be updated and
-# the strategy used.  Adding a new subproject only requires a new entry here.
-# ---------------------------------------------------------------------------
-
-# Strategies:
-#   pyproject    – rewrite `version = "X.Y.Z"` in [project] table
-#   package      – rewrite `"version": "X.Y.Z"` in JSON (package.json)
-#   plugin       – rewrite `"version": "X.Y.Z"` in plugin.json
-#   marketplace  – rewrite `"version"` for a matching plugin entry inside
-#                  a marketplace.json plugins array (matched by source path
-#                  containing the project directory name)
-#   init_py      – rewrite `__version__ = "X.Y.Z"` in a Python file
-
-# (strategy, path relative to PROJECT_ROOT, *optional extra args)
-UpdateRule = tuple  # (strategy, rel_path[, *extras])
-
-PROJECT_RULES: dict[str, list[UpdateRule]] = {
-    "sparkrun": [
-        ("pyproject", Path("pyproject.toml")),
-    ],
-    "sparkrun-cc-plugin": [
-        ("plugin", Path("sparkrun-cc-plugin/.claude-plugin/plugin.json")),
-        ("marketplace", Path(".claude-plugin/marketplace.json"), "sparkrun-cc-plugin"),
-    ],
-    "sparkrun-openclaw-plugin": [
-        ("package", Path("sparkrun-openclaw-plugin/package.json")),
-        ("plugin", Path("sparkrun-openclaw-plugin/openclaw.plugin.json")),
-    ],
-}
-
-# ---------------------------------------------------------------------------
-# Updaters — each returns (changed: bool, old_version: str | None)
-# ---------------------------------------------------------------------------
-
-# Matches: version = "1.2.3"  (with optional surrounding whitespace)
-_RE_PYPROJECT_VERSION = re.compile(r'^(\s*version\s*=\s*")[^"]*(")', re.MULTILINE)
-
-# Matches: __version__ = "1.2.3"  (single or double quotes)
-_RE_INIT_VERSION = re.compile(r"""^(\s*__version__\s*=\s*['"])[^'"]*(['"])""", re.MULTILINE)
+DEFAULT_SOURCE = "git+https://github.com/scitrera/repo-tools.git"
 
 
-def _read_text(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
+def _try_uvx(args: List[str]) -> None:
+    """Replace the current process with a uvx invocation.
 
-
-def _write_text(path: Path, content: str) -> None:
-    path.write_text(content, encoding="utf-8")
-
-
-def update_pyproject(path: Path, version: str, dry_run: bool) -> tuple[bool, str | None]:
-    """Update version = "..." in a pyproject.toml."""
-    text = _read_text(path)
-    m = _RE_PYPROJECT_VERSION.search(text)
-    if not m:
-        logger.warning("No version field found in %s", path)
-        return False, None
-
-    old = text[m.start(1) + len(m.group(1)) : m.end(2) - len(m.group(2))]
-    if old == version:
-        return False, old
-
-    new_text = _RE_PYPROJECT_VERSION.sub(rf"\g<1>{version}\2", text, count=1)
-    if not dry_run:
-        _write_text(path, new_text)
-    return True, old
-
-
-def update_init_py(path: Path, version: str, dry_run: bool) -> tuple[bool, str | None]:
-    """Update __version__ = '...' in a Python __init__.py."""
-    text = _read_text(path)
-    m = _RE_INIT_VERSION.search(text)
-    if not m:
-        logger.warning("No __version__ found in %s", path)
-        return False, None
-
-    old = text[m.start(1) + len(m.group(1)) : m.end(2) - len(m.group(2))]
-    if old == version:
-        return False, old
-
-    new_text = _RE_INIT_VERSION.sub(rf"\g<1>{version}\2", text, count=1)
-    if not dry_run:
-        _write_text(path, new_text)
-    return True, old
-
-
-def update_json_version(path: Path, version: str, dry_run: bool) -> tuple[bool, str | None]:
-    """Update "version" in a JSON file (package.json / plugin.json)."""
-    text = _read_text(path)
-    data = json.loads(text)
-    old = data.get("version")
-    if old == version:
-        return False, old
-
-    data["version"] = version
-
-    if not dry_run:
-        # Preserve 2-space indent and trailing newline (npm/node convention)
-        _write_text(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
-    return True, old
-
-
-def update_marketplace(
-    path: Path,
-    version: str,
-    dry_run: bool,
-    project_dir: str,
-) -> tuple[bool, str | None]:
-    """Update a plugin's version inside a marketplace.json plugins array.
-
-    Finds the plugin whose ``source`` field contains *project_dir* and
-    updates its ``version``.
+    Returns only if neither uvx nor uv is on PATH.
     """
-    text = _read_text(path)
-    data = json.loads(text)
-
-    plugins = data.get("plugins")
-    if not isinstance(plugins, list):
-        logger.warning("No 'plugins' array in %s", path)
-        return False, None
-
-    target = None
-    for entry in plugins:
-        source = entry.get("source", "")
-        if project_dir in source:
-            target = entry
-            break
-
-    if target is None:
-        logger.warning(
-            "No plugin with source containing '%s' in %s",
-            project_dir,
-            path,
-        )
-        return False, None
-
-    old = target.get("version")
-    if old == version:
-        return False, old
-
-    target["version"] = version
-
-    if not dry_run:
-        _write_text(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
-    return True, old
-
-
-STRATEGY_MAP = {
-    "pyproject": update_pyproject,
-    "init_py": update_init_py,
-    "package": update_json_version,
-    "plugin": update_json_version,
-    "marketplace": update_marketplace,
-}
-
-# ---------------------------------------------------------------------------
-# Semver validation
-# ---------------------------------------------------------------------------
-
-_RE_SEMVER = re.compile(
-    r"^\d+\.\d+\.\d+"  # major.minor.patch
-    r"(?:-[0-9A-Za-z.-]+)?"  # optional pre-release
-    r"(?:\+[0-9A-Za-z.-]+)?$"  # optional build metadata
-)
-
-
-def validate_version(version: str) -> bool:
-    return bool(_RE_SEMVER.match(version))
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-
-def load_versions() -> dict[str, str]:
-    """Load and validate versions.yaml."""
-    if not VERSIONS_YAML.exists():
-        sys.exit(f"versions.yaml not found at {VERSIONS_YAML}")
-
-    with open(VERSIONS_YAML, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-
-    if not isinstance(data, dict):
-        sys.exit(f"versions.yaml must be a YAML mapping, got {type(data).__name__}")
-
-    versions: dict[str, str] = {}
-    for key, val in data.items():
-        ver = str(val)
-        if not validate_version(ver):
-            sys.exit(f"Invalid semver for '{key}': {ver}")
-        versions[key] = ver
-
-    return versions
-
-
-def run(*, check: bool = False, verbose: bool = False) -> int:
-    """
-    Synchronize versions.  Returns 0 on success, 1 if --check finds drift.
-    """
-    versions = load_versions()
-    changes: list[str] = []
-    errors: list[str] = []
-
-    for project, target_version in sorted(versions.items()):
-        rules = PROJECT_RULES.get(project)
-        if rules is None:
-            errors.append(f"'{project}' is in versions.yaml but has no rules in update-versions.py — add an entry to PROJECT_RULES")
-            continue
-
-        for rule in rules:
-            strategy, rel_path = rule[0], rule[1]
-            extras = rule[2:]  # additional args for strategies that need them
-            abs_path = PROJECT_ROOT / rel_path
-            if not abs_path.exists():
-                errors.append(f"File not found: {abs_path}")
-                continue
-
-            updater = STRATEGY_MAP[strategy]
-            changed, old_version = updater(abs_path, target_version, check, *extras)
-
-            if changed:
-                msg = f"  {rel_path}: {old_version} -> {target_version}"
-                changes.append(msg)
-                if verbose or check:
-                    logger.info(msg)
-            elif verbose:
-                logger.info("  %s: already %s", rel_path, target_version)
-
-    # Report
-    if errors:
-        logger.error("Errors encountered:")
-        for e in errors:
-            logger.error("  %s", e)
-
-    if check:
-        if changes:
-            logger.error("Version drift detected (%d file(s) out of sync):", len(changes))
-            for c in changes:
-                logger.error(c)
-            return 1
-        else:
-            logger.info("All versions in sync.")
-            return 0
-
-    if changes:
-        logger.info("Updated %d file(s):", len(changes))
-        for c in changes:
-            logger.info(c)
+    uv = shutil.which("uvx") or shutil.which("uv")
+    if uv is None:
+        return
+    source = os.environ.get("REPO_TOOLS_SOURCE", DEFAULT_SOURCE)
+    name = os.path.basename(uv)
+    if name == "uv":
+        cmd = [uv, "tool", "run", "--from", source, "sync-versions", *args]
     else:
-        logger.info("All versions already in sync — nothing to update.")
-
-    if errors:
-        return 1
-    return 0
+        cmd = [uv, "--from", source, "sync-versions", *args]
+    os.execvp(cmd[0], cmd)  # never returns
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Synchronize subproject versions from versions.yaml",
+def _try_import(args: List[str]) -> bool:
+    try:
+        from scitrera_repo_tools.version_sync.cli import main as sync_main
+    except ImportError:
+        return False
+    sys.argv = ["sync-versions", *args]
+    sync_main()
+    return True
+
+
+def main(argv: List[str]) -> int:
+    if _try_import(argv):
+        return 0
+    _try_uvx(argv)  # never returns if uvx/uv is on PATH
+    source = os.environ.get("REPO_TOOLS_SOURCE", DEFAULT_SOURCE)
+    sys.stderr.write(
+        "scitrera-repo-tools is not available.\n"
+        "Install one of:\n"
+        f"  uv tool install --from {source} scitrera-repo-tools\n"
+        f"  pip install {source}\n"
     )
-    parser.add_argument(
-        "--check",
-        action="store_true",
-        help="Dry-run: report drift and exit 1 if any file is out of sync",
-    )
-    parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Show every file inspected, not just changes",
-    )
-    args = parser.parse_args()
-
-    logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(message)s",
-    )
-
-    sys.exit(run(check=args.check, verbose=args.verbose))
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main(sys.argv[1:]))

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -108,12 +108,13 @@ def _fetch_upstream_wheel_hashes() -> dict[str, str]:
 
 
 class EugrBuilder(BuilderPlugin):
-    """Builder for eugr-style container images with mod support.
+    """Builder for eugr-style container images.
 
-    Handles:
-    - Building container images via eugr's ``build-and-copy.sh``
-    - Converting recipe ``mods`` into ``pre_exec`` entries for the
-      hooks system to execute at container launch time.
+    Builds container images via eugr's ``build-and-copy.sh``.
+
+    Note: generic mod support (recipe ``mods:`` → ``pre_exec`` entries)
+    is handled centrally by :mod:`sparkrun.core.mods`, not by this
+    builder.
     """
 
     builder_name = "eugr"
@@ -136,12 +137,10 @@ class EugrBuilder(BuilderPlugin):
         transfer_mode: str = "local",
         ssh_kwargs: dict | None = None,
     ) -> str:
-        """Build container image and inject mod pre_exec commands.
+        """Build the eugr container image when needed.
 
         If the recipe has ``build_args`` in runtime_config, builds
-        the container via eugr's ``build-and-copy.sh``.  If the recipe
-        has ``mods``, converts them to ``pre_exec`` entries that the
-        hook system will execute at container launch time.
+        the container via eugr's ``build-and-copy.sh``.
 
         In delegated mode (``transfer_mode="delegated"``), the build
         and repo clone happen on the **head node** via SSH rather than
@@ -163,8 +162,6 @@ class EugrBuilder(BuilderPlugin):
         logger.debug("eugr prepare_image: transfer_mode=%s, delegated=%s", transfer_mode, delegated)
         head = hosts[0] if hosts else "localhost"
         build_args = recipe.runtime_config.get("build_args", [])
-        mods = recipe.runtime_config.get("mods", [])
-        has_mods = bool(mods)
         needs_build = False  # assume False at first
 
         # ~~ SPECIAL CASES: map pullable eugr nightly images to use direct build ~~~
@@ -208,14 +205,14 @@ class EugrBuilder(BuilderPlugin):
                 else:
                     logger.info("image '%s' not found locally; will build", image)
 
-        # nothing eugr-specific to prepare -- no build, no mods
-        if not needs_build and not has_mods:
+        # nothing eugr-specific to prepare -- no build
+        if not needs_build:
             return image
 
         # Resolve optional branch override from builder_config
         branch = recipe.builder_config.get("branch") if recipe.builder_config else None
 
-        # Ensure repo is available (for build script and/or mods)
+        # Ensure repo is available (for build script)
         if delegated:
             remote_repo = self._ensure_repo_remote(head, ssh_kwargs, dry_run=dry_run, branch=branch)
             self._repo_dir = Path(remote_repo)
@@ -246,11 +243,6 @@ class EugrBuilder(BuilderPlugin):
                 self._build_image(image, build_args, dry_run)
                 if not dry_run:
                     self._save_build_metadata(image, build_args, config)
-
-        # Convert mods to pre_exec entries
-        if has_mods:
-            source_host = head if delegated else None
-            self._inject_mod_pre_exec(recipe, mods, source_host=source_host)
 
         # TODO: potentially inject metadata flags as needed into recipe?
         return image
@@ -477,54 +469,6 @@ class EugrBuilder(BuilderPlugin):
             return resolved
 
         return None
-
-    # --- Mod -> pre_exec conversion ---
-
-    def _inject_mod_pre_exec(
-        self,
-        recipe: Recipe,
-        mods: list[str],
-        source_host: str | None = None,
-    ) -> None:
-        """Convert mod entries to pre_exec commands on the recipe.
-
-        Each mod is a directory containing a ``run.sh`` script.  The
-        conversion produces two pre_exec entries per mod:
-        1. A dict with ``copy`` key — file injection via docker cp
-        2. A string — execute run.sh inside the container
-
-        Args:
-            recipe: Recipe instance (pre_exec list is mutated).
-            mods: List of mod directory names relative to repo root.
-            source_host: When set (delegated mode), the ``copy`` entry
-                gets a ``source_host`` key so the hooks system knows
-                where the source files live.
-        """
-        if not self._repo_dir:
-            logger.warning("Cannot inject mods without a repo dir")
-            return
-
-        for mod_name in mods:
-            # Strip leading 'mods/' if present — recipes may specify either
-            # "fix-something" or "mods/fix-something"; normalise to avoid
-            # doubling the path component.
-            clean_name = mod_name.removeprefix("mods/")
-            mod_path = self._repo_dir / "mods" / clean_name
-            mod_basename = Path(clean_name).name
-            dest = "/workspace/mods/%s" % mod_basename
-
-            # Add copy entry (docker cp source into container)
-            copy_entry: dict[str, str] = {
-                "copy": str(mod_path),
-                "dest": dest,
-            }
-            if source_host is not None:
-                copy_entry["source_host"] = source_host
-            recipe.pre_exec.append(copy_entry)
-            # Add exec entry (run the mod script with WORKSPACE_DIR set)
-            recipe.pre_exec.append("export WORKSPACE_DIR=$PWD && cd %s && chmod +x run.sh && ./run.sh" % dest)
-
-        logger.info("Injected %d mod(s) as pre_exec entries", len(mods))
 
     # --- Build cache ---
 

--- a/src/sparkrun/cli/_adv.py
+++ b/src/sparkrun/cli/_adv.py
@@ -39,8 +39,8 @@ def adv_compare_images(ctx, image, hosts, hosts_file, cluster_name, dry_run, out
       sparkrun adv compare-images myimage:latest --cluster mylab
       sparkrun adv compare-images sparkrun-eugr-vllm-tf5 --hosts 192.168.11.13
     """
-    from sparkrun.containers.distribute import _check_remote_image_ids
-    from sparkrun.containers.registry import get_image_id
+    from sparkrun.containers.distribute import _check_remote_image_identities, _images_match
+    from sparkrun.containers.registry import get_image_identity
     from sparkrun.orchestration.primitives import build_ssh_kwargs
 
     sctx = _get_context(ctx)
@@ -52,11 +52,11 @@ def adv_compare_images(ctx, image, hosts, hosts_file, cluster_name, dry_run, out
         click.echo("[dry-run] Would compare image '%s' across local + %d host(s)" % (image, len(host_list)))
         return
 
-    # Local image ID
-    local_id = get_image_id(image)
+    # Local image identity (Id + RepoDigests)
+    local_id, local_digests = get_image_identity(image)
 
-    # Remote image IDs
-    remote_ids = _check_remote_image_ids(
+    # Remote image identities
+    remote_identities = _check_remote_image_identities(
         image,
         host_list,
         ssh_user=ssh_kwargs.get("ssh_user"),
@@ -68,20 +68,38 @@ def adv_compare_images(ctx, image, hosts, hosts_file, cluster_name, dry_run, out
         print_json(
             {
                 "image": image,
-                "local": local_id,
-                "hosts": {h: remote_ids.get(h) for h in host_list},
+                "local": {"id": local_id, "repo_digests": local_digests},
+                "hosts": {
+                    h: ({"id": remote_identities[h][0], "repo_digests": remote_identities[h][1]} if h in remote_identities else None)
+                    for h in host_list
+                },
             }
         )
         return
 
     # Table output
+    def _short(s: str | None) -> str:
+        if not s:
+            return "(not found)"
+        # Trim sha256: prefix and keep first 12 hex chars to keep the row compact
+        return s.split(":", 1)[-1][:12] if s.startswith("sha256:") else s
+
+    def _short_digest(digests: list[str]) -> str:
+        if not digests:
+            return "(none)"
+        sha = digests[0].rsplit("@", 1)[-1]
+        return _short(sha) if sha.startswith("sha256:") else sha
+
     click.echo("Image: %s\n" % image)
-    click.echo("  %-40s %s" % ("Host", "Image ID"))
-    click.echo("  " + "-" * 110)
-    click.echo("  %-40s %s" % ("(local)", local_id or "(not found)"))
+    click.echo("  %-32s  %-14s  %-14s  %s" % ("Host", "Image ID", "RepoDigest", "Match"))
+    click.echo("  " + "-" * 80)
+    click.echo("  %-32s  %-14s  %-14s  %s" % ("(local)", _short(local_id), _short_digest(local_digests), "-"))
     for h in host_list:
-        rid = remote_ids.get(h)
-        match = ""
-        if rid and local_id:
-            match = "  ✓ match" if rid == local_id else "  ✗ MISMATCH"
-        click.echo("  %-40s %s%s" % (h, rid or "(not found)", match))
+        r_id, r_digests = remote_identities.get(h, (None, []))
+        if r_id is None and not r_digests:
+            match = "(not found)"
+        elif _images_match(local_id, local_digests, r_id, r_digests):
+            match = "✓ match"
+        else:
+            match = "✗ MISMATCH"
+        click.echo("  %-32s  %-14s  %-14s  %s" % (h, _short(r_id), _short_digest(r_digests), match))

--- a/src/sparkrun/cli/_cluster.py
+++ b/src/sparkrun/cli/_cluster.py
@@ -837,7 +837,7 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
     # Resolve auto transfer mode to a concrete value
     from sparkrun.orchestration.distribution import resolve_auto_transfer_mode
 
-    xfer_result = resolve_auto_transfer_mode(xfer_mode, host_list, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
+    xfer_result = resolve_auto_transfer_mode(xfer_mode, host_list, ssh_kwargs=ssh_kwargs, dry_run=dry_run, topology=cluster_cfg.topology)
     resolved_mode = xfer_result.mode
 
     # Detect IB / NCCL env — reuse from transfer mode resolution if available,

--- a/src/sparkrun/cli/_common.py
+++ b/src/sparkrun/cli/_common.py
@@ -869,6 +869,13 @@ def _apply_recipe_overrides(
         if v is not None:
             overrides[k] = v
 
+    # Apply env.* overrides to recipe.env directly
+    if recipe is not None:
+        for k, v in list(overrides.items()):
+            if k.startswith("env."):
+                recipe.env[k[4:]] = str(v)
+                del overrides[k]
+
     # Resolve runtime with overrides visible to resolvers
     if recipe is not None:
         recipe.resolve(overrides)

--- a/src/sparkrun/containers/distribute.py
+++ b/src/sparkrun/containers/distribute.py
@@ -6,13 +6,15 @@ to targets via ``docker save | ssh … docker load``.
 
 A hash check (comparing Docker image IDs) is performed before each
 transfer so hosts that already have the correct image are skipped.
+
+# TODO: [FUTURE]: allow alternatives to docker!
 """
 
 from __future__ import annotations
 
 import logging
 
-from sparkrun.containers.registry import ensure_image, get_image_id
+from sparkrun.containers.registry import ensure_image, get_image_identity
 from sparkrun.orchestration.primitives import map_transfer_failures
 from sparkrun.orchestration.ssh import (
     RemoteResult,
@@ -27,19 +29,69 @@ from sparkrun.core.progress import PROGRESS
 
 logger = logging.getLogger(__name__)
 
-# Command to get a Docker image ID on a remote host (empty output = not present)
-_REMOTE_IMAGE_ID_CMD = "docker image inspect --format '{{{{.Id}}}}' {image} 2>/dev/null || true"
+# Command to get a Docker image identity (Id + RepoDigests) on a remote host.
+# Empty output = image not present.  Output shape after substitution:
+#     <sha256:id>|<repo1@sha256:dig> <repo2@sha256:dig> ...
+_REMOTE_IMAGE_IDENTITY_CMD = (
+    "docker image inspect --format '{{{{.Id}}}}|{{{{range .RepoDigests}}}}{{{{.}}}} {{{{end}}}}' {image} 2>/dev/null || true"
+)
 
 
-def _check_remote_image_ids(
+def _parse_identity(raw: str) -> tuple[str | None, list[str]]:
+    """Parse the output of ``_REMOTE_IMAGE_IDENTITY_CMD``.
+
+    Returns ``(image_id, repo_digests)``.  ``image_id`` is ``None`` when
+    the image is absent (empty output).
+    """
+    raw = raw.strip()
+    if not raw:
+        return None, []
+    image_id, _, digests_str = raw.partition("|")
+    return (image_id or None), digests_str.split()
+
+
+def _digest_shas(repo_digests: list[str]) -> set[str]:
+    """Extract the bare ``sha256:...`` portion from each repo digest.
+
+    A RepoDigest has the form ``repo@sha256:hex``.  Comparing on just the
+    digest portion makes two images count as identical even when tagged
+    under different repository names (e.g. mirrored registries).
+    """
+    return {d.rsplit("@", 1)[-1] for d in repo_digests if "@" in d}
+
+
+def _images_match(
+    local_id: str | None,
+    local_digests: list[str],
+    remote_id: str | None,
+    remote_digests: list[str],
+) -> bool:
+    """Decide whether two image identities refer to the same image.
+
+    Match if **either** the image IDs are equal **or** any RepoDigest sha
+    is shared.  Image IDs vary across hosts with different Docker storage
+    drivers (issue #152), so RepoDigests are the storage-driver-agnostic
+    signal.  RepoDigests are absent for locally-built/save-loaded images,
+    so we keep Id equality as a fallback.
+    """
+    if not remote_id and not remote_digests:
+        return False
+    if local_id and remote_id and local_id == remote_id:
+        return True
+    local_shas = _digest_shas(local_digests)
+    remote_shas = _digest_shas(remote_digests)
+    return bool(local_shas & remote_shas)
+
+
+def _check_remote_image_identities(
     image: str,
     hosts: list[str],
     ssh_user: str | None = None,
     ssh_key: str | None = None,
     ssh_options: list[str] | None = None,
     dry_run: bool = False,
-) -> dict[str, str]:
-    """Check the Docker image ID on multiple remote hosts.
+) -> dict[str, tuple[str | None, list[str]]]:
+    """Check the Docker image identity (Id + RepoDigests) on multiple hosts.
 
     Args:
         image: Image reference to check.
@@ -50,17 +102,16 @@ def _check_remote_image_ids(
         dry_run: If True, return empty dict (skip checks).
 
     Returns:
-        Mapping of host → remote image ID.  Missing hosts or hosts
-        where the image is absent are omitted.
+        Mapping of host → ``(image_id, repo_digests)``.  Hosts where the
+        image is absent or the SSH command failed are omitted.
     """
     if dry_run or not hosts:
         return {}
 
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    # TODO: bypasses executor
-    cmd = _REMOTE_IMAGE_ID_CMD.format(image=quote(image))
-    result_map: dict[str, str] = {}
+    cmd = _REMOTE_IMAGE_IDENTITY_CMD.format(image=quote(image))
+    result_map: dict[str, tuple[str | None, list[str]]] = {}
 
     with ThreadPoolExecutor(max_workers=len(hosts)) as executor:
         futures = {
@@ -77,10 +128,19 @@ def _check_remote_image_ids(
         }
         for future in as_completed(futures):
             result: RemoteResult = future.result()
-            remote_id = result.stdout.strip()
-            logger.debug("  %s: remote image ID = %s", result.host, remote_id or "(empty)")
-            if result.success and remote_id:
-                result_map[result.host] = remote_id
+            if not result.success:
+                logger.debug("  %s: identity check failed (rc=%s)", result.host, result.returncode)
+                continue
+            image_id, repo_digests = _parse_identity(result.stdout)
+            logger.debug(
+                "  %s: remote id=%s digests=%s",
+                result.host,
+                image_id or "(absent)",
+                repo_digests or "(none)",
+            )
+            if image_id is None and not repo_digests:
+                continue
+            result_map[result.host] = (image_id, repo_digests)
 
     return result_map
 
@@ -89,6 +149,7 @@ def _filter_hosts_needing_image(
     image: str,
     hosts: list[str],
     local_image_id: str | None,
+    local_repo_digests: list[str] | None = None,
     ssh_user: str | None = None,
     ssh_key: str | None = None,
     ssh_options: list[str] | None = None,
@@ -96,27 +157,36 @@ def _filter_hosts_needing_image(
 ) -> list[str]:
     """Return the subset of hosts that need the image transferred.
 
-    Compares the local image ID with each remote host's image ID.
-    Hosts where the IDs match are skipped.
+    Compares the local image identity (Id + RepoDigests) with each remote
+    host's identity.  Hosts whose images match are skipped.  RepoDigest
+    overlap is preferred because Docker image IDs differ across hosts that
+    use different storage drivers (issue #152); Id equality is the
+    fallback for locally-built/save-loaded images that lack RepoDigests.
 
     Args:
         image: Image reference.
         hosts: Candidate target hosts.
-        local_image_id: Local Docker image ID (from :func:`get_image_id`).
+        local_image_id: Local Docker image ID (from
+            :func:`get_image_identity`).
+        local_repo_digests: Local RepoDigests (from
+            :func:`get_image_identity`).
         ssh_user: Optional SSH username.
         ssh_key: Optional path to SSH private key.
         ssh_options: Additional SSH options.
         dry_run: If True, return all hosts (no filtering).
 
     Returns:
-        List of hosts that need the image (IDs differ or image absent).
+        List of hosts that need the image.
     """
-    if dry_run or not local_image_id or not hosts:
+    if dry_run or not hosts:
+        return list(hosts)
+    if not local_image_id and not local_repo_digests:
         return list(hosts)
 
-    logger.debug("Local image ID for '%s': %s", image, local_image_id)
+    local_digests = local_repo_digests or []
+    logger.debug("Local image '%s' id=%s digests=%s", image, local_image_id, local_digests)
 
-    remote_ids = _check_remote_image_ids(
+    remote_identities = _check_remote_image_identities(
         image,
         hosts,
         ssh_user=ssh_user,
@@ -126,13 +196,20 @@ def _filter_hosts_needing_image(
 
     needs_transfer = []
     for host in hosts:
-        remote_id = remote_ids.get(host)
-        if remote_id == local_image_id:
-            logger.info("  %s: image up-to-date, skipping", host)
+        remote_id, remote_digests = remote_identities.get(host, (None, []))
+        if _images_match(local_image_id, local_digests, remote_id, remote_digests):
+            reason = "digest match" if _digest_shas(local_digests) & _digest_shas(remote_digests) else "id match"
+            logger.info("  %s: image up-to-date (%s), skipping", host, reason)
         else:
-            if remote_id:
-                logger.info("  %s: image ID mismatch, will transfer", host)
-                logger.debug("    local_id=%s  remote_id=%s", local_image_id, remote_id)
+            if remote_id or remote_digests:
+                logger.info("  %s: image mismatch, will transfer", host)
+                logger.debug(
+                    "    local: id=%s digests=%s | remote: id=%s digests=%s",
+                    local_image_id,
+                    local_digests,
+                    remote_id,
+                    remote_digests,
+                )
             else:
                 logger.info("  %s: image not present, will transfer", host)
             needs_transfer.append(host)
@@ -194,13 +271,14 @@ def distribute_image_from_local(
 
     xfer = transfer_hosts or hosts
 
-    # Step 2: hash check — skip hosts that already have the correct image
-    local_id = get_image_id(image) if not dry_run else None
+    # Step 2: identity check — skip hosts that already have the correct image
+    local_id, local_digests = get_image_identity(image) if not dry_run else (None, [])
 
     needs_transfer = _filter_hosts_needing_image(
         image,
         xfer,
         local_id,
+        local_repo_digests=local_digests,
         ssh_user=ssh_user,
         ssh_key=ssh_key,
         ssh_options=ssh_options,
@@ -276,17 +354,22 @@ def distribute_image_from_head(
 
     # Pre-check image status on all hosts to avoid unnecessary work
     if not dry_run:
-        remote_ids = _check_remote_image_ids(
+        remote_identities = _check_remote_image_identities(
             image,
             hosts,
             ssh_user=ssh_user,
             ssh_key=ssh_key,
             ssh_options=ssh_options,
         )
-        ref_id = remote_ids.get(head)
-        if ref_id:
+        ref = remote_identities.get(head)
+        if ref:
+            ref_id, ref_digests = ref
             # Head already has the image — check which workers need it
-            needs_transfer = [h for h in hosts if remote_ids.get(h) != ref_id]
+            needs_transfer = []
+            for h in hosts:
+                r_id, r_digests = remote_identities.get(h, (None, []))
+                if not _images_match(ref_id, ref_digests, r_id, r_digests):
+                    needs_transfer.append(h)
             if not needs_transfer:
                 logger.log(PROGRESS, "  Container image up-to-date on all %d host(s)", len(hosts))
                 return []

--- a/src/sparkrun/containers/registry.py
+++ b/src/sparkrun/containers/registry.py
@@ -1,4 +1,9 @@
-"""Container image registry operations."""
+"""
+Container image registry operations.
+
+# TODO: [FUTURE]: allow alternatives to docker!
+
+"""
 
 from __future__ import annotations
 
@@ -50,8 +55,51 @@ def image_exists_locally(image: str) -> bool:
     return result.returncode == 0
 
 
+def get_image_identity(image: str) -> tuple[str | None, list[str]]:
+    """Get the Docker image ID and RepoDigests for a local image.
+
+    Image IDs are derived from the *local* image configuration and so vary
+    across hosts that use different Docker storage drivers (e.g. overlay2
+    vs the containerd overlayfs snapshotter), even for the same registry
+    image.  RepoDigests, by contrast, encode the registry manifest hash and
+    are stable across storage drivers — but they are absent for images that
+    were built locally and never pushed, or that were transferred via
+    ``docker save | docker load``.
+
+    Args:
+        image: Image reference to inspect.
+
+    Returns:
+        Tuple ``(image_id, repo_digests)``.  ``image_id`` is
+        ``"sha256:abc..."`` or ``None`` if the image is not present
+        locally.  ``repo_digests`` is the list of ``"repo@sha256:..."``
+        entries (possibly empty).
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            "{{.Id}}|{{range .RepoDigests}}{{.}} {{end}}",
+            image,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None, []
+    image_id, _, digests_str = result.stdout.strip().partition("|")
+    digests = digests_str.split()
+    return (image_id or None), digests
+
+
 def get_image_id(image: str) -> str | None:
-    """Get the Docker image ID (digest) for a local image.
+    """Get the Docker image ID for a local image.
+
+    Convenience wrapper around :func:`get_image_identity` that returns only
+    the image ID.  Prefer :func:`get_image_identity` when comparing images
+    across hosts that may have differing Docker storage drivers.
 
     Args:
         image: Image reference to inspect.
@@ -60,14 +108,7 @@ def get_image_id(image: str) -> str | None:
         Image ID string (e.g. ``"sha256:abc123..."``) or None if the
         image does not exist locally.
     """
-    result = subprocess.run(
-        ["docker", "image", "inspect", "--format", "{{.Id}}", image],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip()
+    return get_image_identity(image)[0]
 
 
 def ensure_image(image: str, dry_run: bool = False) -> int:

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -233,6 +233,27 @@ def launch_inference(
     # Resolve container image
     container_image = runtime.resolve_container(recipe, overrides)
 
+    # Resolve recipe.mods to pre_exec entries (builder-agnostic).
+    # Part of preparation — surfaces resolution failures before any
+    # builder/distribution work, and keeps the builder ignorant of mods.
+    if recipe.mods:
+        if registry_mgr is None and config is not None:
+            registry_mgr = config.get_registry_manager()
+        if registry_mgr is not None:
+            from sparkrun.core.mods import resolve_and_inject_mods
+
+            resolve_and_inject_mods(
+                recipe,
+                registry_mgr,
+                config=config,
+                transfer_mode=effective_transfer_mode,
+                head=host_list[0] if host_list else None,
+                ssh_kwargs=ssh_kwargs,
+                dry_run=dry_run,
+            )
+        else:
+            logger.warning("Cannot resolve recipe.mods: no RegistryManager available")
+
     if p:
         p.phase_end()
 

--- a/src/sparkrun/core/mods.py
+++ b/src/sparkrun/core/mods.py
@@ -1,0 +1,423 @@
+"""Generic mod resolution and pre_exec injection.
+
+A "mod" is a directory containing a ``run.sh`` script (plus any
+supporting files such as patches or templates) that gets copied into a
+container and executed before the serve command. Mods are a
+builder/runtime-agnostic mechanism for small, named container tweaks.
+
+For each ``mods:`` entry on a recipe, the resolver searches in this
+order and uses the first hit:
+
+1. **Explicit scoped reference** — ``@registry/<rel>`` resolves under
+   that registry's configured ``mods_subpath``.
+2. **Adjacent to the recipe file** — tries ``<rel>`` and ``mods/<rel>``
+   relative to ``dirname(recipe.source_path)``.
+3. **Same registry as the recipe** — uses ``recipe.source_registry``
+   plus that registry's ``mods_subpath``.
+4. **Eugr fallback** — falls back to the registry literally named
+   ``eugr`` (the original source of truth for mods).
+
+A leading ``mods/`` prefix is stripped during normalization, so
+``fix-foo`` and ``mods/fix-foo`` resolve identically.
+
+Each resolved mod produces two ``pre_exec`` entries on the recipe (the
+same shape the eugr builder used historically):
+
+* a ``copy`` dict that the hooks system materializes via ``docker cp``
+  (optionally with ``source_host`` for delegated-mode head-node sources),
+* an exec string that runs ``./run.sh`` inside the container with
+  ``WORKSPACE_DIR=$PWD``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from sparkrun.orchestration.ssh import run_rsync
+from sparkrun.utils import parse_scoped_name
+
+if TYPE_CHECKING:
+    from sparkrun.core.config import SparkrunConfig
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.core.registry import RegistryManager
+
+logger = logging.getLogger(__name__)
+
+EUGR_FALLBACK_REGISTRY = "eugr"
+_CONTAINER_MODS_BASE = "/workspace/mods"
+_HEAD_STAGING_BASE = "~/.cache/sparkrun/mods-staging"
+
+
+class ModNotFoundError(Exception):
+    """Raised when a mod reference cannot be resolved to a source path.
+
+    Attributes:
+        name: The original (un-normalized) mod reference.
+        tried: Filesystem paths the resolver attempted.
+    """
+
+    def __init__(self, name: str, tried: list[str]) -> None:
+        self.name = name
+        self.tried = tried
+        tried_lines = "\n  ".join(tried) if tried else "(no candidate paths)"
+        super().__init__("Could not resolve mod %r. Tried:\n  %s" % (name, tried_lines))
+
+
+@dataclass
+class ResolvedMod:
+    """A mod reference resolved to a concrete source location.
+
+    Attributes:
+        name: Basename used as the in-container directory under
+            ``/workspace/mods/<name>``.
+        source_path: Absolute path on the source host.
+        source_host: Hostname owning ``source_path``; ``None`` means the
+            local control machine.
+    """
+
+    name: str
+    source_path: str
+    source_host: str | None
+
+
+def _normalize_ref(ref: str) -> str:
+    """Strip a single leading ``mods/`` from a mod reference."""
+    return ref.removeprefix("mods/")
+
+
+def _mod_dir_if_valid(path: Path) -> Path | None:
+    """Return *path* if it looks like a mod directory (has a ``run.sh``)."""
+    if path.is_dir() and (path / "run.sh").exists():
+        return path
+    return None
+
+
+def _resolve_scoped(
+    ref: str,
+    registry_mgr: RegistryManager,
+    tried: list[str],
+) -> Path | None:
+    """Resolve an ``@registry/...`` reference to a control-machine path."""
+    registry_name, rel = parse_scoped_name(ref)
+    if registry_name is None:
+        return None
+    try:
+        entry = registry_mgr.get_registry(registry_name)
+    except Exception:
+        tried.append("@%s (registry not found)" % registry_name)
+        return None
+    if not entry.mods_subpath:
+        tried.append("@%s (no mods_subpath configured)" % registry_name)
+        return None
+    cache_dir = registry_mgr._cache_dir(entry.name)
+    rel_clean = _normalize_ref(rel)
+    candidate = cache_dir / entry.mods_subpath / rel_clean
+    tried.append(str(candidate))
+    return _mod_dir_if_valid(candidate)
+
+
+def _resolve_adjacent(
+    ref: str,
+    recipe_source_path: str | None,
+    tried: list[str],
+) -> Path | None:
+    """Resolve a mod adjacent to the recipe file on the control machine."""
+    if not recipe_source_path:
+        return None
+    base = Path(recipe_source_path).parent
+    rel_clean = _normalize_ref(ref)
+    for candidate in (base / rel_clean, base / "mods" / rel_clean):
+        tried.append(str(candidate))
+        hit = _mod_dir_if_valid(candidate)
+        if hit is not None:
+            return hit
+    return None
+
+
+def _resolve_in_registry(
+    ref: str,
+    registry_name: str | None,
+    registry_mgr: RegistryManager,
+    tried: list[str],
+    *,
+    default_subpath: str | None = None,
+    sync_if_missing: bool = False,
+) -> Path | None:
+    """Resolve a mod inside a specific registry's ``mods_subpath``.
+
+    Args:
+        default_subpath: Used when the registry entry has no
+            ``mods_subpath`` configured. Lets the eugr fallback work for
+            legacy ``registries.yaml`` files that predate the field.
+        sync_if_missing: If True and the candidate path doesn't exist,
+            trigger a registry clone/pull and re-check. Used for the
+            eugr fallback so users don't have to manually sync.
+    """
+    if not registry_name:
+        return None
+    try:
+        entry = registry_mgr.get_registry(registry_name)
+    except Exception:
+        tried.append("@%s (registry not registered)" % registry_name)
+        return None
+    mods_subpath = entry.mods_subpath or default_subpath
+    if not mods_subpath:
+        tried.append("@%s (no mods_subpath configured)" % registry_name)
+        return None
+    cache_dir = registry_mgr._cache_dir(entry.name)
+    rel_clean = _normalize_ref(ref)
+    candidate = cache_dir / mods_subpath / rel_clean
+    tried.append(str(candidate))
+    hit = _mod_dir_if_valid(candidate)
+    if hit is not None:
+        return hit
+    if sync_if_missing:
+        # Pass an entry with mods_subpath populated so the sparse-checkout
+        # actually fetches the mods directory — legacy registries.yaml
+        # entries without mods_subpath would otherwise pull only the
+        # recipe subpath and the mod files would stay absent.
+        if not entry.mods_subpath:
+            from dataclasses import replace
+
+            sync_entry = replace(entry, mods_subpath=mods_subpath)
+        else:
+            sync_entry = entry
+        try:
+            registry_mgr._clone_or_pull(sync_entry)
+        except Exception as exc:
+            tried.append("@%s sync failed: %s" % (registry_name, exc))
+            return None
+        hit = _mod_dir_if_valid(candidate)
+        if hit is not None:
+            return hit
+        tried.append("@%s sync completed but mod still missing at %s" % (registry_name, candidate))
+    return None
+
+
+def _build_pre_exec_entries(resolved: ResolvedMod) -> list:
+    """Return the (copy, exec) pre_exec pair for a resolved mod."""
+    dest = "%s/%s" % (_CONTAINER_MODS_BASE, resolved.name)
+    copy_entry: dict[str, str] = {"copy": resolved.source_path, "dest": dest}
+    if resolved.source_host is not None:
+        copy_entry["source_host"] = resolved.source_host
+    exec_entry = "export WORKSPACE_DIR=$PWD && cd %s && chmod +x run.sh && ./run.sh" % dest
+    return [copy_entry, exec_entry]
+
+
+def _resolve_local(
+    ref: str,
+    recipe: Recipe,
+    registry_mgr: RegistryManager,
+) -> ResolvedMod:
+    """Resolve a mod reference to a control-machine path (no SSH).
+
+    Raises ``ModNotFoundError`` on miss. Caller is responsible for
+    transferring the result to a remote host if required.
+    """
+    tried: list[str] = []
+
+    hit = _resolve_scoped(ref, registry_mgr, tried)
+    if hit is None:
+        hit = _resolve_adjacent(ref, recipe.source_path, tried)
+    if hit is None and parse_scoped_name(ref)[0] is None:
+        # rule 3: same registry as the recipe (skipped for explicit @scoped refs)
+        hit = _resolve_in_registry(ref, recipe.source_registry, registry_mgr, tried)
+    if hit is None and parse_scoped_name(ref)[0] is None:
+        # rule 4: eugr fallback (also skipped for explicit @scoped refs).
+        # Use "mods" as the default subpath even if the local registries.yaml
+        # predates the mods_subpath field, and sync the registry on demand
+        # so users don't have to pre-clone eugr just for mods.
+        hit = _resolve_in_registry(
+            ref,
+            EUGR_FALLBACK_REGISTRY,
+            registry_mgr,
+            tried,
+            default_subpath="mods",
+            sync_if_missing=True,
+        )
+    if hit is None:
+        raise ModNotFoundError(ref, tried)
+
+    return ResolvedMod(name=hit.name, source_path=str(hit.resolve()), source_host=None)
+
+
+def _rsync_to_head(
+    local_path: str,
+    name: str,
+    head: str,
+    ssh_kwargs: dict | None,
+    dry_run: bool,
+) -> str:
+    """Push a local mod directory to a deterministic staging dir on *head*.
+
+    Returns the head-side absolute path (with ``~`` left for shell to expand).
+    """
+    dest = "%s/%s" % (_HEAD_STAGING_BASE, name)
+    logger.info("Staging mod %r to %s:%s", name, head, dest)
+    kw = ssh_kwargs or {}
+    if dry_run:
+        return dest
+    result = run_rsync(
+        local_path,
+        head,
+        dest,
+        ssh_user=kw.get("ssh_user"),
+        ssh_key=kw.get("ssh_key"),
+        ssh_options=kw.get("ssh_options"),
+        timeout=120,
+    )
+    if not result.success:
+        raise RuntimeError("Failed to stage mod %r to %s: %s" % (name, head, result.stderr.strip() if result.stderr else "(no output)"))
+    return dest
+
+
+def _resolve_delegated(
+    ref: str,
+    recipe: Recipe,
+    registry_mgr: RegistryManager,
+    head: str,
+    ssh_kwargs: dict | None,
+    dry_run: bool,
+    ensured_registries: dict[str, str],
+) -> ResolvedMod:
+    """Resolve a mod for delegated mode: source files live on *head*.
+
+    Registry-backed mods are materialized via
+    ``RegistryManager.ensure_registry_on_host``; adjacent recipes' mods
+    are rsynced to a staging directory on the head node.
+    """
+
+    def _ensure_registry(name: str) -> str:
+        path = ensured_registries.get(name)
+        if path is None:
+            path = registry_mgr.ensure_registry_on_host(name, head, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
+            ensured_registries[name] = path
+        return path
+
+    # rule 1: explicit @registry/...
+    registry_name, rel = parse_scoped_name(ref)
+    if registry_name is not None:
+        try:
+            entry = registry_mgr.get_registry(registry_name)
+        except Exception as exc:
+            raise ModNotFoundError(ref, ["@%s (registry not found)" % registry_name]) from exc
+        if not entry.mods_subpath:
+            raise ModNotFoundError(ref, ["@%s (no mods_subpath configured)" % registry_name])
+        remote_root = _ensure_registry(registry_name)
+        rel_clean = _normalize_ref(rel)
+        remote_path = "%s/%s/%s" % (remote_root, entry.mods_subpath, rel_clean)
+        name = Path(rel_clean).name
+        return ResolvedMod(name=name, source_path=remote_path, source_host=head)
+
+    # rule 2: adjacent to recipe (local) -> rsync to head
+    tried: list[str] = []
+    local_hit = _resolve_adjacent(ref, recipe.source_path, tried)
+    if local_hit is not None:
+        staged = _rsync_to_head(str(local_hit.resolve()), local_hit.name, head, ssh_kwargs, dry_run)
+        return ResolvedMod(name=local_hit.name, source_path=staged, source_host=head)
+
+    # rule 3: same registry as recipe
+    if recipe.source_registry:
+        try:
+            entry = registry_mgr.get_registry(recipe.source_registry)
+        except Exception:
+            entry = None
+        if entry is not None and entry.mods_subpath:
+            remote_root = _ensure_registry(recipe.source_registry)
+            rel_clean = _normalize_ref(ref)
+            remote_path = "%s/%s/%s" % (remote_root, entry.mods_subpath, rel_clean)
+            tried.append(remote_path + " (on %s)" % head)
+            # Trust delegated existence — if missing the docker cp will fail
+            # with a clear error; we cannot easily stat over SSH per-mod
+            # without paying a round-trip per ref. Verify only at the
+            # registry level (ensure_registry_on_host succeeded).
+            return ResolvedMod(name=Path(rel_clean).name, source_path=remote_path, source_host=head)
+
+    # rule 4: eugr fallback — default subpath to "mods" so legacy
+    # registries.yaml files (no mods_subpath field) still work.
+    try:
+        eugr_entry = registry_mgr.get_registry(EUGR_FALLBACK_REGISTRY)
+    except Exception:
+        eugr_entry = None
+        tried.append("@%s (registry not registered)" % EUGR_FALLBACK_REGISTRY)
+    if eugr_entry is not None:
+        eugr_subpath = eugr_entry.mods_subpath or "mods"
+        remote_root = _ensure_registry(EUGR_FALLBACK_REGISTRY)
+        rel_clean = _normalize_ref(ref)
+        remote_path = "%s/%s/%s" % (remote_root, eugr_subpath, rel_clean)
+        tried.append(remote_path + " (on %s)" % head)
+        return ResolvedMod(name=Path(rel_clean).name, source_path=remote_path, source_host=head)
+
+    raise ModNotFoundError(ref, tried)
+
+
+def resolve_and_inject_mods(
+    recipe: Recipe,
+    registry_mgr: RegistryManager,
+    *,
+    config: SparkrunConfig | None = None,
+    transfer_mode: str = "local",
+    head: str | None = None,
+    ssh_kwargs: dict | None = None,
+    dry_run: bool = False,
+) -> None:
+    """Resolve ``recipe.mods`` and append the matching ``pre_exec`` entries.
+
+    Idempotent: sets ``recipe._mods_resolved = True`` after a successful
+    pass; subsequent invocations are no-ops. ``recipe.mods`` is preserved
+    in place so ``Recipe.to_dict()`` keeps emitting the original ``mods:``
+    field, while mod-derived ``pre_exec`` entries are reset from raw input
+    on export (the same mechanism that strips builder-added entries).
+
+    Args:
+        recipe: Recipe to mutate (``pre_exec`` is extended in place).
+        registry_mgr: Used to resolve registry-backed mods.
+        config: Optional sparkrun config (reserved for future use).
+        transfer_mode: ``"local"`` or ``"delegated"`` — controls whether
+            sources land on the control machine or the head node.
+        head: Head host for delegated mode (required when delegated).
+        ssh_kwargs: SSH options for delegated mode.
+        dry_run: Skip side effects (no rsync, no git clone) and return
+            the would-be paths.
+
+    Raises:
+        ModNotFoundError: A reference could not be resolved.
+        ValueError: ``transfer_mode="delegated"`` without ``head``.
+    """
+    del config  # unused for now; kept for API symmetry with builders
+    if not recipe.mods:
+        return
+    if getattr(recipe, "_mods_resolved", False):
+        return
+
+    delegated = transfer_mode == "delegated"
+    if delegated and not head:
+        raise ValueError("resolve_and_inject_mods: head is required when transfer_mode='delegated'")
+
+    ensured_registries: dict[str, str] = {}
+    resolved: list[ResolvedMod] = []
+    for ref in recipe.mods:
+        if delegated:
+            assert head is not None  # narrowed by the guard above
+            resolved.append(
+                _resolve_delegated(
+                    ref,
+                    recipe,
+                    registry_mgr,
+                    head=head,
+                    ssh_kwargs=ssh_kwargs,
+                    dry_run=dry_run,
+                    ensured_registries=ensured_registries,
+                )
+            )
+        else:
+            resolved.append(_resolve_local(ref, recipe, registry_mgr))
+
+    for r in resolved:
+        recipe.pre_exec.extend(_build_pre_exec_entries(r))
+
+    logger.info("Resolved %d mod(s) into pre_exec entries", len(resolved))
+    recipe._mods_resolved = True

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -58,6 +58,7 @@ _KNOWN_KEYS = {
     "pre_exec",
     "post_exec",
     "post_commands",
+    "mods",
     "stop_after_post",
     "builder",
     "builder_config",
@@ -333,7 +334,7 @@ def _resolve_eugr_signals(recipe: Recipe) -> None:
     if recipe.runtime not in ("vllm", ""):
         return
     rc = recipe.runtime_config
-    if rc.get("build_args") or rc.get("mods") or recipe.container.strip().startswith("ghcr.io/spark-arena/dgx-vllm-eugr-nightly"):
+    if rc.get("build_args") or recipe.mods or recipe.container.strip().startswith("ghcr.io/spark-arena/dgx-vllm-eugr-nightly"):
         if not recipe.builder:
             recipe.builder = "eugr"
 
@@ -641,6 +642,14 @@ class Recipe:
         self.post_exec: list[str] = list(data.get("post_exec", []))
         self.post_commands: list[str] = list(data.get("post_commands", []))
         self.stop_after_post: bool = bool(data.get("stop_after_post", False))
+
+        # Mods (generic, builder-agnostic): list of references resolved to
+        # pre_exec entries by core/mods.py before container launch.
+        # v1 recipes carry mods under runtime_config; migrate to top-level
+        # so exports round-trip cleanly and the resolver sees a single source.
+        self.mods: list[str] = list(data.get("mods", []) or [])
+        if not self.mods and isinstance(self.runtime_config.get("mods"), list):
+            self.mods = list(self.runtime_config.pop("mods"))
 
         # Builder plugin
         self.builder: str = data.get("builder", "")
@@ -1082,6 +1091,7 @@ class Recipe:
             "post_exec": list(self.post_exec),
             "post_commands": list(self.post_commands),
             "stop_after_post": self.stop_after_post,
+            "mods": list(self.mods),
             "builder": self.builder,
             "builder_config": dict(self.builder_config),
             "executor_config": dict(self.executor_config),
@@ -1118,6 +1128,7 @@ class Recipe:
         self.post_exec = list(state.get("post_exec") or [])
         self.post_commands = list(state.get("post_commands") or [])
         self.stop_after_post = bool(state.get("stop_after_post", False))
+        self.mods = list(state.get("mods") or [])
         self.builder = state.get("builder", "")
         self.builder_config = dict(state.get("builder_config") or {})
         self.executor_config = dict(state.get("executor_config") or {})
@@ -1248,6 +1259,10 @@ class Recipe:
             d["defaults"] = dict(self.defaults)
         if self.env:
             d["env"] = dict(self.env)
+
+        # -- Mods (resolved to pre_exec at run time; preserve source list on export) --
+        if self.mods:
+            d["mods"] = list(self.mods)
 
         # -- Lifecycle hooks --
         if self.pre_exec:

--- a/src/sparkrun/core/registry.py
+++ b/src/sparkrun/core/registry.py
@@ -38,6 +38,7 @@ class RegistryEntry:
         visible: If False, recipes hidden from default listings
         tuning_subpath: Path within repo for tuning configs
         benchmark_subpath: Path within repo for benchmark profiles
+        mods_subpath: Path within repo for shared mods (run.sh + supporting files)
     """
 
     name: str
@@ -48,6 +49,7 @@ class RegistryEntry:
     visible: bool = True
     tuning_subpath: str = ""
     benchmark_subpath: str = ""
+    mods_subpath: str = ""
 
 
 FALLBACK_DEFAULT_REGISTRIES = [
@@ -74,6 +76,7 @@ FALLBACK_DEFAULT_REGISTRIES = [
         url="https://github.com/eugr/spark-vllm-docker",
         subpath="recipes",
         description="Official eugr/spark-vllm-docker repo recipes",
+        mods_subpath="mods",
         visible=True,
     ),
     RegistryEntry(
@@ -365,6 +368,7 @@ class RegistryManager:
                 visible=r.get("visible", True),
                 tuning_subpath=r.get("tuning_subpath", ""),
                 benchmark_subpath=r.get("benchmark_subpath", ""),
+                mods_subpath=r.get("mods_subpath", ""),
             )
             for r in registries
         ]
@@ -416,6 +420,8 @@ class RegistryManager:
                 d["tuning_subpath"] = e.tuning_subpath
             if e.benchmark_subpath:
                 d["benchmark_subpath"] = e.benchmark_subpath
+            if e.mods_subpath:
+                d["mods_subpath"] = e.mods_subpath
             data_list.append(d)
 
         data = {"registries": data_list}
@@ -448,13 +454,15 @@ class RegistryManager:
         """Build the sparse-checkout path list for a single registry entry.
 
         Always includes the recipe subpath and ``.sparkrun`` (for manifests).
-        Tuning and benchmark subpaths are added when configured.
+        Tuning, benchmark, and mods subpaths are added when configured.
         """
         paths = [entry.subpath]
         if entry.tuning_subpath:
             paths.append(entry.tuning_subpath)
         if entry.benchmark_subpath:
             paths.append(entry.benchmark_subpath)
+        if entry.mods_subpath:
+            paths.append(entry.mods_subpath)
         paths.append(".sparkrun")
         return paths
 
@@ -768,6 +776,7 @@ class RegistryManager:
                     visible=reg_data.get("visible", True),
                     tuning_subpath=reg_data.get("tuning_subpath", reg_data.get("tuning", "")),
                     benchmark_subpath=reg_data.get("benchmark_subpath", reg_data.get("benchmarks", "")),
+                    mods_subpath=reg_data.get("mods_subpath", reg_data.get("mods", "")),
                 )
                 for reg_data in registries_data
             ]
@@ -1310,6 +1319,84 @@ class RegistryManager:
                         }
                     )
         return configs
+
+    def _mods_dir(self, entry: RegistryEntry) -> Path | None:
+        """Get the mods directory within a cached registry.
+
+        Args:
+            entry: Registry entry
+
+        Returns:
+            Path to the mods directory, or None if not configured/available
+        """
+        if not entry.mods_subpath:
+            return None
+        cache_dir = self._cache_dir(entry.name)
+        mods_path = cache_dir / entry.mods_subpath
+        return mods_path if mods_path.exists() else None
+
+    def ensure_registry_on_host(
+        self,
+        name: str,
+        host: str,
+        ssh_kwargs: dict | None = None,
+        dry_run: bool = False,
+    ) -> str:
+        """Clone or update a registry's git repo on a remote head node.
+
+        Used by delegated-mode flows that need registry-backed resources
+        (e.g. mods) to live on the head node rather than the control
+        machine. Mirrors the local clone layout under
+        ``~/.cache/sparkrun/registries/_url_<hash>/`` on the remote host
+        with sparse-checkout configured for the union of all subpaths
+        declared by registries sharing this URL.
+
+        Args:
+            name: Registry name (used to look up the URL and subpaths).
+            host: Remote head node hostname.
+            ssh_kwargs: SSH connection kwargs.
+            dry_run: When True, return the would-be path without acting.
+
+        Returns:
+            Absolute path on the remote host where the registry is checked out.
+        """
+        import hashlib
+
+        from sparkrun.orchestration.primitives import run_script_on_host
+        from sparkrun.utils.shell import quote
+
+        entry = self.get_registry(name)
+        sparse_paths = self._sparse_checkout_paths_for_url(entry.url)
+        url_hash = hashlib.sha256(entry.url.encode()).hexdigest()[:12]
+        remote_clone_dir = "~/.cache/sparkrun/registries/_url_%s" % url_hash
+        sparse_args = " ".join(quote(p) for p in sparse_paths) if sparse_paths else ""
+
+        script = (
+            "set -e\n"
+            "REPO_DIR=%(path)s\n"
+            'if [ -d "$REPO_DIR/.git" ]; then\n'
+            '  git -C "$REPO_DIR" fetch origin\n'
+            '  git -C "$REPO_DIR" reset --hard FETCH_HEAD\n'
+            "else\n"
+            '  mkdir -p "$(dirname "$REPO_DIR")"\n'
+            '  git clone --filter=blob:none --sparse %(url)s "$REPO_DIR"\n'
+            "fi\n"
+        ) % {"path": remote_clone_dir, "url": quote(entry.url)}
+        if sparse_args:
+            script += 'git -C "$REPO_DIR" sparse-checkout set %s\n' % sparse_args
+        script += 'echo "$REPO_DIR"\n'
+
+        logger.info("Ensuring registry %r on head node %s...", name, host)
+        if dry_run:
+            return remote_clone_dir
+
+        result = run_script_on_host(host, script, ssh_kwargs=ssh_kwargs, timeout=180)
+        if not result.success:
+            raise RegistryError(
+                "Failed to ensure registry %r on %s: %s" % (name, host, result.stderr.strip() if result.stderr else "(no output)")
+            )
+        # Strip trailing newlines and return the resolved path
+        return result.stdout.strip() if result.stdout else remote_clone_dir
 
     def _benchmark_dir(self, entry: RegistryEntry) -> Path | None:
         """Get benchmark directory within a cached registry.

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -54,6 +54,7 @@ VLLM_FLAG_MAP = {
     "pipeline_parallel": "-pp",
     "data_parallel": "--data-parallel-size",
     "kv_cache_dtype": "--kv-cache-dtype",
+    "otlp_traces_endpoint": "--otlp-traces-endpoint",
 }
 
 # Boolean flags (present = True, absent = False)

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -44,9 +44,9 @@ class VllmMixin:
             # TODO: support various ways that speculative config can be specified
             # noinspection PyProtectedMember
             spec_cfg = recipe._effective_default("speculative_config")
-            spec_cfg_dict = json.loads(spec_cfg)
-            if spec_cfg_dict["method"] == "dflash":
-                return spec_cfg_dict.get("model", None)
+            spec_cfg_dict = json.loads(spec_cfg) or {}
+            # intended primarily for dflash, but we allow any "model" field for future extensibility
+            return spec_cfg_dict.get("model", None)
         except Exception:
             return None
 

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -29,6 +29,7 @@ from sparkrun.runtimes._util import default_env_hf_offline
 from sparkrun.runtimes.base import RuntimePlugin
 
 if TYPE_CHECKING:
+    from sparkrun.core.config import SparkrunConfig
     from sparkrun.core.recipe import Recipe
     from sparkrun.orchestration.comm_env import ClusterCommEnv
 
@@ -122,6 +123,21 @@ class AtlasRuntime(RuntimePlugin):
 
     def get_common_env(self):
         return default_env_hf_offline()
+
+    def prepare(
+        self,
+        recipe: Recipe,
+        hosts: list[str],
+        config: "SparkrunConfig | None" = None,
+        dry_run: bool = False,
+        transfer_mode: str = "auto",
+        overrides: dict[str, Any] | None = None,
+    ) -> None:
+        """Pre-sync the speculative draft model when configured."""
+        # noinspection PyProtectedMember
+        draft_model = recipe._effective_default("draft_model")
+        if draft_model:
+            recipe.distribution_config.add_model(str(draft_model))
 
     # --- Command generation ---
 

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -282,8 +282,8 @@ class AtlasRuntime(RuntimePlugin):
         else:
             result = tp * ep
 
-        # if result > 1:
-        #     raise ValueError("Atlas runtime currently only supports single node. Support for multiple nodes is coming soon.")
+        if result > 1:
+            raise ValueError("Atlas runtime currently only supports single node. Support for multiple nodes is coming soon.")
 
         return result
 

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -282,8 +282,8 @@ class AtlasRuntime(RuntimePlugin):
         else:
             result = tp * ep
 
-        if result > 1:
-            raise ValueError("Atlas runtime currently only supports single node. Support for multiple nodes is coming soon.")
+        # if result > 1:
+        #     raise ValueError("Atlas runtime currently only supports single node. Support for multiple nodes is coming soon.")
 
         return result
 

--- a/src/sparkrun/runtimes/sglang.py
+++ b/src/sparkrun/runtimes/sglang.py
@@ -9,6 +9,7 @@ from sparkrun.runtimes._util import default_env_hf_offline
 from sparkrun.runtimes.base import RuntimePlugin
 
 if TYPE_CHECKING:
+    from sparkrun.core.config import SparkrunConfig
     from sparkrun.core.recipe import Recipe
     from sparkrun.orchestration.comm_env import ClusterCommEnv
 
@@ -30,6 +31,7 @@ _SGLANG_FLAG_MAP = {
     "chunked_prefill": "--chunked-prefill-size",
     "kv_cache_dtype": "--kv-cache-dtype",
     "tokenizer_path": "--tokenizer-path",
+    "speculative_draft_model_path": "--speculative-draft-model-path",
 }
 
 _SGLANG_BOOL_FLAGS = {
@@ -54,6 +56,35 @@ class SglangRuntime(RuntimePlugin):
         """SGLang uses native multi-node distribution, not Ray."""
         return "native"
 
+    def prepare(
+        self,
+        recipe: Recipe,
+        hosts: list[str],
+        config: "SparkrunConfig | None" = None,
+        dry_run: bool = False,
+        transfer_mode: str = "auto",
+        overrides: dict[str, Any] | None = None,
+    ) -> None:
+        """Pre-sync the speculative draft model when configured."""
+        draft_model = self._detect_speculative_draft_model(recipe)
+        if draft_model:
+            recipe.distribution_config.add_model(draft_model)
+
+    @staticmethod
+    def _detect_speculative_draft_model(recipe: "Recipe") -> str | None:
+        """Resolve the speculative draft model from recipe defaults.
+
+        Accepts either ``speculative_draft_model_path`` (canonical, matches
+        the CLI flag) or ``speculative_draft_model`` (alias).  Returns
+        ``None`` when neither is set.
+        """
+        for key in ("speculative_draft_model_path", "speculative_draft_model"):
+            # noinspection PyProtectedMember
+            val = recipe._effective_default(key)
+            if val:
+                return str(val)
+        return None
+
     def generate_command(
         self,
         recipe: Recipe,
@@ -70,7 +101,7 @@ class SglangRuntime(RuntimePlugin):
         per-node variant.
         """
         config = recipe.build_config_chain(overrides)
-        self._inject_gguf_model(config)
+        self._normalize_config(config)
 
         # If recipe has an explicit command template, render it
         rendered = recipe.render_command(config)
@@ -110,7 +141,7 @@ class SglangRuntime(RuntimePlugin):
         ``--node-rank`` flags appended.
         """
         config = recipe.build_config_chain(overrides)
-        self._inject_gguf_model(config)
+        self._normalize_config(config)
 
         # If recipe has an explicit command template, render it
         rendered = recipe.render_command(config)
@@ -155,6 +186,18 @@ class SglangRuntime(RuntimePlugin):
         gguf_path = config.get("_gguf_model_path")
         if gguf_path:
             config.put("model", str(gguf_path))
+
+    @staticmethod
+    def _normalize_config(config) -> None:
+        """Apply pre-render config normalizations (GGUF path + speculative alias)."""
+        SglangRuntime._inject_gguf_model(config)
+        # Accept ``speculative_draft_model`` as an alias for the canonical
+        # ``speculative_draft_model_path`` key so users can use either in
+        # recipe defaults; flag emission only looks at the canonical key.
+        if not config.get("speculative_draft_model_path"):
+            alias = config.get("speculative_draft_model")
+            if alias:
+                config.set("speculative_draft_model_path", alias)
 
     def _build_base_command(self, recipe: Recipe, config, skip_keys: set[str] | frozenset[str] = frozenset()) -> str:
         """Build the sglang command without cluster-specific arguments."""

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -296,3 +296,57 @@ def test_atlas_bool_flag_falsy_omitted():
     cmd = runtime.generate_command(recipe, {}, is_cluster=False)
     assert "--speculative" not in cmd
     assert "--enable-prefix-caching" not in cmd
+
+
+# --- prepare(): speculative draft-model pre-sync ---
+
+
+def _draft_model_names(recipe) -> list[str]:
+    return [e.name for e in recipe.distribution_config.models.entries]
+
+
+def test_atlas_prepare_adds_draft_model_to_distribution():
+    """prepare() copies recipe defaults.draft_model into distribution_config."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"draft_model": "Sehyo/Qwen3.5-35B-Draft"})
+
+    assert "Sehyo/Qwen3.5-35B-Draft" not in _draft_model_names(recipe)
+    runtime.prepare(recipe, hosts=["10.0.0.1"])
+    assert "Sehyo/Qwen3.5-35B-Draft" in _draft_model_names(recipe)
+
+
+def test_atlas_prepare_no_draft_model_is_noop():
+    """prepare() does nothing when draft_model is absent."""
+    runtime = AtlasRuntime()
+    recipe = _recipe()
+    before = list(_draft_model_names(recipe))
+    runtime.prepare(recipe, hosts=["10.0.0.1"])
+    assert _draft_model_names(recipe) == before
+
+
+def test_atlas_prepare_dedupes_when_draft_equals_main_model():
+    """add_model dedups by name, so prepare() is safe even if draft matches main."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"draft_model": "Sehyo/Qwen3.5-35B-A3B-NVFP4"})
+    runtime.prepare(recipe, hosts=["10.0.0.1"])
+    names = _draft_model_names(recipe)
+    # Default entry holds the templated "{model}" placeholder; the draft
+    # is added as a separate entry (substitution happens later via resolve()).
+    assert names.count("Sehyo/Qwen3.5-35B-A3B-NVFP4") == 1
+
+
+def test_atlas_prepare_with_cli_override():
+    """prepare() respects CLI overrides via _effective_default."""
+    runtime = AtlasRuntime()
+    recipe = _recipe()
+    recipe._applied_overrides = {"draft_model": "override/draft"}
+    runtime.prepare(recipe, hosts=["10.0.0.1"])
+    assert "override/draft" in _draft_model_names(recipe)
+
+
+def test_atlas_draft_model_flag_still_renders():
+    """Regression: --draft-model still emits with new prepare() wiring."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"draft_model": "Sehyo/Qwen3.5-35B-Draft", "speculative": True})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--draft-model Sehyo/Qwen3.5-35B-Draft" in cmd

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -178,25 +178,27 @@ def test_atlas_compute_required_nodes_solo():
     assert runtime.compute_required_nodes(_recipe()) is None
 
 
-def test_atlas_compute_required_nodes_pure_ep():
-    """ep_size=2, tp=1 → 2 nodes."""
-    runtime = AtlasRuntime()
-    recipe = _recipe(defaults={"ep_size": 2})
-    assert runtime.compute_required_nodes(recipe) == 2
-
-
-def test_atlas_compute_required_nodes_overlapping_tp_ep():
-    """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
-    runtime = AtlasRuntime()
-    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
-    assert runtime.compute_required_nodes(recipe) == 2
-
-
-def test_atlas_compute_required_nodes_orthogonal_tp_ep():
-    """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
-    runtime = AtlasRuntime()
-    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
-    assert runtime.compute_required_nodes(recipe) == 8
+# TODO: re-enable tests with multi-node / distributed support
+#
+# def test_atlas_compute_required_nodes_pure_ep():
+#     """ep_size=2, tp=1 → 2 nodes."""
+#     runtime = AtlasRuntime()
+#     recipe = _recipe(defaults={"ep_size": 2})
+#     assert runtime.compute_required_nodes(recipe) == 2
+#
+#
+# def test_atlas_compute_required_nodes_overlapping_tp_ep():
+#     """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
+#     runtime = AtlasRuntime()
+#     recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
+#     assert runtime.compute_required_nodes(recipe) == 2
+#
+#
+# def test_atlas_compute_required_nodes_orthogonal_tp_ep():
+#     """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
+#     runtime = AtlasRuntime()
+#     recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
+#     assert runtime.compute_required_nodes(recipe) == 8
 
 
 # --- Cluster env / docker opts ---

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -178,27 +178,25 @@ def test_atlas_compute_required_nodes_solo():
     assert runtime.compute_required_nodes(_recipe()) is None
 
 
-# TODO: re-enable tests with multi-node / distributed support
-#
-# def test_atlas_compute_required_nodes_pure_ep():
-#     """ep_size=2, tp=1 → 2 nodes."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"ep_size": 2})
-#     assert runtime.compute_required_nodes(recipe) == 2
-#
-#
-# def test_atlas_compute_required_nodes_overlapping_tp_ep():
-#     """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
-#     assert runtime.compute_required_nodes(recipe) == 2
-#
-#
-# def test_atlas_compute_required_nodes_orthogonal_tp_ep():
-#     """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
-#     assert runtime.compute_required_nodes(recipe) == 8
+def test_atlas_compute_required_nodes_pure_ep():
+    """ep_size=2, tp=1 → 2 nodes."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"ep_size": 2})
+    assert runtime.compute_required_nodes(recipe) == 2
+
+
+def test_atlas_compute_required_nodes_overlapping_tp_ep():
+    """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
+    assert runtime.compute_required_nodes(recipe) == 2
+
+
+def test_atlas_compute_required_nodes_orthogonal_tp_ep():
+    """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
+    assert runtime.compute_required_nodes(recipe) == 8
 
 
 # --- Cluster env / docker opts ---

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -212,27 +212,8 @@ class TestEugrPrepareImage:
 
         mock_run.assert_not_called()
 
-    def test_eugr_prepare_injects_mod_pre_exec(self, eugr_builder_with_repo):
-        """prepare_image() injects mod entries into recipe.pre_exec."""
-        builder, repo_dir = eugr_builder_with_repo
-        recipe = Recipe.from_dict(
-            {
-                "name": "test",
-                "model": "some/model",
-                "runtime": "eugr-vllm",
-                "runtime_config": {"mods": ["mods/flash-attn"]},
-            }
-        )
-        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=True):
-            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                builder.prepare_image("vllm-node", recipe, ["10.0.0.1"])
-
-        # Should have injected one copy dict + one exec string per mod
-        assert len(recipe.pre_exec) == 2
-        assert isinstance(recipe.pre_exec[0], dict)
-        assert "copy" in recipe.pre_exec[0]
-        assert isinstance(recipe.pre_exec[1], str)
-        assert "run.sh" in recipe.pre_exec[1]
+    # Note: mod -> pre_exec injection moved out of the eugr builder into the
+    # generic core/mods.py resolver. See tests/test_mods.py for that coverage.
 
     def test_eugr_prepare_build_failure_raises(self, eugr_builder_with_repo):
         """prepare_image() raises RuntimeError when the build exits non-zero."""
@@ -250,71 +231,6 @@ class TestEugrPrepareImage:
                 mock_run.return_value = mock.Mock(returncode=1)
                 with pytest.raises(RuntimeError, match="eugr container build failed"):
                     builder.prepare_image("vllm-node", recipe, ["10.0.0.1"])
-
-    def test_eugr_mod_pre_exec_format(self, eugr_builder_with_repo):
-        """Injected mod pre_exec entries have correct copy/dest keys and run.sh string."""
-        builder, repo_dir = eugr_builder_with_repo
-        recipe = Recipe.from_dict(
-            {
-                "name": "test",
-                "model": "some/model",
-                "runtime": "eugr-vllm",
-                "runtime_config": {"mods": ["mods/flash-attn"]},
-            }
-        )
-        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=True):
-            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                builder.prepare_image("vllm-node", recipe, ["10.0.0.1"])
-
-        copy_entry = recipe.pre_exec[0]
-        exec_entry = recipe.pre_exec[1]
-
-        # The copy dict must have "copy" (source path) and "dest" (container path)
-        assert "copy" in copy_entry
-        assert "dest" in copy_entry
-        assert copy_entry["dest"].startswith("/workspace/mods/")
-
-        # The exec string must reference run.sh
-        assert "run.sh" in exec_entry
-
-        # The copy source must NOT double the 'mods/' prefix
-        assert "mods/mods/" not in copy_entry["copy"]
-        assert copy_entry["copy"].endswith("/mods/flash-attn")
-
-    def test_eugr_mod_bare_name_same_as_prefixed(self, eugr_builder_with_repo):
-        """Mod specified as 'flash-attn' (bare) produces same paths as 'mods/flash-attn'."""
-        builder, repo_dir = eugr_builder_with_repo
-
-        # Build recipe with bare mod name (no 'mods/' prefix)
-        recipe_bare = Recipe.from_dict(
-            {
-                "name": "test",
-                "model": "some/model",
-                "runtime": "eugr-vllm",
-                "runtime_config": {"mods": ["flash-attn"]},
-            }
-        )
-        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=True):
-            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                builder.prepare_image("vllm-node", recipe_bare, ["10.0.0.1"])
-
-        # Build recipe with prefixed mod name
-        recipe_prefixed = Recipe.from_dict(
-            {
-                "name": "test",
-                "model": "some/model",
-                "runtime": "eugr-vllm",
-                "runtime_config": {"mods": ["mods/flash-attn"]},
-            }
-        )
-        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=True):
-            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                builder.prepare_image("vllm-node", recipe_prefixed, ["10.0.0.1"])
-
-        # Both should produce identical pre_exec entries
-        assert recipe_bare.pre_exec[0]["copy"] == recipe_prefixed.pre_exec[0]["copy"]
-        assert recipe_bare.pre_exec[0]["dest"] == recipe_prefixed.pre_exec[0]["dest"]
-        assert recipe_bare.pre_exec[1] == recipe_prefixed.pre_exec[1]
 
 
 # ---------------------------------------------------------------------------
@@ -503,80 +419,8 @@ class TestEugrDelegatedMode:
         )
         assert result == "my-image"
 
-    def test_eugr_prepare_delegated_clones_repo_remotely(self, eugr_builder_with_repo):
-        """In delegated mode, _ensure_repo_remote is called instead of local ensure_repo."""
-        builder, repo_dir = eugr_builder_with_repo
-        recipe = Recipe.from_dict(
-            {
-                "name": "test",
-                "model": "some/model",
-                "runtime": "eugr-vllm",
-                "runtime_config": {"mods": ["flash-attn"]},
-            }
-        )
-        with mock.patch.object(builder, "_image_exists_on_host", return_value=True):
-            with mock.patch.object(builder, "_ensure_repo_remote", return_value="/remote/repo") as mock_remote_repo:
-                with mock.patch.object(builder, "ensure_repo") as mock_local_repo:
-                    builder.prepare_image(
-                        "vllm-node",
-                        recipe,
-                        ["head-host"],
-                        transfer_mode="delegated",
-                        ssh_kwargs={},
-                    )
-        mock_remote_repo.assert_called_once()
-        mock_local_repo.assert_not_called()
-
-    def test_eugr_mod_pre_exec_delegated_sets_source_host(self, eugr_builder_with_repo):
-        """In delegated mode, copy entries include a source_host key."""
-        builder, repo_dir = eugr_builder_with_repo
-        recipe = Recipe.from_dict(
-            {
-                "name": "test",
-                "model": "some/model",
-                "runtime": "eugr-vllm",
-                "runtime_config": {"mods": ["flash-attn"]},
-            }
-        )
-        with mock.patch.object(builder, "_image_exists_on_host", return_value=True):
-            with mock.patch.object(builder, "_ensure_repo_remote", return_value=str(repo_dir)):
-                builder.prepare_image(
-                    "vllm-node",
-                    recipe,
-                    ["head-host"],
-                    transfer_mode="delegated",
-                    ssh_kwargs={},
-                )
-
-        assert len(recipe.pre_exec) == 2
-        copy_entry = recipe.pre_exec[0]
-        assert isinstance(copy_entry, dict)
-        assert copy_entry["source_host"] == "head-host"
-
-    def test_eugr_prepare_local_no_source_host(self, eugr_builder_with_repo):
-        """In local mode, copy entries do NOT include a source_host key."""
-        builder, repo_dir = eugr_builder_with_repo
-        recipe = Recipe.from_dict(
-            {
-                "name": "test",
-                "model": "some/model",
-                "runtime": "eugr-vllm",
-                "runtime_config": {"mods": ["flash-attn"]},
-            }
-        )
-        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=True):
-            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                builder.prepare_image(
-                    "vllm-node",
-                    recipe,
-                    ["10.0.0.1"],
-                    transfer_mode="local",
-                )
-
-        assert len(recipe.pre_exec) == 2
-        copy_entry = recipe.pre_exec[0]
-        assert isinstance(copy_entry, dict)
-        assert "source_host" not in copy_entry
+    # Note: mod-specific delegated-mode behavior moved to core/mods.py;
+    # covered by tests/test_mods.py.
 
     @mock.patch("sparkrun.orchestration.primitives.run_script_on_host")
     def test_image_exists_on_host_true(self, mock_run):

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -3,7 +3,7 @@
 Covers:
 - SSH transfer primitives (build_ssh_opts_string, run_pipeline_to_remote,
   run_rsync, and their parallel variants)
-- Container image hash checking (_check_remote_image_ids, _filter_hosts_needing_image)
+- Container image identity checking (_check_remote_image_identities, _filter_hosts_needing_image)
 - Container distribution (distribute_image_from_local, distribute_image_from_head)
 - Model distribution (distribute_model_from_local, distribute_model_from_head)
 - InfiniBand detection helpers (IBDetectionResult, extract_ib_ips, detect_ib_for_hosts)
@@ -280,90 +280,245 @@ class TestParallelRsync:
 
 
 # ---------------------------------------------------------------------------
-# Image hash checking
+# Image identity checking
 # ---------------------------------------------------------------------------
 
 
-class TestCheckRemoteImageIds:
-    """Test _check_remote_image_ids."""
+class TestParseIdentity:
+    """Test _parse_identity (parser for combined inspect output)."""
+
+    def test_id_and_one_digest(self):
+        from sparkrun.containers.distribute import _parse_identity
+
+        image_id, digests = _parse_identity("sha256:abc|repo@sha256:xyz \n")
+        assert image_id == "sha256:abc"
+        assert digests == ["repo@sha256:xyz"]
+
+    def test_id_and_multiple_digests(self):
+        from sparkrun.containers.distribute import _parse_identity
+
+        image_id, digests = _parse_identity("sha256:abc|r1@sha256:x r2@sha256:x ")
+        assert image_id == "sha256:abc"
+        assert digests == ["r1@sha256:x", "r2@sha256:x"]
+
+    def test_id_and_no_digests(self):
+        from sparkrun.containers.distribute import _parse_identity
+
+        image_id, digests = _parse_identity("sha256:abc|")
+        assert image_id == "sha256:abc"
+        assert digests == []
+
+    def test_empty_means_absent(self):
+        from sparkrun.containers.distribute import _parse_identity
+
+        image_id, digests = _parse_identity("")
+        assert image_id is None
+        assert digests == []
+
+
+class TestImagesMatch:
+    """Test _images_match (digest-overlap or id-equality)."""
+
+    def test_id_equality(self):
+        """Same Id, both sides — match even without RepoDigests."""
+        from sparkrun.containers.distribute import _images_match
+
+        assert _images_match("sha256:abc", [], "sha256:abc", []) is True
+
+    def test_digest_overlap_with_different_ids(self):
+        """Issue #152: different Ids (storage-driver drift), same RepoDigest sha → match."""
+        from sparkrun.containers.distribute import _images_match
+
+        # Same registry image pulled on hosts with different storage drivers.
+        assert (
+            _images_match(
+                "sha256:lenovo",
+                ["sparkarena/spark-vllm-docker@sha256:e07b3d4e9c45"],
+                "sha256:msi",
+                ["sparkarena/spark-vllm-docker@sha256:e07b3d4e9c45"],
+            )
+            is True
+        )
+
+    def test_digest_overlap_across_repos(self):
+        """Same digest sha under different repo names (mirror) → match."""
+        from sparkrun.containers.distribute import _images_match
+
+        assert (
+            _images_match(
+                "sha256:a",
+                ["docker.io/foo@sha256:X"],
+                "sha256:b",
+                ["quay.io/foo@sha256:X"],
+            )
+            is True
+        )
+
+    def test_no_overlap_and_different_ids(self):
+        """Different Ids and different RepoDigests → no match."""
+        from sparkrun.containers.distribute import _images_match
+
+        assert (
+            _images_match(
+                "sha256:a",
+                ["repo@sha256:X"],
+                "sha256:b",
+                ["repo@sha256:Y"],
+            )
+            is False
+        )
+
+    def test_local_has_digest_remote_does_not_falls_back_to_id(self):
+        """Mixed: only local has RepoDigests — fall back to Id comparison."""
+        from sparkrun.containers.distribute import _images_match
+
+        # Different Id, no remote digests → mismatch (Id fallback).
+        assert _images_match("sha256:a", ["repo@sha256:X"], "sha256:b", []) is False
+        # Same Id, no remote digests → match.
+        assert _images_match("sha256:a", ["repo@sha256:X"], "sha256:a", []) is True
+
+    def test_remote_absent(self):
+        """Remote has no Id and no digests → image not present, no match."""
+        from sparkrun.containers.distribute import _images_match
+
+        assert _images_match("sha256:a", ["r@sha256:X"], None, []) is False
+
+
+class TestCheckRemoteImageIdentities:
+    """Test _check_remote_image_identities."""
 
     @mock.patch("sparkrun.containers.distribute.run_remote_command")
-    def test_returns_host_id_map(self, mock_cmd):
-        """Returns mapping of host → image ID for hosts that have the image."""
+    def test_returns_host_identity_map(self, mock_cmd):
+        """Returns mapping of host → (id, repo_digests) for hosts with the image."""
         mock_cmd.side_effect = [
-            RemoteResult(host="h1", returncode=0, stdout="sha256:abc123\n", stderr=""),
-            RemoteResult(host="h2", returncode=0, stdout="sha256:def456\n", stderr=""),
+            RemoteResult(host="h1", returncode=0, stdout="sha256:abc|repo@sha256:x \n", stderr=""),
+            RemoteResult(host="h2", returncode=0, stdout="sha256:def|\n", stderr=""),
         ]
-        from sparkrun.containers.distribute import _check_remote_image_ids
+        from sparkrun.containers.distribute import _check_remote_image_identities
 
-        result = _check_remote_image_ids("img:latest", ["h1", "h2"])
-        assert result == {"h1": "sha256:abc123", "h2": "sha256:def456"}
+        result = _check_remote_image_identities("img:latest", ["h1", "h2"])
+        assert result == {
+            "h1": ("sha256:abc", ["repo@sha256:x"]),
+            "h2": ("sha256:def", []),
+        }
 
     @mock.patch("sparkrun.containers.distribute.run_remote_command")
     def test_skips_hosts_without_image(self, mock_cmd):
         """Hosts where the image is absent (empty stdout) are omitted."""
         mock_cmd.side_effect = [
-            RemoteResult(host="h1", returncode=0, stdout="sha256:abc123\n", stderr=""),
+            RemoteResult(host="h1", returncode=0, stdout="sha256:abc|r@sha256:x \n", stderr=""),
             RemoteResult(host="h2", returncode=0, stdout="", stderr=""),
         ]
-        from sparkrun.containers.distribute import _check_remote_image_ids
+        from sparkrun.containers.distribute import _check_remote_image_identities
 
-        result = _check_remote_image_ids("img:latest", ["h1", "h2"])
-        assert result == {"h1": "sha256:abc123"}
+        result = _check_remote_image_identities("img:latest", ["h1", "h2"])
+        assert result == {"h1": ("sha256:abc", ["r@sha256:x"])}
 
     @mock.patch("sparkrun.containers.distribute.run_remote_command")
     def test_skips_failed_commands(self, mock_cmd):
         """Hosts where the SSH command failed are omitted."""
         mock_cmd.side_effect = [
-            RemoteResult(host="h1", returncode=0, stdout="sha256:abc123\n", stderr=""),
+            RemoteResult(host="h1", returncode=0, stdout="sha256:abc|\n", stderr=""),
             RemoteResult(host="h2", returncode=1, stdout="", stderr="error"),
         ]
-        from sparkrun.containers.distribute import _check_remote_image_ids
+        from sparkrun.containers.distribute import _check_remote_image_identities
 
-        result = _check_remote_image_ids("img:latest", ["h1", "h2"])
-        assert result == {"h1": "sha256:abc123"}
+        result = _check_remote_image_identities("img:latest", ["h1", "h2"])
+        assert result == {"h1": ("sha256:abc", [])}
 
     def test_dry_run_returns_empty(self):
-        from sparkrun.containers.distribute import _check_remote_image_ids
+        from sparkrun.containers.distribute import _check_remote_image_identities
 
-        result = _check_remote_image_ids("img:latest", ["h1", "h2"], dry_run=True)
+        result = _check_remote_image_identities("img:latest", ["h1", "h2"], dry_run=True)
         assert result == {}
 
     def test_empty_hosts_returns_empty(self):
-        from sparkrun.containers.distribute import _check_remote_image_ids
+        from sparkrun.containers.distribute import _check_remote_image_identities
 
-        result = _check_remote_image_ids("img:latest", [])
+        result = _check_remote_image_identities("img:latest", [])
         assert result == {}
 
 
 class TestFilterHostsNeedingImage:
     """Test _filter_hosts_needing_image."""
 
-    @mock.patch("sparkrun.containers.distribute._check_remote_image_ids")
-    def test_all_hosts_up_to_date(self, mock_check):
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
+    def test_all_hosts_up_to_date_by_id(self, mock_check):
         """Hosts with matching image ID are filtered out."""
-        mock_check.return_value = {"h1": "sha256:abc", "h2": "sha256:abc"}
+        mock_check.return_value = {"h1": ("sha256:abc", []), "h2": ("sha256:abc", [])}
         from sparkrun.containers.distribute import _filter_hosts_needing_image
 
         result = _filter_hosts_needing_image("img", ["h1", "h2"], "sha256:abc")
         assert result == []
 
-    @mock.patch("sparkrun.containers.distribute._check_remote_image_ids")
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
     def test_all_hosts_need_transfer(self, mock_check):
         """Hosts with missing or mismatched IDs are included."""
-        mock_check.return_value = {"h1": "sha256:old"}  # h2 not present
+        mock_check.return_value = {"h1": ("sha256:old", [])}  # h2 not present
         from sparkrun.containers.distribute import _filter_hosts_needing_image
 
         result = _filter_hosts_needing_image("img", ["h1", "h2"], "sha256:new")
         assert result == ["h1", "h2"]
 
-    @mock.patch("sparkrun.containers.distribute._check_remote_image_ids")
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
     def test_partial_match(self, mock_check):
         """Only hosts with mismatched IDs are returned."""
-        mock_check.return_value = {"h1": "sha256:abc", "h2": "sha256:old"}
+        mock_check.return_value = {"h1": ("sha256:abc", []), "h2": ("sha256:old", [])}
         from sparkrun.containers.distribute import _filter_hosts_needing_image
 
         result = _filter_hosts_needing_image("img", ["h1", "h2"], "sha256:abc")
+        assert result == ["h2"]
+
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
+    def test_issue_152_storage_driver_drift(self, mock_check):
+        """Different Ids but overlapping RepoDigests → skip transfer (issue #152)."""
+        # Lenovo host (overlay2) and MSI host (containerd overlayfs) report
+        # different local Ids but the same RepoDigest for the same image.
+        mock_check.return_value = {
+            "lenovo": ("sha256:lenovo", ["sparkarena/spark-vllm@sha256:e07b3d"]),
+            "msi": ("sha256:msi", ["sparkarena/spark-vllm@sha256:e07b3d"]),
+        }
+        from sparkrun.containers.distribute import _filter_hosts_needing_image
+
+        result = _filter_hosts_needing_image(
+            "img",
+            ["lenovo", "msi"],
+            "sha256:control",  # control machine yet another Id
+            local_repo_digests=["sparkarena/spark-vllm@sha256:e07b3d"],
+        )
+        assert result == []
+
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
+    def test_digest_match_across_mirrored_repos(self, mock_check):
+        """Same digest sha under different repo names → skip transfer."""
+        mock_check.return_value = {
+            "h1": ("sha256:a", ["quay.io/foo@sha256:X"]),
+        }
+        from sparkrun.containers.distribute import _filter_hosts_needing_image
+
+        result = _filter_hosts_needing_image(
+            "img",
+            ["h1"],
+            "sha256:b",
+            local_repo_digests=["docker.io/foo@sha256:X"],
+        )
+        assert result == []
+
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
+    def test_id_fallback_when_remote_has_no_digests(self, mock_check):
+        """Locally-built / save-loaded remote with no digests → Id fallback."""
+        mock_check.return_value = {
+            "h1": ("sha256:same", []),  # same Id, no digests (e.g. after save/load)
+            "h2": ("sha256:other", []),
+        }
+        from sparkrun.containers.distribute import _filter_hosts_needing_image
+
+        result = _filter_hosts_needing_image(
+            "img",
+            ["h1", "h2"],
+            "sha256:same",
+            local_repo_digests=["repo@sha256:X"],  # local has digest, remote doesn't
+        )
         assert result == ["h2"]
 
     def test_dry_run_returns_all(self):
@@ -373,11 +528,11 @@ class TestFilterHostsNeedingImage:
         result = _filter_hosts_needing_image("img", ["h1", "h2"], "sha256:abc", dry_run=True)
         assert result == ["h1", "h2"]
 
-    def test_no_local_id_returns_all(self):
-        """When local image ID is None, all hosts need transfer."""
+    def test_no_local_identity_returns_all(self):
+        """When local Id and digests are both empty, all hosts need transfer."""
         from sparkrun.containers.distribute import _filter_hosts_needing_image
 
-        result = _filter_hosts_needing_image("img", ["h1", "h2"], None)
+        result = _filter_hosts_needing_image("img", ["h1", "h2"], None, local_repo_digests=[])
         assert result == ["h1", "h2"]
 
 
@@ -390,7 +545,7 @@ class TestDistributeImageFromLocal:
     """Test distribute_image_from_local."""
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value=None)
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=(None, []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_dry_run(self, mock_ensure, mock_id, mock_parallel):
         mock_ensure.return_value = 0
@@ -403,7 +558,7 @@ class TestDistributeImageFromLocal:
         assert failed == []
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value=None)
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=(None, []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_success(self, mock_ensure, mock_id, mock_parallel):
         mock_ensure.return_value = 0
@@ -422,7 +577,7 @@ class TestDistributeImageFromLocal:
         assert "docker load" in call_kwargs[0][2]
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value=None)
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=(None, []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_ensure_fails(self, mock_ensure, mock_id, mock_parallel):
         """If ensure_image fails, all hosts are returned as failed."""
@@ -434,7 +589,7 @@ class TestDistributeImageFromLocal:
         mock_parallel.assert_not_called()
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value=None)
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=(None, []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_partial_failure(self, mock_ensure, mock_id, mock_parallel):
         """Only failed hosts are returned."""
@@ -449,7 +604,7 @@ class TestDistributeImageFromLocal:
         assert failed == ["h2"]
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value=None)
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=(None, []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_empty_hosts(self, mock_ensure, mock_id, mock_parallel):
         mock_ensure.return_value = 0
@@ -461,7 +616,7 @@ class TestDistributeImageFromLocal:
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
     @mock.patch("sparkrun.containers.distribute._filter_hosts_needing_image")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value="sha256:abc")
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=("sha256:abc", []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_hash_check_skips_up_to_date(self, mock_ensure, mock_id, mock_filter, mock_parallel):
         """When all hosts are up to date, no transfer happens."""
@@ -475,7 +630,7 @@ class TestDistributeImageFromLocal:
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
     @mock.patch("sparkrun.containers.distribute._filter_hosts_needing_image")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value="sha256:abc")
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=("sha256:abc", []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_hash_check_transfers_stale_hosts(self, mock_ensure, mock_id, mock_filter, mock_parallel):
         """Only hosts that need the image get the transfer."""
@@ -497,7 +652,7 @@ class TestDistributeImageTransferHosts:
     """Test transfer_hosts routing in distribute_image_from_local."""
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value=None)
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=(None, []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_transfer_hosts_used_for_pipeline(self, mock_ensure, mock_id, mock_parallel):
         """When transfer_hosts is provided, pipeline uses those IPs."""
@@ -520,7 +675,7 @@ class TestDistributeImageTransferHosts:
         assert "10.0.0.2" in transferred
 
     @mock.patch("sparkrun.containers.distribute.run_pipeline_to_remotes_parallel")
-    @mock.patch("sparkrun.containers.distribute.get_image_id", return_value=None)
+    @mock.patch("sparkrun.containers.distribute.get_image_identity", return_value=(None, []))
     @mock.patch("sparkrun.containers.distribute.ensure_image")
     def test_transfer_hosts_failure_maps_back(self, mock_ensure, mock_id, mock_parallel):
         """Failures on transfer IPs are reported as management hostnames."""
@@ -653,14 +808,14 @@ class TestDistributeImageFromHead:
         assert "10.0.0.1" in dist_script
         assert "10.0.0.2" in dist_script
 
-    @mock.patch("sparkrun.containers.distribute._check_remote_image_ids")
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
     @mock.patch("sparkrun.orchestration.distribution._distribute_from_head")
     def test_all_hosts_up_to_date_early_return(self, mock_dist, mock_check):
         """All hosts have matching image → early return, no distribution."""
         mock_check.return_value = {
-            "head": "sha256:abc123",
-            "w1": "sha256:abc123",
-            "w2": "sha256:abc123",
+            "head": ("sha256:abc123", []),
+            "w1": ("sha256:abc123", []),
+            "w2": ("sha256:abc123", []),
         }
         from sparkrun.containers.distribute import distribute_image_from_head
 
@@ -668,14 +823,28 @@ class TestDistributeImageFromHead:
         assert failed == []
         mock_dist.assert_not_called()
 
-    @mock.patch("sparkrun.containers.distribute._check_remote_image_ids")
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
+    @mock.patch("sparkrun.orchestration.distribution._distribute_from_head")
+    def test_all_hosts_up_to_date_by_digest_storage_driver_drift(self, mock_dist, mock_check):
+        """Issue #152: different Ids but matching RepoDigests → early return."""
+        mock_check.return_value = {
+            "head": ("sha256:lenovo", ["repo@sha256:e07b3d"]),
+            "w1": ("sha256:msi", ["repo@sha256:e07b3d"]),
+        }
+        from sparkrun.containers.distribute import distribute_image_from_head
+
+        failed = distribute_image_from_head("img:latest", ["head", "w1"])
+        assert failed == []
+        mock_dist.assert_not_called()
+
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
     @mock.patch("sparkrun.orchestration.distribution._distribute_from_head")
     def test_partial_workers_stale(self, mock_dist, mock_check):
         """Head has image, 1 of 2 workers stale → distribute only to stale worker."""
         mock_check.return_value = {
-            "head": "sha256:abc123",
-            "w1": "sha256:abc123",
-            "w2": "sha256:old999",
+            "head": ("sha256:abc123", []),
+            "w1": ("sha256:abc123", []),
+            "w2": ("sha256:old999", []),
         }
         mock_dist.return_value = []
         from sparkrun.containers.distribute import distribute_image_from_head
@@ -693,11 +862,11 @@ class TestDistributeImageFromHead:
         assert "10.0.0.2" in call_kwargs["distribute_script"]
         assert "10.0.0.1" not in call_kwargs["distribute_script"]
 
-    @mock.patch("sparkrun.containers.distribute._check_remote_image_ids")
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
     @mock.patch("sparkrun.orchestration.distribution._distribute_from_head")
     def test_head_missing_image_falls_through(self, mock_dist, mock_check):
-        """Head missing image (not in remote_ids) → all hosts passed through."""
-        mock_check.return_value = {"w1": "sha256:abc123"}
+        """Head missing image (not in remote_identities) → all hosts passed through."""
+        mock_check.return_value = {"w1": ("sha256:abc123", [])}
         mock_dist.return_value = []
         from sparkrun.containers.distribute import distribute_image_from_head
 
@@ -707,7 +876,7 @@ class TestDistributeImageFromHead:
         call_kwargs = mock_dist.call_args[1]
         assert call_kwargs["hosts"] == ["head", "w1", "w2"]
 
-    @mock.patch("sparkrun.containers.distribute._check_remote_image_ids")
+    @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
     @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
     def test_dry_run_skips_precheck(self, mock_run, mock_check):
         """dry_run skips the pre-check entirely."""

--- a/tests/test_mods.py
+++ b/tests/test_mods.py
@@ -1,0 +1,480 @@
+"""Tests for the generic mod resolver in :mod:`sparkrun.core.mods`.
+
+Covers resolution order, normalization, pre_exec injection shape (local
+vs. delegated), Recipe.to_dict round-trip preservation, and delegated-mode
+behavior (ensure_registry_on_host invocation, rsync staging).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from sparkrun.core.mods import (
+    ModNotFoundError,
+    ResolvedMod,
+    resolve_and_inject_mods,
+)
+from sparkrun.core.recipe import Recipe
+from sparkrun.core.registry import RegistryEntry, RegistryManager
+
+
+def _write_mod(base: Path, name: str, body: str = "echo hi") -> Path:
+    """Create a mod directory under *base*/<name>/ with a run.sh script."""
+    mod_dir = base / name
+    mod_dir.mkdir(parents=True, exist_ok=True)
+    (mod_dir / "run.sh").write_text("#!/bin/bash\n%s\n" % body)
+    return mod_dir
+
+
+def _make_registry_manager(
+    tmp_path: Path,
+    entries: list[RegistryEntry],
+) -> RegistryManager:
+    """Return a RegistryManager wired to a tmp config root + cache root."""
+    config_root = tmp_path / "config"
+    cache_root = tmp_path / "cache"
+    config_root.mkdir(parents=True, exist_ok=True)
+    cache_root.mkdir(parents=True, exist_ok=True)
+    mgr = RegistryManager(config_root=config_root, cache_root=cache_root)
+    mgr._save_registries(entries)
+    return mgr
+
+
+def _populate_registry_cache(
+    mgr: RegistryManager,
+    entry: RegistryEntry,
+    mods: dict[str, str] | None = None,
+) -> Path:
+    """Materialize <cache>/<name>/<mods_subpath>/<each mod>/run.sh."""
+    cache_dir = mgr._cache_dir(entry.name)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    if entry.mods_subpath and mods:
+        mods_dir = cache_dir / entry.mods_subpath
+        mods_dir.mkdir(parents=True, exist_ok=True)
+        for name, body in mods.items():
+            _write_mod(mods_dir, name, body)
+    return cache_dir
+
+
+def _recipe_with_mods(mods: list[str], source_path: Path | None = None) -> Recipe:
+    recipe = Recipe.from_dict(
+        {
+            "name": "test",
+            "model": "some/model",
+            "runtime": "vllm-distributed",
+            "container": "scitrera/dgx-spark-vllm:latest",
+            "mods": mods,
+        }
+    )
+    if source_path is not None:
+        recipe.source_path = str(source_path)
+    return recipe
+
+
+# ---------------------------------------------------------------------------
+# Local-mode resolution rules
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_adjacent_mod(tmp_path: Path):
+    """Rule 2: mod sitting next to the recipe at mods/<name>/run.sh resolves."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo")
+    recipe = _recipe_with_mods(["foo"], source_path=recipe_path)
+    mgr = _make_registry_manager(tmp_path, [])
+
+    resolve_and_inject_mods(recipe, mgr)
+
+    # mods list is preserved on the recipe so it round-trips via to_dict();
+    # idempotency is tracked separately via recipe._mods_resolved.
+    assert recipe.mods == ["foo"]
+    assert recipe._mods_resolved is True
+    assert len(recipe.pre_exec) == 2
+    copy_entry = recipe.pre_exec[0]
+    assert isinstance(copy_entry, dict)
+    assert copy_entry["copy"].endswith("/mods/foo")
+    assert copy_entry["dest"] == "/workspace/mods/foo"
+    assert "source_host" not in copy_entry
+    assert "run.sh" in recipe.pre_exec[1]
+
+
+def test_resolve_scoped_mod_explicit(tmp_path: Path):
+    """Rule 1: @registry/foo resolves under that registry's mods_subpath."""
+    entry = RegistryEntry(name="alt", url="https://example/alt.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [entry])
+    _populate_registry_cache(mgr, entry, mods={"foo": "echo alt"})
+
+    recipe = _recipe_with_mods(["@alt/foo"])
+    resolve_and_inject_mods(recipe, mgr)
+
+    assert "alt" in recipe.pre_exec[0]["copy"]
+    assert recipe.pre_exec[0]["copy"].endswith("/mods/foo")
+
+
+def test_resolve_same_registry(tmp_path: Path):
+    """Rule 3: recipe.source_registry's mods_subpath supplies the mod."""
+    entry = RegistryEntry(name="home", url="https://example/home.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [entry])
+    _populate_registry_cache(mgr, entry, mods={"foo": "echo home"})
+
+    recipe = _recipe_with_mods(["foo"])
+    recipe.source_registry = "home"
+    resolve_and_inject_mods(recipe, mgr)
+
+    assert recipe.pre_exec[0]["copy"].endswith("/mods/foo")
+    assert "home" in recipe.pre_exec[0]["copy"]
+
+
+def test_resolve_eugr_fallback(tmp_path: Path):
+    """Rule 4: missing elsewhere, look in the registry literally named 'eugr'."""
+    eugr_entry = RegistryEntry(name="eugr", url="https://example/eugr.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [eugr_entry])
+    _populate_registry_cache(mgr, eugr_entry, mods={"legacy": "echo legacy"})
+
+    recipe = _recipe_with_mods(["legacy"])  # no source_registry, no adjacent
+    resolve_and_inject_mods(recipe, mgr)
+
+    assert recipe.pre_exec[0]["copy"].endswith("/mods/legacy")
+
+
+def test_resolve_eugr_fallback_legacy_registry_without_mods_subpath(tmp_path: Path):
+    """Legacy registries.yaml entries (no mods_subpath) still get the fallback.
+
+    Older sparkrun installs have an eugr RegistryEntry that pre-dates the
+    mods_subpath field. The eugr-fallback path must default to ``"mods"``
+    rather than silently skipping.
+    """
+    eugr_entry = RegistryEntry(
+        name="eugr",
+        url="https://example/eugr.git",
+        subpath="recipes",
+        # NOTE: mods_subpath intentionally omitted (legacy layout)
+    )
+    mgr = _make_registry_manager(tmp_path, [eugr_entry])
+    _populate_registry_cache(
+        mgr,
+        # Materialize at the conventional <cache>/eugr/mods/<name>/run.sh
+        RegistryEntry(
+            name="eugr",
+            url=eugr_entry.url,
+            subpath="recipes",
+            mods_subpath="mods",
+        ),
+        mods={"fix-foo": "echo fix"},
+    )
+
+    recipe = _recipe_with_mods(["mods/fix-foo"])
+    resolve_and_inject_mods(recipe, mgr)
+    assert recipe.pre_exec[0]["copy"].endswith("/mods/fix-foo")
+
+
+def test_resolve_eugr_fallback_syncs_when_cache_missing(tmp_path: Path):
+    """If the eugr cache isn't populated, the resolver triggers a clone."""
+    eugr_entry = RegistryEntry(
+        name="eugr",
+        url="https://example/eugr.git",
+        subpath="recipes",
+        mods_subpath="mods",
+    )
+    mgr = _make_registry_manager(tmp_path, [eugr_entry])
+    # Do NOT pre-populate the cache; simulate _clone_or_pull creating it
+    # by writing the mod into the cache when called.
+
+    def _fake_clone_or_pull(entry):
+        target = mgr._cache_dir(entry.name) / entry.mods_subpath / "synced"
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "run.sh").write_text("#!/bin/bash\necho synced\n")
+        return True
+
+    recipe = _recipe_with_mods(["synced"])
+
+    with mock.patch.object(RegistryManager, "_clone_or_pull", side_effect=_fake_clone_or_pull) as mock_sync:
+        resolve_and_inject_mods(recipe, mgr)
+
+    mock_sync.assert_called_once()
+    assert recipe.pre_exec[0]["copy"].endswith("/mods/synced")
+
+
+def test_resolve_order_priority_adjacent_beats_registry(tmp_path: Path):
+    """Adjacent mods win over same-registry mods when both exist."""
+    entry = RegistryEntry(name="home", url="https://example/home.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [entry])
+    _populate_registry_cache(mgr, entry, mods={"foo": "echo from-registry"})
+
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    adjacent_dir = tmp_path / "mods"
+    _write_mod(adjacent_dir, "foo", body="echo adjacent")
+
+    recipe = _recipe_with_mods(["foo"], source_path=recipe_path)
+    recipe.source_registry = "home"
+    resolve_and_inject_mods(recipe, mgr)
+
+    # Adjacent path wins over registry path
+    copy_path = recipe.pre_exec[0]["copy"]
+    assert "mods/foo" in copy_path
+    assert "home" not in copy_path  # registry cache name not in path
+
+
+def test_resolve_order_priority_scoped_beats_adjacent(tmp_path: Path):
+    """Explicit @scoped reference bypasses adjacent-search."""
+    entry = RegistryEntry(name="alt", url="https://example/alt.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [entry])
+    _populate_registry_cache(mgr, entry, mods={"foo": "echo alt"})
+
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo", body="echo adjacent")
+
+    recipe = _recipe_with_mods(["@alt/foo"], source_path=recipe_path)
+    resolve_and_inject_mods(recipe, mgr)
+
+    assert "alt" in recipe.pre_exec[0]["copy"]
+
+
+def test_resolve_strips_mods_prefix(tmp_path: Path):
+    """`foo` and `mods/foo` resolve to identical pre_exec entries."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo")
+    mgr = _make_registry_manager(tmp_path, [])
+
+    r1 = _recipe_with_mods(["foo"], source_path=recipe_path)
+    r2 = _recipe_with_mods(["mods/foo"], source_path=recipe_path)
+    resolve_and_inject_mods(r1, mgr)
+    resolve_and_inject_mods(r2, mgr)
+
+    assert r1.pre_exec == r2.pre_exec
+    # And no double 'mods/mods/' in the source path
+    assert "mods/mods/" not in r1.pre_exec[0]["copy"]
+
+
+def test_resolve_not_found_raises_with_paths(tmp_path: Path):
+    """ModNotFoundError lists every candidate path the resolver tried."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    mgr = _make_registry_manager(tmp_path, [])
+    recipe = _recipe_with_mods(["nope"], source_path=recipe_path)
+
+    with pytest.raises(ModNotFoundError) as excinfo:
+        resolve_and_inject_mods(recipe, mgr)
+    err = excinfo.value
+    assert err.name == "nope"
+    assert err.tried, "ModNotFoundError should record the attempted paths"
+    # Adjacent paths should be present in the list
+    joined = " ".join(err.tried)
+    assert "mods/nope" in joined or "/nope" in joined
+
+
+def test_resolve_is_idempotent(tmp_path: Path):
+    """A second call after resolution is a no-op (recipe.mods cleared)."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo")
+    mgr = _make_registry_manager(tmp_path, [])
+    recipe = _recipe_with_mods(["foo"], source_path=recipe_path)
+
+    resolve_and_inject_mods(recipe, mgr)
+    pre_exec_after_first = list(recipe.pre_exec)
+    resolve_and_inject_mods(recipe, mgr)
+    assert recipe.pre_exec == pre_exec_after_first
+
+
+# ---------------------------------------------------------------------------
+# Pre-exec entry shape (local vs. delegated)
+# ---------------------------------------------------------------------------
+
+
+def test_pre_exec_entries_shape_local(tmp_path: Path):
+    """Local mode: copy dict has no `source_host` key."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo")
+    mgr = _make_registry_manager(tmp_path, [])
+    recipe = _recipe_with_mods(["foo"], source_path=recipe_path)
+
+    resolve_and_inject_mods(recipe, mgr, transfer_mode="local")
+
+    copy_entry = recipe.pre_exec[0]
+    assert isinstance(copy_entry, dict)
+    assert set(copy_entry.keys()) == {"copy", "dest"}
+    assert copy_entry["dest"] == "/workspace/mods/foo"
+    assert recipe.pre_exec[1] == ("export WORKSPACE_DIR=$PWD && cd /workspace/mods/foo && chmod +x run.sh && ./run.sh")
+
+
+def test_pre_exec_entries_shape_delegated_scoped(tmp_path: Path):
+    """Delegated mode: copy dict carries `source_host=<head>` for registry mods."""
+    entry = RegistryEntry(name="alt", url="https://example/alt.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [entry])
+    _populate_registry_cache(mgr, entry, mods={"foo": "echo alt"})
+
+    recipe = _recipe_with_mods(["@alt/foo"])
+
+    with mock.patch.object(RegistryManager, "ensure_registry_on_host", return_value="/remote/registries/_url_abc") as mock_ensure:
+        resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head="head-host", ssh_kwargs={})
+
+    mock_ensure.assert_called_once()
+    copy_entry = recipe.pre_exec[0]
+    assert copy_entry["source_host"] == "head-host"
+    assert copy_entry["dest"] == "/workspace/mods/foo"
+    assert copy_entry["copy"] == "/remote/registries/_url_abc/mods/foo"
+
+
+def test_delegated_rsyncs_adjacent_mod_to_head(tmp_path: Path):
+    """Adjacent mod in delegated mode is rsync'd to the head staging dir."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo")
+    mgr = _make_registry_manager(tmp_path, [])
+    recipe = _recipe_with_mods(["foo"], source_path=recipe_path)
+
+    with mock.patch("sparkrun.core.mods.run_rsync") as _mock_rsync:
+        _mock_rsync.return_value = mock.Mock(success=True, stderr="")
+        resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head="head-host", ssh_kwargs={})
+
+    _mock_rsync.assert_called_once()
+    args, kwargs = _mock_rsync.call_args
+    # run_rsync(local_path, host, dest, ...)
+    assert "head-host" in args
+    copy_entry = recipe.pre_exec[0]
+    assert copy_entry["source_host"] == "head-host"
+    assert copy_entry["copy"].endswith("/foo")
+
+
+def test_delegated_requires_head(tmp_path: Path):
+    mgr = _make_registry_manager(tmp_path, [])
+    recipe = _recipe_with_mods(["foo"])
+    with pytest.raises(ValueError, match="head"):
+        resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head=None)
+
+
+def test_delegated_dry_run_skips_rsync(tmp_path: Path):
+    """Dry-run still computes paths but never calls rsync or git on the head."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo")
+    mgr = _make_registry_manager(tmp_path, [])
+    recipe = _recipe_with_mods(["foo"], source_path=recipe_path)
+
+    with mock.patch("sparkrun.core.mods.run_rsync") as _mock_rsync:
+        resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head="head-host", dry_run=True)
+    _mock_rsync.assert_not_called()
+    assert recipe.pre_exec[0]["source_host"] == "head-host"
+
+
+# ---------------------------------------------------------------------------
+# Empty inputs and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_no_mods_is_noop(tmp_path: Path):
+    mgr = _make_registry_manager(tmp_path, [])
+    recipe = _recipe_with_mods([])
+    resolve_and_inject_mods(recipe, mgr)
+    assert recipe.pre_exec == []
+    assert recipe.mods == []
+
+
+def test_resolve_mod_dir_without_run_sh_misses(tmp_path: Path):
+    """A directory exists but lacks run.sh — should not match."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    (tmp_path / "mods" / "foo").mkdir(parents=True)  # no run.sh
+    mgr = _make_registry_manager(tmp_path, [])
+    recipe = _recipe_with_mods(["foo"], source_path=recipe_path)
+
+    with pytest.raises(ModNotFoundError):
+        resolve_and_inject_mods(recipe, mgr)
+
+
+# ---------------------------------------------------------------------------
+# Recipe.to_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_recipe_to_dict_preserves_mods_after_resolution(tmp_path: Path):
+    """Export contains the original mods list; pre_exec excludes mod-derived entries."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo")
+    mgr = _make_registry_manager(tmp_path, [])
+
+    recipe = Recipe.from_dict(
+        {
+            "name": "test",
+            "model": "m",
+            "runtime": "vllm-distributed",
+            "container": "img:tag",
+            "mods": ["foo"],
+            # No user-authored pre_exec
+        }
+    )
+    recipe.source_path = str(recipe_path)
+    resolve_and_inject_mods(recipe, mgr)
+
+    assert len(recipe.pre_exec) == 2  # mods injected entries are live in memory
+    exported = recipe.to_dict()
+    # mods round-trips
+    assert exported.get("mods") == ["foo"]
+    # mod-derived pre_exec entries are NOT exported (Recipe.to_dict() resets
+    # pre_exec from raw input — which had no pre_exec key)
+    assert "pre_exec" not in exported
+
+
+def test_recipe_to_dict_preserves_user_pre_exec_only(tmp_path: Path):
+    """If the user authored pre_exec, export keeps that — not mod-derived entries."""
+    recipe_path = tmp_path / "my.yaml"
+    recipe_path.write_text("name: x\n")
+    _write_mod(tmp_path / "mods", "foo")
+    mgr = _make_registry_manager(tmp_path, [])
+
+    user_pre_exec = ["echo hello"]
+    recipe = Recipe.from_dict(
+        {
+            "name": "test",
+            "model": "m",
+            "runtime": "vllm-distributed",
+            "container": "img:tag",
+            "mods": ["foo"],
+            "pre_exec": list(user_pre_exec),
+        }
+    )
+    recipe.source_path = str(recipe_path)
+    resolve_and_inject_mods(recipe, mgr)
+
+    assert len(recipe.pre_exec) == 3  # user 1 + injected 2
+    exported = recipe.to_dict()
+    assert exported["mods"] == ["foo"]
+    assert exported["pre_exec"] == user_pre_exec
+
+
+def test_recipe_getstate_setstate_roundtrips_mods():
+    recipe = Recipe.from_dict(
+        {
+            "name": "test",
+            "model": "m",
+            "runtime": "vllm-distributed",
+            "container": "img:tag",
+            "mods": ["foo", "mods/bar"],
+        }
+    )
+    state = recipe.__getstate__()
+    assert state["mods"] == ["foo", "mods/bar"]
+
+    restored = Recipe._deserialize(state)
+    assert restored.mods == ["foo", "mods/bar"]
+
+
+# ---------------------------------------------------------------------------
+# ResolvedMod sanity
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_mod_dataclass():
+    r = ResolvedMod(name="foo", source_path="/x/foo", source_host=None)
+    assert r.name == "foo"
+    assert r.source_host is None

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -68,9 +68,12 @@ def test_load_v1_recipe_migrates_to_eugr(tmp_recipe_dir: Path):
     assert recipe.runtime == "vllm-distributed"
     assert recipe.builder == "eugr"
 
-    # build_args and mods should be in runtime_config
+    # build_args stays in runtime_config; mods is now a top-level field
+    # (auto-migrated from v1 runtime_config to recipe.mods so the generic
+    # core/mods.py resolver can handle any builder)
     assert recipe.runtime_config["build_args"] == ["ARG1=value1"]
-    assert recipe.runtime_config["mods"] == ["mod1.patch"]
+    assert recipe.mods == ["mod1.patch"]
+    assert "mods" not in recipe.runtime_config
 
 
 def test_load_v1_recipe_no_mods_still_eugr(tmp_recipe_dir: Path):
@@ -559,7 +562,9 @@ def test_recipe_runtime_config_catchall():
         }
     )
     assert recipe.runtime_config["build_args"] == ["--pre-tf"]
-    assert recipe.runtime_config["mods"] == ["mods/fix-something"]
+    # mods is a known top-level field, not swept into runtime_config
+    assert recipe.mods == ["mods/fix-something"]
+    assert "mods" not in recipe.runtime_config
     assert recipe.runtime_config["custom_field"] == "custom_value"
     # Known keys should NOT be in runtime_config
     assert "name" not in recipe.runtime_config

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -301,6 +301,106 @@ def test_sglang_validate_recipe_no_model():
     assert "model is required" in issues[0]
 
 
+# --- SGLang prepare(): speculative draft-model pre-sync ---
+
+
+def _sglang_recipe(**overrides) -> Recipe:
+    data = {
+        "name": "test-recipe",
+        "model": "meta-llama/Llama-2-7b-hf",
+        "runtime": "sglang",
+    }
+    data.update(overrides)
+    return Recipe.from_dict(data)
+
+
+def _model_names(recipe) -> list[str]:
+    return [e.name for e in recipe.distribution_config.models.entries]
+
+
+def test_sglang_prepare_canonical_key_adds_draft_model():
+    """speculative_draft_model_path → distribution_config.add_model."""
+    runtime = SglangRuntime()
+    recipe = _sglang_recipe(defaults={"speculative_draft_model_path": "draft/repo"})
+    runtime.prepare(recipe, hosts=["10.0.0.1"])
+    assert "draft/repo" in _model_names(recipe)
+
+
+def test_sglang_prepare_alias_key_adds_draft_model():
+    """speculative_draft_model alias also triggers add_model."""
+    runtime = SglangRuntime()
+    recipe = _sglang_recipe(defaults={"speculative_draft_model": "alias/draft"})
+    runtime.prepare(recipe, hosts=["10.0.0.1"])
+    assert "alias/draft" in _model_names(recipe)
+
+
+def test_sglang_prepare_canonical_wins_when_both_set():
+    """When both keys are set, canonical key wins; add_model called once."""
+    runtime = SglangRuntime()
+    recipe = _sglang_recipe(
+        defaults={
+            "speculative_draft_model_path": "canonical/draft",
+            "speculative_draft_model": "alias/draft",
+        },
+    )
+    runtime.prepare(recipe, hosts=["10.0.0.1"])
+    names = _model_names(recipe)
+    assert "canonical/draft" in names
+    assert "alias/draft" not in names
+
+
+def test_sglang_prepare_no_speculative_is_noop():
+    """prepare() does nothing when neither key is set."""
+    runtime = SglangRuntime()
+    recipe = _sglang_recipe()
+    before = list(_model_names(recipe))
+    runtime.prepare(recipe, hosts=["10.0.0.1"])
+    assert _model_names(recipe) == before
+
+
+def test_sglang_speculative_canonical_emits_flag():
+    """Generated command includes --speculative-draft-model-path."""
+    runtime = SglangRuntime()
+    recipe = _sglang_recipe(defaults={"speculative_draft_model_path": "draft/repo"})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--speculative-draft-model-path draft/repo" in cmd
+
+
+def test_sglang_speculative_alias_emits_flag():
+    """Alias key normalizes to canonical so the flag still emits."""
+    runtime = SglangRuntime()
+    recipe = _sglang_recipe(defaults={"speculative_draft_model": "alias/draft"})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--speculative-draft-model-path alias/draft" in cmd
+
+
+def test_sglang_speculative_alias_emits_flag_in_node_command():
+    """Alias normalization also applies to per-node command generation."""
+    runtime = SglangRuntime()
+    recipe = _sglang_recipe(defaults={"speculative_draft_model": "alias/draft"})
+    cmd = runtime.generate_node_command(
+        recipe,
+        {},
+        head_ip="10.0.0.1",
+        num_nodes=2,
+        node_rank=0,
+    )
+    assert "--speculative-draft-model-path alias/draft" in cmd
+
+
+def test_sglang_speculative_skip_key_strips_flag():
+    """skip_keys suppresses --speculative-draft-model-path."""
+    runtime = SglangRuntime()
+    recipe = _sglang_recipe(defaults={"speculative_draft_model_path": "draft/repo"})
+    cmd = runtime.generate_command(
+        recipe,
+        {},
+        is_cluster=False,
+        skip_keys={"speculative_draft_model_path"},
+    )
+    assert "--speculative-draft-model-path" not in cmd
+
+
 # --- VllmDistributedRuntime Tests ---
 
 

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -913,25 +913,8 @@ class TestEugrPrepare:
                     # subprocess.run should not be called in dry-run
                     mock_run.assert_not_called()
 
-    def test_prepare_injects_mod_pre_exec(self, eugr_builder):
-        """prepare_image() injects mod entries into recipe.pre_exec."""
-        builder, repo_dir = eugr_builder
-        recipe = Recipe.from_dict(
-            {
-                "name": "test",
-                "model": "some-model",
-                "runtime": "eugr-vllm",
-                "runtime_config": {"mods": ["mods/flash-attn"]},
-            }
-        )
-        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=True):
-            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                builder.prepare_image("vllm-node", recipe, ["10.0.0.1"])
-                # Should have injected copy + exec entries
-                assert len(recipe.pre_exec) == 2
-                assert isinstance(recipe.pre_exec[0], dict)
-                assert "copy" in recipe.pre_exec[0]
-                assert "run.sh" in recipe.pre_exec[1]
+    # Note: mod -> pre_exec injection moved out of the eugr builder into the
+    # generic core/mods.py resolver. See tests/test_mods.py for that coverage.
 
     def test_prepare_build_failure_raises(self, eugr_builder):
         """prepare_image() raises RuntimeError on build failure."""

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,6 +2,6 @@
 # Run: python scripts/update-versions.py to sync all files
 # Run: python scripts/update-versions.py --check to verify (CI-friendly)
 
-sparkrun: 0.2.31
+sparkrun: 0.2.32
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,7 +1,17 @@
-# Authoritative versions for all sparkrun packages
-# Run: python scripts/update-versions.py to sync all files
-# Run: python scripts/update-versions.py --check to verify (CI-friendly)
+# Authoritative versions for all sparkrun packages.
+# Run: python scripts/update-versions.py             to sync all files
+# Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
 sparkrun: 0.2.32
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
+
+project_rules:
+  sparkrun:
+    - { type: pyproject, path: pyproject.toml }
+  sparkrun-cc-plugin:
+    - { type: plugin,      path: sparkrun-cc-plugin/.claude-plugin/plugin.json }
+    - { type: marketplace, path: .claude-plugin/marketplace.json, args: [ sparkrun-cc-plugin ] }
+  sparkrun-openclaw-plugin:
+    - { type: package, path: sparkrun-openclaw-plugin/package.json }
+    - { type: plugin,  path: sparkrun-openclaw-plugin/openclaw.plugin.json }

--- a/versions.yaml
+++ b/versions.yaml
@@ -6,6 +6,17 @@ sparkrun: 0.2.32
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 
+# Prefer pinned versions to avoid supply chain attacks.
+preferred_versions:
+  python:
+    "scitrera-app-framework": "0.0.69"
+    "vpd": "0.9.13"
+    "six": "1.17.0" # transitive dependency of vpd but we pin the version for security reasons
+    "click": "8.3.3"
+    "pyyaml": "6.0.3"
+    "huggingface_hub": "1.14.0"
+    "textual": "8.2.5"
+
 project_rules:
   sparkrun:
     - { type: pyproject, path: pyproject.toml }


### PR DESCRIPTION
This pull request refactors and improves version management, dependency updates, and image comparison logic in the project. The most significant change is refining the handling of mods and image comparison output. 

**Builder and mod handling changes:**

* The `EugrBuilder` class and its `prepare_image` method no longer handle conversion of recipe `mods` into `pre_exec` entries; this responsibility is now centralized in `sparkrun.core.mods`. All related code and docstrings have been removed or updated for clarity. [[1]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL111-R117) [[2]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL139-R143) [[3]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL166-L167) [[4]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL211-R215) [[5]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL250-L254) [[6]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL481-L528)

* sparkrun's new universal mods support has 4-stage resolution:

1. adjacent to recipe (whether local or repo)
2. recipe registry declared mods directory
3. remote registries via @registry/ syntax
4. fallback to mods in eugr’s repo for compatibility/transition

**Improvements to Draft Model Handling**
* Now vllm, sglang, and atlas runtimes all have automatic handling for transferring & distributing draft models from HF to relevant nodes (previously just vllm for dflash). 

**Image comparison improvements:**

* The `adv compare-images` CLI command now compares both image IDs and repo digests across hosts, using new helper functions for more robust identity checking. The output is enhanced for both JSON and table formats, showing image IDs, repo digests, and match status in a clearer, more compact layout. [[1]](diffhunk://#diff-30ce6bb7b18ef11f2ebdac4c0519134cfa6829fd4a2f44cf1868cbefec6ba094L42-R43) [[2]](diffhunk://#diff-30ce6bb7b18ef11f2ebdac4c0519134cfa6829fd4a2f44cf1868cbefec6ba094L55-R59) [[3]](diffhunk://#diff-30ce6bb7b18ef11f2ebdac4c0519134cfa6829fd4a2f44cf1868cbefec6ba094L71-R105)

**Version management and dependency updates:**

* The `scripts/update-versions.py` script is now a thin wrapper that delegates all version synchronization logic to the `scitrera-repo-tools` package, either by direct import or by invoking it through `uvx`/`uv`. This removes all custom logic from the script and ensures consistency with other repositories using the same tooling.
* Updated dependencies in `pyproject.toml`, including bumping `click` to 8.3.3, `textual` to 8.2.5, and `pytest` to 9.0.3. The project version is incremented to 0.2.32. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L30-R38)