### PR TITLE
v0.2.33 mods resolution hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.32"
+version = "0.2.33"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/core/mods.py
+++ b/src/sparkrun/core/mods.py
@@ -36,8 +36,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from sparkrun.orchestration.primitives import run_script_on_host
 from sparkrun.orchestration.ssh import run_rsync
 from sparkrun.utils import parse_scoped_name
+from sparkrun.utils.shell import safe_remote_path
 
 if TYPE_CHECKING:
     from sparkrun.core.config import SparkrunConfig
@@ -274,6 +276,29 @@ def _rsync_to_head(
     return dest
 
 
+def _mod_exists_on_head(
+    remote_path: str,
+    head: str,
+    ssh_kwargs: dict | None,
+    dry_run: bool,
+) -> bool:
+    """Check that ``remote_path`` is a mod directory on *head* (has a ``run.sh``).
+
+    Mirrors :func:`_mod_dir_if_valid` semantics over SSH so the delegated
+    resolver can fall through to later stages when an earlier stage's
+    candidate path doesn't actually exist on the head node.
+
+    Skipped (returns ``True``) during ``dry_run`` so resolution proceeds
+    without contacting the head.
+    """
+    if dry_run:
+        return True
+    safe = safe_remote_path(remote_path)
+    script = 'test -d "%s" && test -e "%s/run.sh"\n' % (safe, safe)
+    result = run_script_on_host(head, script, ssh_kwargs=ssh_kwargs, timeout=30)
+    return result.success
+
+
 def _resolve_delegated(
     ref: str,
     recipe: Recipe,
@@ -288,14 +313,28 @@ def _resolve_delegated(
     Registry-backed mods are materialized via
     ``RegistryManager.ensure_registry_on_host``; adjacent recipes' mods
     are rsynced to a staging directory on the head node.
+
+    Each registry-backed stage probes the head with a single
+    ``test -d <path>/run.sh`` round-trip after ensuring the registry is
+    on disk, so resolution falls through to the next stage when the
+    candidate is absent (e.g. the @eugr safety net at stage 4 for
+    legacy mods).
     """
 
-    def _ensure_registry(name: str) -> str:
+    def _ensure_registry(name: str, extra_sparse_paths: list[str] | None = None) -> str:
         path = ensured_registries.get(name)
         if path is None:
-            path = registry_mgr.ensure_registry_on_host(name, head, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
+            path = registry_mgr.ensure_registry_on_host(
+                name,
+                head,
+                ssh_kwargs=ssh_kwargs,
+                dry_run=dry_run,
+                extra_sparse_paths=extra_sparse_paths,
+            )
             ensured_registries[name] = path
         return path
+
+    tried: list[str] = []
 
     # rule 1: explicit @registry/...
     registry_name, rel = parse_scoped_name(ref)
@@ -309,17 +348,22 @@ def _resolve_delegated(
         remote_root = _ensure_registry(registry_name)
         rel_clean = _normalize_ref(rel)
         remote_path = "%s/%s/%s" % (remote_root, entry.mods_subpath, rel_clean)
+        tried.append(remote_path + " (on %s)" % head)
+        if not _mod_exists_on_head(remote_path, head, ssh_kwargs, dry_run):
+            raise ModNotFoundError(ref, tried)
         name = Path(rel_clean).name
         return ResolvedMod(name=name, source_path=remote_path, source_host=head)
 
     # rule 2: adjacent to recipe (local) -> rsync to head
-    tried: list[str] = []
     local_hit = _resolve_adjacent(ref, recipe.source_path, tried)
     if local_hit is not None:
         staged = _rsync_to_head(str(local_hit.resolve()), local_hit.name, head, ssh_kwargs, dry_run)
         return ResolvedMod(name=local_hit.name, source_path=staged, source_host=head)
 
-    # rule 3: same registry as recipe
+    # rule 3: same registry as recipe — verify the candidate actually
+    # exists on the head so missing mods (e.g. in a registry whose
+    # mods_subpath is empty or not yet populated) fall through to the
+    # eugr fallback at stage 4.
     if recipe.source_registry:
         try:
             entry = registry_mgr.get_registry(recipe.source_registry)
@@ -330,11 +374,8 @@ def _resolve_delegated(
             rel_clean = _normalize_ref(ref)
             remote_path = "%s/%s/%s" % (remote_root, entry.mods_subpath, rel_clean)
             tried.append(remote_path + " (on %s)" % head)
-            # Trust delegated existence — if missing the docker cp will fail
-            # with a clear error; we cannot easily stat over SSH per-mod
-            # without paying a round-trip per ref. Verify only at the
-            # registry level (ensure_registry_on_host succeeded).
-            return ResolvedMod(name=Path(rel_clean).name, source_path=remote_path, source_host=head)
+            if _mod_exists_on_head(remote_path, head, ssh_kwargs, dry_run):
+                return ResolvedMod(name=Path(rel_clean).name, source_path=remote_path, source_host=head)
 
     # rule 4: eugr fallback — default subpath to "mods" so legacy
     # registries.yaml files (no mods_subpath field) still work.
@@ -345,11 +386,15 @@ def _resolve_delegated(
         tried.append("@%s (registry not registered)" % EUGR_FALLBACK_REGISTRY)
     if eugr_entry is not None:
         eugr_subpath = eugr_entry.mods_subpath or "mods"
-        remote_root = _ensure_registry(EUGR_FALLBACK_REGISTRY)
+        # Force the eugr mods subpath into sparse-checkout so legacy
+        # registries.yaml files (whose eugr entry lacks ``mods_subpath``)
+        # still produce a working ``mods/`` directory on the head.
+        remote_root = _ensure_registry(EUGR_FALLBACK_REGISTRY, extra_sparse_paths=[eugr_subpath])
         rel_clean = _normalize_ref(ref)
         remote_path = "%s/%s/%s" % (remote_root, eugr_subpath, rel_clean)
         tried.append(remote_path + " (on %s)" % head)
-        return ResolvedMod(name=Path(rel_clean).name, source_path=remote_path, source_host=head)
+        if _mod_exists_on_head(remote_path, head, ssh_kwargs, dry_run):
+            return ResolvedMod(name=Path(rel_clean).name, source_path=remote_path, source_host=head)
 
     raise ModNotFoundError(ref, tried)
 

--- a/src/sparkrun/core/registry.py
+++ b/src/sparkrun/core/registry.py
@@ -1341,6 +1341,7 @@ class RegistryManager:
         host: str,
         ssh_kwargs: dict | None = None,
         dry_run: bool = False,
+        extra_sparse_paths: list[str] | None = None,
     ) -> str:
         """Clone or update a registry's git repo on a remote head node.
 
@@ -1356,6 +1357,10 @@ class RegistryManager:
             host: Remote head node hostname.
             ssh_kwargs: SSH connection kwargs.
             dry_run: When True, return the would-be path without acting.
+            extra_sparse_paths: Additional sparse-checkout paths to union
+                with the URL's normal set. Used by the eugr fallback to
+                guarantee ``mods/`` is checked out even when the local
+                registry entry predates the ``mods_subpath`` field.
 
         Returns:
             Absolute path on the remote host where the registry is checked out.
@@ -1366,25 +1371,33 @@ class RegistryManager:
         from sparkrun.utils.shell import quote
 
         entry = self.get_registry(name)
-        sparse_paths = self._sparse_checkout_paths_for_url(entry.url)
+        sparse_paths = list(self._sparse_checkout_paths_for_url(entry.url))
+        if extra_sparse_paths:
+            for p in extra_sparse_paths:
+                if p and p not in sparse_paths:
+                    sparse_paths.append(p)
         url_hash = hashlib.sha256(entry.url.encode()).hexdigest()[:12]
         remote_clone_dir = "~/.cache/sparkrun/registries/_url_%s" % url_hash
         sparse_args = " ".join(quote(p) for p in sparse_paths) if sparse_paths else ""
 
+        # Redirect git's chatty output to stderr (1>&2) so stdout stays clean,
+        # then emit the resolved path via a printf sentinel.  Parsing the
+        # sentinel is robust even if some SSH config merges streams or a
+        # future change adds more shell noise.
         script = (
             "set -e\n"
             "REPO_DIR=%(path)s\n"
             'if [ -d "$REPO_DIR/.git" ]; then\n'
-            '  git -C "$REPO_DIR" fetch origin\n'
-            '  git -C "$REPO_DIR" reset --hard FETCH_HEAD\n'
+            '  git -C "$REPO_DIR" fetch origin 1>&2\n'
+            '  git -C "$REPO_DIR" reset --hard FETCH_HEAD 1>&2\n'
             "else\n"
             '  mkdir -p "$(dirname "$REPO_DIR")"\n'
-            '  git clone --filter=blob:none --sparse %(url)s "$REPO_DIR"\n'
+            '  git clone --filter=blob:none --sparse %(url)s "$REPO_DIR" 1>&2\n'
             "fi\n"
         ) % {"path": remote_clone_dir, "url": quote(entry.url)}
         if sparse_args:
-            script += 'git -C "$REPO_DIR" sparse-checkout set %s\n' % sparse_args
-        script += 'echo "$REPO_DIR"\n'
+            script += 'git -C "$REPO_DIR" sparse-checkout set %s 1>&2\n' % sparse_args
+        script += 'printf "__SPARKRUN_REPO_DIR__%s\\n" "$REPO_DIR"\n'
 
         logger.info("Ensuring registry %r on head node %s...", name, host)
         if dry_run:
@@ -1395,8 +1408,15 @@ class RegistryManager:
             raise RegistryError(
                 "Failed to ensure registry %r on %s: %s" % (name, host, result.stderr.strip() if result.stderr else "(no output)")
             )
-        # Strip trailing newlines and return the resolved path
-        return result.stdout.strip() if result.stdout else remote_clone_dir
+        # Scan stdout in reverse for the sentinel line so any unexpected
+        # preceding output (e.g. SSH config merging stderr into stdout) is
+        # ignored.  Fall back to the computed path if the sentinel is absent.
+        marker = "__SPARKRUN_REPO_DIR__"
+        if result.stdout:
+            for line in reversed(result.stdout.splitlines()):
+                if line.startswith(marker):
+                    return line[len(marker) :].strip()
+        return remote_clone_dir
 
     def _benchmark_dir(self, entry: RegistryEntry) -> Path | None:
         """Get benchmark directory within a cached registry.

--- a/tests/test_mods.py
+++ b/tests/test_mods.py
@@ -314,7 +314,10 @@ def test_pre_exec_entries_shape_delegated_scoped(tmp_path: Path):
 
     recipe = _recipe_with_mods(["@alt/foo"])
 
-    with mock.patch.object(RegistryManager, "ensure_registry_on_host", return_value="/remote/registries/_url_abc") as mock_ensure:
+    with (
+        mock.patch.object(RegistryManager, "ensure_registry_on_host", return_value="/remote/registries/_url_abc") as mock_ensure,
+        mock.patch("sparkrun.core.mods.run_script_on_host", return_value=mock.Mock(success=True)),
+    ):
         resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head="head-host", ssh_kwargs={})
 
     mock_ensure.assert_called_once()
@@ -467,6 +470,114 @@ def test_recipe_getstate_setstate_roundtrips_mods():
 
     restored = Recipe._deserialize(state)
     assert restored.mods == ["foo", "mods/bar"]
+
+
+# ---------------------------------------------------------------------------
+# Delegated existence verification & 4-stage fall-through
+# ---------------------------------------------------------------------------
+
+
+def _ensure_registry_side_effect(name, host, ssh_kwargs=None, dry_run=False, extra_sparse_paths=None) -> str:
+    """Distinct remote roots per registry so existence-probe paths are unambiguous."""
+    return "/remote/%s" % name
+
+
+def _make_exists_probe(present_paths: set[str]):
+    """Return a run_script_on_host stub keyed on `test -d <path>` substrings."""
+
+    def _stub(host, script, ssh_kwargs=None, timeout=None):
+        for p in present_paths:
+            if p in script:
+                return mock.Mock(success=True)
+        return mock.Mock(success=False)
+
+    return _stub
+
+
+def test_delegated_stage3_falls_through_to_eugr_on_missing_mod(tmp_path: Path):
+    """Stage 3 returning a path that doesn't exist on head must fall through to @eugr."""
+    official = RegistryEntry(name="official", url="https://example/off.git", subpath="recipes", mods_subpath="official-mods")
+    eugr = RegistryEntry(name="eugr", url="https://example/eugr.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [official, eugr])
+
+    recipe = _recipe_with_mods(["mods/fix-qwen3-coder-next"])
+    recipe.source_registry = "official"
+
+    eugr_path = "/remote/eugr/mods/fix-qwen3-coder-next"
+    probe = _make_exists_probe(present_paths={eugr_path})
+
+    with (
+        mock.patch.object(RegistryManager, "ensure_registry_on_host", side_effect=_ensure_registry_side_effect),
+        mock.patch("sparkrun.core.mods.run_script_on_host", side_effect=probe) as mock_probe,
+    ):
+        resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head="head-host", ssh_kwargs={})
+
+    # Both stage 3 (official) and stage 4 (eugr) were probed
+    probed_scripts = [call.args[1] if len(call.args) > 1 else call.kwargs.get("script", "") for call in mock_probe.call_args_list]
+    assert any("/remote/official/official-mods/fix-qwen3-coder-next" in s for s in probed_scripts)
+    assert any(eugr_path in s for s in probed_scripts)
+
+    copy_entry = recipe.pre_exec[0]
+    assert copy_entry["copy"] == eugr_path
+    assert copy_entry["source_host"] == "head-host"
+
+
+def test_delegated_stage4_forces_mods_into_sparse_checkout(tmp_path: Path):
+    """Stage 4 must pass extra_sparse_paths so legacy eugr entries still get mods/."""
+    # Note: eugr_entry has no mods_subpath here (legacy registries.yaml shape).
+    official = RegistryEntry(name="official", url="https://example/off.git", subpath="recipes")
+    eugr = RegistryEntry(name="eugr", url="https://example/eugr.git", subpath="recipes")
+    mgr = _make_registry_manager(tmp_path, [official, eugr])
+
+    recipe = _recipe_with_mods(["mods/some-mod"])
+    recipe.source_registry = "official"
+
+    with (
+        mock.patch.object(RegistryManager, "ensure_registry_on_host", side_effect=_ensure_registry_side_effect) as mock_ensure,
+        mock.patch("sparkrun.core.mods.run_script_on_host", return_value=mock.Mock(success=True)),
+    ):
+        resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head="head-host", ssh_kwargs={})
+
+    # The eugr call must include `mods` in extra_sparse_paths.
+    eugr_calls = [c for c in mock_ensure.call_args_list if c.args[0] == "eugr"]
+    assert eugr_calls, "expected eugr to be ensured on head"
+    assert eugr_calls[0].kwargs.get("extra_sparse_paths") == ["mods"]
+
+
+def test_delegated_stage1_scoped_raises_when_mod_missing(tmp_path: Path):
+    """Stage 1 (@registry/<rel>) must fail loudly when the explicit path is absent."""
+    alt = RegistryEntry(name="alt", url="https://example/alt.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [alt])
+
+    recipe = _recipe_with_mods(["@alt/missing"])
+
+    with (
+        mock.patch.object(RegistryManager, "ensure_registry_on_host", side_effect=_ensure_registry_side_effect),
+        mock.patch("sparkrun.core.mods.run_script_on_host", return_value=mock.Mock(success=False)),
+        pytest.raises(ModNotFoundError, match="missing"),
+    ):
+        resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head="head-host", ssh_kwargs={})
+
+
+def test_delegated_stage4_raises_when_eugr_also_missing(tmp_path: Path):
+    """If stage 3 and stage 4 both miss, ModNotFoundError lists every tried path."""
+    official = RegistryEntry(name="official", url="https://example/off.git", subpath="recipes", mods_subpath="official-mods")
+    eugr = RegistryEntry(name="eugr", url="https://example/eugr.git", subpath="recipes", mods_subpath="mods")
+    mgr = _make_registry_manager(tmp_path, [official, eugr])
+
+    recipe = _recipe_with_mods(["mods/nope"])
+    recipe.source_registry = "official"
+
+    with (
+        mock.patch.object(RegistryManager, "ensure_registry_on_host", side_effect=_ensure_registry_side_effect),
+        mock.patch("sparkrun.core.mods.run_script_on_host", return_value=mock.Mock(success=False)),
+        pytest.raises(ModNotFoundError) as exc_info,
+    ):
+        resolve_and_inject_mods(recipe, mgr, transfer_mode="delegated", head="head-host", ssh_kwargs={})
+
+    msg = str(exc_info.value)
+    assert "/remote/official/official-mods/nope" in msg
+    assert "/remote/eugr/mods/nope" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1646,3 +1646,49 @@ class TestClearCache:
     def test_returns_zero_on_empty_cache(self, mgr):
         """clear_cache returns 0 when cache is already empty."""
         assert mgr.clear_cache() == 0
+
+
+class TestEnsureRegistryOnHost:
+    """Path extraction in ensure_registry_on_host (issue #181)."""
+
+    def _setup(self, mgr):
+        entry = RegistryEntry(
+            name="alt",
+            url="https://github.com/example/recipes.git",
+            subpath="recipes",
+            mods_subpath="mods",
+        )
+        mgr._save_registries([entry])
+        return entry
+
+    def test_extracts_path_with_sentinel_despite_git_stderr_noise(self, mgr):
+        """A noisy stdout (e.g. git output bleeding through) must not corrupt the path."""
+        self._setup(mgr)
+        noisy_stdout = (
+            "From github.com:example/recipes\n"
+            " * branch            HEAD       -> FETCH_HEAD\n"
+            "HEAD is now at 8eeea34 update container names\n"
+            "__SPARKRUN_REPO_DIR__/home/user/.cache/sparkrun/registries/_url_abcdef012345\n"
+        )
+        fake_result = mock.Mock(success=True, stdout=noisy_stdout, stderr="")
+        with mock.patch("sparkrun.orchestration.primitives.run_script_on_host", return_value=fake_result):
+            path = mgr.ensure_registry_on_host("alt", "head-host", ssh_kwargs={})
+        assert path == "/home/user/.cache/sparkrun/registries/_url_abcdef012345"
+        assert "\n" not in path
+        assert "HEAD is now at" not in path
+
+    def test_extracts_path_when_only_sentinel_present(self, mgr):
+        """Normal happy path — stdout is just the sentinel line."""
+        self._setup(mgr)
+        fake_result = mock.Mock(success=True, stdout="__SPARKRUN_REPO_DIR__/remote/repo\n", stderr="")
+        with mock.patch("sparkrun.orchestration.primitives.run_script_on_host", return_value=fake_result):
+            path = mgr.ensure_registry_on_host("alt", "head-host", ssh_kwargs={})
+        assert path == "/remote/repo"
+
+    def test_falls_back_to_computed_path_when_sentinel_absent(self, mgr):
+        """Defensive fallback if the sentinel is somehow stripped."""
+        self._setup(mgr)
+        fake_result = mock.Mock(success=True, stdout="something else\n", stderr="")
+        with mock.patch("sparkrun.orchestration.primitives.run_script_on_host", return_value=fake_result):
+            path = mgr.ensure_registry_on_host("alt", "head-host", ssh_kwargs={})
+        assert path.startswith("~/.cache/sparkrun/registries/_url_")

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.2.32
+sparkrun: 0.2.33
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
This pull request improves the reliability and correctness of delegated mod resolution and registry handling, especially when working with remote hosts and legacy configurations. The changes ensure that mod directories are verified on the head node before use, add robust path extraction from remote commands, and extend test coverage for edge cases and legacy scenarios.

**Delegated mod resolution improvements:**

- Added explicit existence checks for mod directories on the head node during delegated mod resolution, ensuring that missing mods fall through to later resolution stages instead of failing silently. This includes verifying the presence of a `run.sh` in the candidate directory before proceeding. [[1]](diffhunk://#diff-ca3b25c5c7de8ad6c9dd5bf8d46594b66bff2ec101e3f728bdeb975d55089360R279-R301) [[2]](diffhunk://#diff-ca3b25c5c7de8ad6c9dd5bf8d46594b66bff2ec101e3f728bdeb975d55089360R351-R366) [[3]](diffhunk://#diff-ca3b25c5c7de8ad6c9dd5bf8d46594b66bff2ec101e3f728bdeb975d55089360L333-R377)
- When falling back to the `eugr` registry in stage 4, the code now forces the `mods/` subpath into the sparse-checkout configuration, ensuring compatibility with legacy registries that may lack the `mods_subpath` field. [[1]](diffhunk://#diff-ca3b25c5c7de8ad6c9dd5bf8d46594b66bff2ec101e3f728bdeb975d55089360L348-R396) [[2]](diffhunk://#diff-fbfc44915e7d79a167ac33d183a054c0025361bdea2cb9ae25ef72c510733d07R1360-R1363) [[3]](diffhunk://#diff-fbfc44915e7d79a167ac33d183a054c0025361bdea2cb9ae25ef72c510733d07L1369-R1400)

**Registry handling and robustness:**

- Enhanced the `ensure_registry_on_host` method to accept extra sparse-checkout paths and to robustly extract the resolved path from remote command output using a sentinel marker, even if noisy output is present. Falls back to the computed path if the marker is missing. [[1]](diffhunk://#diff-fbfc44915e7d79a167ac33d183a054c0025361bdea2cb9ae25ef72c510733d07R1344) [[2]](diffhunk://#diff-fbfc44915e7d79a167ac33d183a054c0025361bdea2cb9ae25ef72c510733d07L1369-R1400) [[3]](diffhunk://#diff-fbfc44915e7d79a167ac33d183a054c0025361bdea2cb9ae25ef72c510733d07L1398-R1419)

**Testing improvements:**

- Added comprehensive tests covering delegated mod existence verification, multi-stage fall-through logic, sparse-checkout handling for legacy registries, and error reporting when mods are missing at various stages.
- Added tests for the robustness of remote path extraction in `ensure_registry_on_host`, including scenarios with noisy output and missing sentinels.

**Version bumps:**

- Bumped the `sparkrun` version to `0.2.33` in `pyproject.toml` and `versions.yaml`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)