### PR TITLE
feature secure api key

### DIFF
--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -561,7 +561,28 @@ def _run_benchmark(
             click.echo("Error: --bench-option must be key=value, got: %s" % opt_str, err=True)
             sys.exit(1)
         key, _, val = opt_str.partition("=")
-        bench_args[key.strip()] = fw.interpret_arg(key.strip(), val.strip())
+        stripped_key = key.strip()
+        if "api_key" in stripped_key.lower():
+            click.echo(
+                f"Error: Passing '{stripped_key}' via --bench-option is insecure. "
+                "Please set the OPENAI_API_KEY environment variable or use a .env file instead.",
+                err=True,
+            )
+            sys.exit(1)
+        bench_args[stripped_key] = fw.interpret_arg(stripped_key, val.strip())
+
+    if "api_key" not in bench_args:
+        import os
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            try:
+                from dotenv import load_dotenv
+                load_dotenv()
+                api_key = os.environ.get("OPENAI_API_KEY")
+            except ImportError:
+                pass
+        if api_key:
+            bench_args["api_key"] = api_key
 
     if exit_on_first_fail:
         bench_args["exit_on_first_fail"] = True
@@ -652,7 +673,8 @@ def _run_benchmark(
     click.echo("")
     click.echo("Benchmark args:")
     for k, bv in bench_args.items():
-        click.echo("  %-35s %s" % (k + ":", bv))
+        display_val = "***REDACTED***" if "api_key" in k.lower() else bv
+        click.echo("  %-35s %s" % (k + ":", display_val))
     click.echo("=" * 60)
     click.echo("")
 

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -573,7 +573,7 @@ def _run_benchmark(
         if "api_key" in stripped_key.lower():
             click.echo(
                 f"Error: Passing '{stripped_key}' via --bench-option is insecure. "
-                "Please set the OPENAI_API_KEY environment variable or use a .env file instead.",
+                "Please use the --api-key-env flag to pass it via an environment variable instead.",
                 err=True,
             )
             sys.exit(1)

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -135,6 +135,11 @@ def benchmark(ctx):
 @click.option("--output", "output_file", default=None, type=click.Path(), help="Output file for results YAML")
 @click.option("-b", "--benchmark-option", "bench_options", multiple=True, help="Override benchmark arg: -b key=value (repeatable)")
 @click.option(
+    "--api-key-env",
+    default=None,
+    help="Name of the environment variable to read the API key from (e.g. OPENAI_API_KEY).",
+)
+@click.option(
     "--exit-on-first-fail/--no-exit-on-first-fail",
     "exit_on_first_fail",
     default=True,
@@ -180,6 +185,7 @@ def benchmark_run(
     framework,
     output_file,
     bench_options,
+    api_key_env,
     exit_on_first_fail,
     no_stop,
     skip_run,
@@ -211,6 +217,7 @@ def benchmark_run(
         framework,
         output_file,
         bench_options,
+        api_key_env,
         exit_on_first_fail,
         no_stop,
         skip_run,
@@ -464,6 +471,7 @@ def _run_benchmark(
     framework,
     output_file,
     bench_options,
+    api_key_env,
     exit_on_first_fail,
     no_stop,
     skip_run,
@@ -571,18 +579,22 @@ def _run_benchmark(
             sys.exit(1)
         bench_args[stripped_key] = fw.interpret_arg(stripped_key, val.strip())
 
-    if "api_key" not in bench_args:
+    if "api_key" not in bench_args and api_key_env:
         import os
-        api_key = os.environ.get("OPENAI_API_KEY")
+        api_key = os.environ.get(api_key_env)
         if not api_key:
             try:
                 from dotenv import load_dotenv
                 load_dotenv()
-                api_key = os.environ.get("OPENAI_API_KEY")
+                api_key = os.environ.get(api_key_env)
             except ImportError:
                 pass
         if api_key:
             bench_args["api_key"] = api_key
+        else:
+            click.echo(
+                f"Warning: --api-key-env '{api_key_env}' specified, but not found in environment.", err=True
+            )
 
     if exit_on_first_fail:
         bench_args["exit_on_first_fail"] = True


### PR DESCRIPTION
- **chore: bump version to 0.2.32 in pyproject.toml and versions.yaml**
- **re-enable Atlas multi-node computation tests and comment out single-node restriction in runtime**
- **chg: enhance container image matching with digest-based checks; intended to address #152**
- **refactor: move mod-to-pre_exec logic to core resolver and update relevant tests**
- **Revert "re-enable Atlas multi-node computation tests and comment out single-node restriction in runtime"**
- **refactor: replace custom version sync logic with scitrera-repo-tools shim**
- **bump: update dependencies and versions in pyproject.toml and versions.yaml**
- **feat(cli): reject api_key via --bench-option and inject securely from env**
- **feat(cli): add opt-in --api-key-env flag for api key injection**
