### PR TITLE
v0.2.34 eugr vllm image building integrity and distribution fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.33"
+version = "0.2.34"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -235,6 +235,9 @@ class EugrBuilder(BuilderPlugin):
 
         # Build image if needed
         if needs_build:
+            if "--cleanup" not in build_args:
+                build_args.append("--cleanup")
+
             if delegated:
                 self._build_image_remote(image, build_args, head, ssh_kwargs, dry_run)
                 if not dry_run:

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -235,15 +235,19 @@ class EugrBuilder(BuilderPlugin):
 
         # Build image if needed
         if needs_build:
-            if "--cleanup" not in build_args:
-                build_args.append("--cleanup")
+            # `--cleanup` is an unconditional builder-hygiene flag — keep it out of the
+            # cached build_args so cache identity remains tied to the recipe's canonical
+            # build_args (otherwise every subsequent cache check would miss).
+            effective_build_args = list(build_args)
+            if "--cleanup" not in effective_build_args:
+                effective_build_args.append("--cleanup")
 
             if delegated:
-                self._build_image_remote(image, build_args, head, ssh_kwargs, dry_run)
+                self._build_image_remote(image, effective_build_args, head, ssh_kwargs, dry_run)
                 if not dry_run:
                     self._save_build_metadata(image, build_args, config, host=head, ssh_kwargs=ssh_kwargs)
             else:
-                self._build_image(image, build_args, dry_run)
+                self._build_image(image, effective_build_args, dry_run)
                 if not dry_run:
                     self._save_build_metadata(image, build_args, config)
 

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -56,6 +56,129 @@ _RE_FLASHINFER_COMMIT = re.compile(r"\([\d.]+\w*-([0-9a-f]{6,})-d\d{8}\)")
 # build_args values that are eligible for cache skip checks
 _CACHEABLE_BUILD_ARGS: list[list[str]] = [[], ["--tf5"]]
 
+# Subdirectory under the sparkrun cache dir where per-build log files are written
+EUGR_BUILD_LOG_DIR = "eugr-builds"
+
+# Number of trailing lines from the build log to include in error messages
+_BUILD_ERROR_TAIL_LINES = 80
+
+# build-and-copy.sh phase markers — used to identify which phase failed.
+# Order matters: later markers shadow earlier ones when both appear.
+_BUILD_PHASE_MARKERS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"^Cleaning up wheels directory\.\.\.", re.MULTILINE), "cleanup"),
+    (re.compile(r"^Rebuilding FlashInfer wheels", re.MULTILINE), "flashinfer-rebuild"),
+    (re.compile(r"^FlashInfer build command:", re.MULTILINE), "flashinfer-build"),
+    (re.compile(r"^FlashInfer wheels ready\.", re.MULTILINE), "flashinfer-ready"),
+    (re.compile(r"^No FlashInfer wheels available", re.MULTILINE), "flashinfer-download-failed"),
+    (re.compile(r"^Rebuilding vLLM wheels", re.MULTILINE), "vllm-rebuild"),
+    (re.compile(r"^vLLM build command:", re.MULTILINE), "vllm-build"),
+    (re.compile(r"^vLLM wheels ready\.", re.MULTILINE), "vllm-ready"),
+    (re.compile(r"^No vLLM wheels available", re.MULTILINE), "vllm-download-failed"),
+    (re.compile(r"^Building runner image with command:", re.MULTILINE), "runner-build"),
+    (re.compile(r"^Building image with command:", re.MULTILINE), "mxfp4-build"),
+    (re.compile(r"^Saving image locally", re.MULTILINE), "image-save"),
+    (re.compile(r"^Loading image into", re.MULTILINE), "image-copy"),
+]
+
+# Explicit failure signatures — when present, override the phase inference.
+_BUILD_FAILURE_MARKERS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"^FlashInfer build failed", re.MULTILINE), "flashinfer-build (failed)"),
+    (re.compile(r"^vLLM build failed", re.MULTILINE), "vllm-build (failed)"),
+    (re.compile(r"^Error: No wheel files found", re.MULTILINE), "runner-build (no wheels)"),
+    (re.compile(r"^GPU arch .* not supported", re.MULTILINE), "wheel-download (gpu arch)"),
+    (re.compile(r"^Could not fetch release metadata", re.MULTILINE), "wheel-download (release metadata)"),
+    (re.compile(r"^Failed to download", re.MULTILINE), "wheel-download (asset)"),
+    (re.compile(r"^Copy to .* failed", re.MULTILINE), "image-copy (failed)"),
+]
+
+
+def _safe_image_name(image: str) -> str:
+    """Convert an image reference into a filesystem-safe slug."""
+    return re.sub(r"[^A-Za-z0-9._-]", "-", image).strip("-") or "image"
+
+
+def _identify_build_phase(output: str) -> str:
+    """Return a short phase identifier inferred from build-and-copy.sh output.
+
+    Failure markers take precedence over phase markers (a "FlashInfer build
+    failed" message overrides the earlier "FlashInfer build command:" so the
+    error context is more actionable).
+    """
+    for pat, label in _BUILD_FAILURE_MARKERS:
+        if pat.search(output):
+            return label
+    last_phase = "unknown"
+    for pat, label in _BUILD_PHASE_MARKERS:
+        if pat.search(output):
+            last_phase = label
+    return last_phase
+
+
+def _build_error_tail(output: str, n: int = _BUILD_ERROR_TAIL_LINES) -> str:
+    """Return the last *n* non-empty lines from *output* for error reporting."""
+    lines = [ln for ln in output.splitlines() if ln.strip()]
+    return "\n".join(lines[-n:])
+
+
+def _run_build_capturing(
+    cmd: list[str],
+    cwd: str | None = None,
+    log_path: Path | None = None,
+    stream: bool = False,
+) -> tuple[int, str]:
+    """Run *cmd*, capturing combined stdout+stderr to memory and (optionally) a file.
+
+    When *stream* is True, each line is also echoed to the parent stdout in
+    real time so the user can watch a long-running build. The full output is
+    captured regardless so callers always have something to parse on failure.
+
+    Args:
+        cmd: Command argv to execute.
+        cwd: Working directory.
+        log_path: Optional file path to tee output into. Creation failures are
+            logged at WARNING but do not abort the build.
+        stream: If True, echo each line to ``sys.stdout`` as it's read.
+
+    Returns:
+        Tuple of ``(returncode, captured_output)``.
+    """
+    import sys
+
+    log_file = None
+    if log_path is not None:
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_file = open(log_path, "w", encoding="utf-8", errors="replace")
+        except OSError as e:
+            logger.warning("Could not open build log %s: %s", log_path, e)
+            log_file = None
+
+    captured_lines: list[str] = []
+    try:
+        with subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        ) as proc:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                captured_lines.append(line)
+                if log_file is not None:
+                    log_file.write(line)
+                    log_file.flush()
+                if stream:
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+            rc = proc.wait()
+    finally:
+        if log_file is not None:
+            log_file.close()
+
+    return rc, "".join(captured_lines)
+
 
 def _load_build_cache(cache_dir: Path) -> dict:
     """Load the eugr build cache from disk."""
@@ -243,12 +366,17 @@ class EugrBuilder(BuilderPlugin):
                 effective_build_args.append("--cleanup")
 
             if delegated:
-                self._build_image_remote(image, effective_build_args, head, ssh_kwargs, dry_run)
+                self._build_image_remote(image, effective_build_args, head, ssh_kwargs, dry_run, config=config)
+                # Verify the freshly built image has flashinfer before we cache the
+                # metadata — a missing flashinfer triplet is the most common silent
+                # corruption mode the rebuild path produces (see issue #164).
                 if not dry_run:
+                    self._verify_image_imports(image, host=head, ssh_kwargs=ssh_kwargs)
                     self._save_build_metadata(image, build_args, config, host=head, ssh_kwargs=ssh_kwargs)
             else:
-                self._build_image(image, effective_build_args, dry_run)
+                self._build_image(image, effective_build_args, dry_run, config=config)
                 if not dry_run:
+                    self._verify_image_imports(image)
                     self._save_build_metadata(image, build_args, config)
 
         # TODO: potentially inject metadata flags as needed into recipe?
@@ -516,6 +644,122 @@ class EugrBuilder(BuilderPlugin):
         except Exception:
             return None
 
+    def _build_log_path(
+        self,
+        image: str,
+        config: SparkrunConfig | None = None,
+        host: str | None = None,
+    ) -> Path | None:
+        """Return a per-build log file path under the sparkrun cache dir.
+
+        Returns ``None`` if the cache dir cannot be resolved — callers should
+        treat logging to disk as best-effort.
+        """
+        cache_dir = self._resolve_cache_dir(config)
+        if cache_dir is None:
+            return None
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        suffix = "-remote-%s" % _safe_image_name(host) if host else ""
+        name = "%s-%s%s.log" % (_safe_image_name(image), ts, suffix)
+        return cache_dir / EUGR_BUILD_LOG_DIR / name
+
+    # --- Post-build smoke test ---
+
+    # Three sub-packages from the upstream flashinfer release. All three must be
+    # importable for the runner image to be considered healthy.
+    _FLASHINFER_SMOKE_IMPORTS = ("flashinfer", "flashinfer_cubin", "flashinfer_jit_cache")
+
+    def _verify_image_imports(
+        self,
+        image: str,
+        host: str | None = None,
+        ssh_kwargs: dict | None = None,
+    ) -> None:
+        """Run a flashinfer import smoke test inside the freshly built image.
+
+        Catches the silent-corruption failure mode where build-and-copy.sh
+        produces a runner image that tagged successfully but lacks one or more
+        flashinfer wheels (see issue #164).
+
+        On failure: best-effort remove the broken tag (so the next launch
+        retries from scratch) and raise ``RuntimeError`` with the captured
+        ``ImportError`` so users can tell *which* sub-package is missing.
+
+        Args:
+            image: Image reference to test.
+            host: When set, run the test on this remote host via SSH.
+            ssh_kwargs: SSH connection kwargs for the remote case.
+        """
+        py_check = "; ".join("import %s" % mod for mod in self._FLASHINFER_SMOKE_IMPORTS)
+        logger.info("Verifying flashinfer imports in %s ...", image)
+
+        if host:
+            from sparkrun.orchestration.primitives import run_script_on_host
+
+            script = "docker run --rm --entrypoint= %s python3 -c %s" % (
+                quote(image),
+                quote(py_check),
+            )
+            result = run_script_on_host(host, script, ssh_kwargs=ssh_kwargs, timeout=60)
+            rc = 0 if result.success else (result.returncode or 1)
+            stderr = result.stderr if isinstance(result.stderr, str) else ""
+        else:
+            try:
+                proc = subprocess.run(
+                    ["docker", "run", "--rm", "--entrypoint=", image, "python3", "-c", py_check],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                rc = proc.returncode
+                stderr = proc.stderr or ""
+            except subprocess.TimeoutExpired:
+                rc = 124
+                stderr = "smoke test timed out after 60s"
+
+        if rc == 0:
+            logger.debug("flashinfer import smoke test passed for %s", image)
+            return
+
+        stderr_tail = "\n".join(stderr.strip().splitlines()[-20:]) if stderr.strip() else "(no stderr)"
+        logger.error(
+            "flashinfer import smoke test FAILED for %s (rc=%d):\n%s",
+            image,
+            rc,
+            stderr_tail,
+        )
+
+        # Remove the poisoned tag so the next launch doesn't reuse it.
+        self._remove_image(image, host=host, ssh_kwargs=ssh_kwargs)
+
+        raise RuntimeError(
+            "eugr build produced an image without flashinfer (rc=%d): %s\n"
+            "(broken wheel split or missing prebuilt asset; check the build log)" % (rc, stderr_tail)
+        )
+
+    @staticmethod
+    def _remove_image(image: str, host: str | None = None, ssh_kwargs: dict | None = None) -> None:
+        """Best-effort ``docker rmi`` to drop a tag we no longer trust."""
+        try:
+            if host:
+                from sparkrun.orchestration.primitives import run_script_on_host
+
+                run_script_on_host(
+                    host,
+                    "docker rmi -f %s >/dev/null 2>&1 || true" % quote(image),
+                    ssh_kwargs=ssh_kwargs,
+                    timeout=30,
+                )
+            else:
+                subprocess.run(
+                    ["docker", "rmi", "-f", image],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+        except Exception:
+            logger.debug("Failed to remove image %s (continuing)", image, exc_info=True)
+
     def _can_skip_build(
         self,
         image: str,
@@ -686,13 +930,20 @@ class EugrBuilder(BuilderPlugin):
 
     # --- Image building ---
 
-    def _build_image(self, image: str, build_args: list[str], dry_run: bool = False) -> None:
+    def _build_image(
+        self,
+        image: str,
+        build_args: list[str],
+        dry_run: bool = False,
+        config: SparkrunConfig | None = None,
+    ) -> None:
         """Build container image via eugr's build-and-copy.sh.
 
         Args:
             image: Target image name (passed as ``-t``).
             build_args: Additional build arguments forwarded to the script.
             dry_run: Show what would be done without executing.
+            config: SparkrunConfig (for resolving the build log directory).
         """
         build_script = self._repo_dir / "build-and-copy.sh"
         if not build_script.exists():
@@ -704,18 +955,27 @@ class EugrBuilder(BuilderPlugin):
         if dry_run:
             return
 
-        # Stream build output only at INFO+ (i.e. -v); at default verbosity capture silently
+        log_path = self._build_log_path(image, config=config)
         stream = logging.getLogger().isEnabledFor(logging.INFO)
-        if stream:
-            result = subprocess.run(cmd, cwd=str(self._repo_dir))
-        else:
-            result = subprocess.run(cmd, cwd=str(self._repo_dir), capture_output=True, text=True)
-            if result.stdout and isinstance(result.stdout, str):
-                logger.debug("Build stdout:\n%s", result.stdout[-2000:])
-            if result.stderr and isinstance(result.stderr, str):
-                logger.debug("Build stderr:\n%s", result.stderr[-2000:])
-        if result.returncode != 0:
-            raise RuntimeError("eugr container build failed (exit %d)" % result.returncode)
+        if log_path is not None:
+            logger.info("Build log: %s", log_path)
+
+        rc, captured = _run_build_capturing(cmd, cwd=str(self._repo_dir), log_path=log_path, stream=stream)
+
+        if rc != 0:
+            phase = _identify_build_phase(captured)
+            tail = _build_error_tail(captured)
+            log_hint = ("\n(full log: %s)" % log_path) if log_path else ""
+            # Surface failure context at ERROR level so the user sees it even at default verbosity.
+            logger.error(
+                "eugr container build failed (exit %d); phase=%s%s\n--- last %d lines ---\n%s",
+                rc,
+                phase,
+                log_hint,
+                _BUILD_ERROR_TAIL_LINES,
+                tail,
+            )
+            raise RuntimeError("eugr container build failed (exit %d); phase=%s%s" % (rc, phase, log_hint))
 
     # --- Remote / delegated helpers ---
 
@@ -803,6 +1063,7 @@ class EugrBuilder(BuilderPlugin):
         head: str,
         ssh_kwargs: dict | None = None,
         dry_run: bool = False,
+        config: SparkrunConfig | None = None,
     ) -> None:
         """Build container image on the head node via SSH.
 
@@ -812,13 +1073,17 @@ class EugrBuilder(BuilderPlugin):
             head: Head node hostname.
             ssh_kwargs: SSH connection kwargs.
             dry_run: Show what would be done without executing.
+            config: SparkrunConfig (for resolving the build log directory).
         """
         from sparkrun.orchestration.ssh import run_remote_script_streaming
 
         # TODO: hard-coded inline script
         remote_path = "~/.cache/sparkrun/eugr-spark-vllm-docker"
         args_str = args_list_to_shell_str(build_args)
-        script = "set -e\ncd %(path)s\nchmod +x build-and-copy.sh\n./build-and-copy.sh -t %(image)s %(args)s\n" % {
+        # set -o pipefail + ${PIPESTATUS[0]} preserves the build script's true rc when piping
+        # through tee on the remote side; we redirect 2>&1 so phase markers in either stream
+        # land in the captured log.
+        script = ("set -eo pipefail\ncd %(path)s\nchmod +x build-and-copy.sh\n./build-and-copy.sh -t %(image)s %(args)s 2>&1\n") % {
             "path": remote_path,
             "image": quote(image),
             "args": args_str,
@@ -829,7 +1094,12 @@ class EugrBuilder(BuilderPlugin):
         if dry_run:
             return
 
+        log_path = self._build_log_path(image, config=config, host=head)
+        if log_path is not None:
+            logger.info("Build log: %s", log_path)
+
         kw = ssh_kwargs or {}
+        # Always capture (quiet=True); we'll write to the log file and optionally echo to terminal.
         result = run_remote_script_streaming(
             head,
             script,
@@ -837,10 +1107,41 @@ class EugrBuilder(BuilderPlugin):
             ssh_key=kw.get("ssh_key"),
             ssh_options=kw.get("ssh_options"),
             timeout=1800,
-            quiet=not logging.getLogger().isEnabledFor(logging.INFO),
+            quiet=True,
         )
+
+        # Persist captured output to the local log file (best-effort)
+        captured = result.stdout if isinstance(result.stdout, str) else ""
+        if log_path is not None:
+            try:
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                log_path.write_text(captured, encoding="utf-8", errors="replace")
+            except OSError as e:
+                logger.warning("Could not write remote build log %s: %s", log_path, e)
+
+        # Echo to terminal at INFO+ verbosity so the user can see what happened.
+        if captured and logging.getLogger().isEnabledFor(logging.INFO):
+            import sys
+
+            sys.stdout.write(captured)
+            sys.stdout.flush()
+
         if not result.success:
-            raise RuntimeError("eugr remote container build failed on %s (exit %d)" % (head, result.returncode))
+            phase = _identify_build_phase(captured)
+            tail = _build_error_tail(captured)
+            log_hint = ("\n(full log: %s)" % log_path) if log_path else ""
+            logger.error(
+                "eugr remote container build failed on %s (exit %d); phase=%s%s\n--- last %d lines ---\n%s",
+                head,
+                result.returncode,
+                phase,
+                log_hint,
+                _BUILD_ERROR_TAIL_LINES,
+                tail,
+            )
+            raise RuntimeError(
+                "eugr remote container build failed on %s (exit %d); phase=%s%s" % (head, result.returncode, phase, log_hint)
+            )
 
     # --- Repo management ---
 

--- a/src/sparkrun/orchestration/distribution.py
+++ b/src/sparkrun/orchestration/distribution.py
@@ -137,6 +137,11 @@ def _distribute_from_head(
     2. If single host, return (done).
     3. Run *distribute_script* on head to stream to remaining hosts.
 
+    Both remote scripts use streaming SSH so progress (e.g. ``huggingface-cli``
+    tqdm bars during model download, ``docker pull`` layer pulls, rsync
+    transfer counts) is visible in real time at INFO+ verbosity.  At default
+    verbosity the output is captured silently and surfaced on failure.
+
     Args:
         head: Head hostname (``hosts[0]``).
         hosts: Full cluster host list (head + workers).
@@ -152,10 +157,14 @@ def _distribute_from_head(
     Returns:
         List of hostnames where distribution failed (empty = full success).
     """
-    from sparkrun.orchestration.ssh import run_remote_script
+    from sparkrun.orchestration.ssh import run_remote_script_streaming
+
+    # Default verbosity captures silently; INFO+ streams to terminal so long-running
+    # operations (model downloads, image pulls) show progress instead of hanging mute.
+    _quiet = not logging.getLogger().isEnabledFor(logging.INFO)
 
     # Step 1: ensure resource on head
-    ensure_result = run_remote_script(
+    ensure_result = run_remote_script_streaming(
         head,
         ensure_script,
         ssh_user=ssh_user,
@@ -163,9 +172,16 @@ def _distribute_from_head(
         ssh_options=ssh_options,
         timeout=timeout,
         dry_run=dry_run,
+        quiet=_quiet,
     )
     if not ensure_result.success:
-        logger.error("Failed to ensure %s on head %s", resource_label, head)
+        logger.error("Failed to ensure %s on head %s (rc=%d)", resource_label, head, ensure_result.returncode)
+        if _quiet:
+            # Surface captured output so the user can diagnose silent-mode failures.
+            if ensure_result.stdout:
+                logger.error("stdout:\n%s", ensure_result.stdout[-2000:])
+            if ensure_result.stderr:
+                logger.error("stderr:\n%s", ensure_result.stderr[-2000:])
         return list(hosts)
 
     # Step 2: if single host, we're done
@@ -174,7 +190,7 @@ def _distribute_from_head(
         return []
 
     # Step 3: distribute from head to remaining hosts
-    dist_result = run_remote_script(
+    dist_result = run_remote_script_streaming(
         head,
         distribute_script,
         ssh_user=ssh_user,
@@ -182,6 +198,7 @@ def _distribute_from_head(
         ssh_options=ssh_options,
         timeout=timeout,
         dry_run=dry_run,
+        quiet=_quiet,
     )
 
     if dist_result.success:
@@ -192,6 +209,11 @@ def _distribute_from_head(
 
     # Report failure using management hostnames
     logger.warning("%s distribution from head failed (rc=%d)", resource_label, dist_result.returncode)
+    if _quiet:
+        if dist_result.stdout:
+            logger.error("stdout:\n%s", dist_result.stdout[-2000:])
+        if dist_result.stderr:
+            logger.error("stderr:\n%s", dist_result.stderr[-2000:])
     return list(hosts[1:])
 
 
@@ -475,6 +497,7 @@ def distribute_resources(
         ib_ip_map = _ib_validated or {}
         if ib_ip_map and not _use_mgmt:
             transfer_hosts = [ib_result.ib_ip_map.get(h, h) for h in host_list]
+            logger.debug("ib_ip_map=%r host_list=%r transfer_hosts=%r", ib_result.ib_ip_map, host_list, transfer_hosts)
             logger.info(
                 "Using IB network for transfers (%d/%d hosts)",
                 len(ib_result.ib_ip_map),
@@ -805,6 +828,25 @@ def distribute_from_config(
     return comm_env, ib_ip_map, mgmt_ip_map
 
 
+def _subset_transfer_hosts(
+    host_subset_source: list[str],
+    transfer_hosts: list[str] | None,
+    target_set: set[str],
+) -> list[str] | None:
+    """Return the slice of *transfer_hosts* whose paired entry in *host_subset_source*
+    is in *target_set*.
+
+    *transfer_hosts* is positionally aligned with *host_subset_source* (one entry per
+    host).  The two lists may carry different values per host (e.g. mgmt IPs vs IB IPs),
+    so filtering must compare against *host_subset_source* and emit the matching
+    *transfer_hosts* entry — comparing *transfer_hosts* values directly against
+    *target_set* would silently miss whenever the values differ, defeating IB routing.
+    """
+    if not transfer_hosts:
+        return None
+    return [t for h, t in zip(host_subset_source, transfer_hosts) if h in target_set]
+
+
 def _distribute_single_image(
     image: str,
     targets: list[str],
@@ -819,10 +861,14 @@ def _distribute_single_image(
     """Distribute a single image to a subset of hosts."""
     from sparkrun.containers.distribute import distribute_image_from_local, distribute_image_from_head
 
-    # Map transfer hosts to target subset
+    # Map transfer hosts to target subset.  transfer_hosts is positionally aligned with
+    # full_hosts (one entry per host, value = IB IP or mgmt IP), so we filter by index
+    # against the target subset rather than by value (which would compare IB IPs against
+    # mgmt-IP target names and always miss — see issue notes on IB falling back to mgmt).
     target_set = set(targets)
-    t_hosts = [h for h in transfer_hosts if h in target_set] if transfer_hosts else None
-    w_hosts = [h for h in worker_transfer_hosts if h in target_set] if worker_transfer_hosts else None
+    t_hosts = _subset_transfer_hosts(full_hosts, transfer_hosts, target_set)
+    # worker_transfer_hosts is aligned with full_hosts[1:] (workers only).
+    w_hosts = _subset_transfer_hosts(full_hosts[1:], worker_transfer_hosts, target_set)
 
     if transfer_mode == "local":
         return distribute_image_from_local(image, targets, transfer_hosts=t_hosts, dry_run=dry_run, **ssh_kwargs)
@@ -866,9 +912,10 @@ def _distribute_single_model(
     """Distribute a single model to a subset of hosts."""
     from sparkrun.models.distribute import distribute_model_from_local, distribute_model_from_head
 
+    # Position-aligned subset (see _subset_transfer_hosts docstring).
     target_set = set(targets)
-    t_hosts = [h for h in transfer_hosts if h in target_set] if transfer_hosts else None
-    w_hosts = [h for h in worker_transfer_hosts if h in target_set] if worker_transfer_hosts else None
+    t_hosts = _subset_transfer_hosts(full_hosts, transfer_hosts, target_set)
+    w_hosts = _subset_transfer_hosts(full_hosts[1:], worker_transfer_hosts, target_set)
 
     if transfer_mode == "local":
         return distribute_model_from_local(

--- a/src/sparkrun/orchestration/executor.py
+++ b/src/sparkrun/orchestration/executor.py
@@ -29,7 +29,7 @@ EXECUTOR_DEFAULTS = {
     "privileged": True,
     "gpus": "all",
     "ipc": "host",
-    "shm_size": "10.24gb",
+    "shm_size": "32gb",
     "network": "host",
     "user": None,
     "security_opt": None,

--- a/src/sparkrun/orchestration/executor.py
+++ b/src/sparkrun/orchestration/executor.py
@@ -235,8 +235,8 @@ class Executor(ABC):
 
         template = read_script("container_launch.sh")
         return template.format(
-            container_name=container_name,
-            image=image,
+            container_name=quote(container_name),
+            image=quote(image),
             cleanup_cmd=cleanup,
             run_cmd=run,
         )

--- a/src/sparkrun/scripts/container_launch.sh
+++ b/src/sparkrun/scripts/container_launch.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -uo pipefail
 
-printf "Cleaning up existing container: %%s\n" {container_name}
+printf "Cleaning up existing container: %s\n" {container_name}
 {cleanup_cmd}
 
-printf "Launching container: %%s\n" {container_name}
-printf "Image: %%s\n" {image}
+printf "Launching container: %s\n" {container_name}
+printf "Image: %s\n" {image}
 {run_cmd}
 
-printf "Container %%s launched successfully\n" {container_name}
+printf "Container %s launched successfully\n" {container_name}

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -412,7 +412,10 @@ class TestEugrDelegatedMode:
                 )
         mock_remote_build.assert_called_once_with(
             "my-image",
-            ["--flag"],
+            [
+                "--flag",
+                "--cleanup",  # cleanup flag is injected!
+            ],
             "head-host",
             {"ssh_user": "u"},
             False,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -139,18 +139,20 @@ class TestEugrPrepareImage:
         )
         with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
             with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                with mock.patch("subprocess.run") as mock_run:
-                    mock_run.return_value = mock.Mock(returncode=0)
-                    with mock.patch.object(builder, "_save_build_metadata"):
-                        result = builder.prepare_image("my-image", recipe, ["10.0.0.1"])
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")) as mock_build:
+                    with mock.patch.object(builder, "_verify_image_imports"):
+                        with mock.patch.object(builder, "_save_build_metadata"):
+                            result = builder.prepare_image("my-image", recipe, ["10.0.0.1"])
 
         assert result == "my-image"
-        mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
+        mock_build.assert_called_once()
+        cmd = mock_build.call_args[0][0]
         assert str(repo_dir / "build-and-copy.sh") in cmd[0]
         assert "-t" in cmd
         assert "my-image" in cmd
         assert "--some-flag" in cmd
+        # --cleanup is always appended to the effective build args (issue #164)
+        assert "--cleanup" in cmd
 
     def test_eugr_prepare_without_build_args_image_exists(self, eugr_builder_with_repo):
         """prepare_image() is a no-op when no build_args/mods and image exists locally."""
@@ -182,13 +184,13 @@ class TestEugrPrepareImage:
         )
         with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
             with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                with mock.patch("subprocess.run") as mock_run:
-                    mock_run.return_value = mock.Mock(returncode=0)
-                    with mock.patch.object(builder, "_save_build_metadata"):
-                        result = builder.prepare_image("my-image", recipe, ["10.0.0.1"])
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")) as mock_build:
+                    with mock.patch.object(builder, "_verify_image_imports"):
+                        with mock.patch.object(builder, "_save_build_metadata"):
+                            result = builder.prepare_image("my-image", recipe, ["10.0.0.1"])
 
-        mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
+        mock_build.assert_called_once()
+        cmd = mock_build.call_args[0][0]
         assert str(repo_dir / "build-and-copy.sh") in cmd[0]
         assert "-t" in cmd
         assert "my-image" in cmd
@@ -207,10 +209,12 @@ class TestEugrPrepareImage:
         )
         with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
             with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                with mock.patch("subprocess.run") as mock_run:
-                    builder.prepare_image("vllm-node", recipe, ["10.0.0.1"], dry_run=True)
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing") as mock_build:
+                    with mock.patch.object(builder, "_verify_image_imports") as mock_verify:
+                        builder.prepare_image("vllm-node", recipe, ["10.0.0.1"], dry_run=True)
 
-        mock_run.assert_not_called()
+        mock_build.assert_not_called()
+        mock_verify.assert_not_called()
 
     # Note: mod -> pre_exec injection moved out of the eugr builder into the
     # generic core/mods.py resolver. See tests/test_mods.py for that coverage.
@@ -226,11 +230,104 @@ class TestEugrPrepareImage:
                 "runtime_config": {"build_args": ["--flag"]},
             }
         )
-        with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-            with mock.patch("subprocess.run") as mock_run:
-                mock_run.return_value = mock.Mock(returncode=1)
-                with pytest.raises(RuntimeError, match="eugr container build failed"):
-                    builder.prepare_image("vllm-node", recipe, ["10.0.0.1"])
+        # Simulate FlashInfer download exhausting all options.
+        captured_output = (
+            "Phase 1\n"
+            "Could not fetch release metadata for 'prebuilt-flashinfer-current' — skipping download.\n"
+            "No FlashInfer wheels available (download failed) — building...\n"
+            "FlashInfer build failed — restoring previous wheels...\n"
+        )
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+                with mock.patch(
+                    "sparkrun.builders.eugr._run_build_capturing",
+                    return_value=(1, captured_output),
+                ):
+                    with pytest.raises(RuntimeError) as excinfo:
+                        builder.prepare_image("vllm-node", recipe, ["10.0.0.1"])
+
+        msg = str(excinfo.value)
+        assert "eugr container build failed" in msg
+        # Phase identification should pick up the explicit failure marker.
+        assert "flashinfer-build (failed)" in msg
+
+    def test_eugr_prepare_appends_cleanup_without_duplicates(self, eugr_builder_with_repo):
+        """`--cleanup` is not duplicated if already present in build_args."""
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": "my-image",
+                "runtime_config": {"build_args": ["--cleanup", "--flag"]},
+            }
+        )
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")) as mock_build:
+                    with mock.patch.object(builder, "_verify_image_imports"):
+                        with mock.patch.object(builder, "_save_build_metadata"):
+                            builder.prepare_image("my-image", recipe, ["10.0.0.1"])
+
+        cmd = mock_build.call_args[0][0]
+        # Exactly one --cleanup, regardless of recipe ordering.
+        assert cmd.count("--cleanup") == 1
+
+    def test_eugr_prepare_cleanup_not_persisted_to_cache(self, eugr_builder_with_repo):
+        """`--cleanup` is appended to the build invocation but NOT to the cached build_args.
+
+        This keeps the build cache identity tied to the recipe's canonical args so
+        subsequent cache lookups still hit when nothing else changed (commit 110aca7).
+        """
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": "my-image",
+                "runtime_config": {"build_args": ["--tf5"]},
+            }
+        )
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")):
+                    with mock.patch.object(builder, "_verify_image_imports"):
+                        with mock.patch.object(builder, "_save_build_metadata") as mock_save:
+                            builder.prepare_image("my-image", recipe, ["10.0.0.1"])
+
+        # _save_build_metadata is called with the recipe's original build_args (no --cleanup).
+        args, kwargs = mock_save.call_args
+        # Signature: _save_build_metadata(image, build_args, config, host=..., ssh_kwargs=...)
+        saved_build_args = args[1]
+        assert saved_build_args == ["--tf5"]
+
+    def test_eugr_prepare_smoke_failure_removes_tag_and_skips_cache(self, eugr_builder_with_repo):
+        """If the post-build flashinfer smoke test fails, the tag is removed and cache is not updated."""
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": "my-image",
+                "runtime_config": {"build_args": ["--flag"]},
+            }
+        )
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")):
+                    with mock.patch.object(builder, "_remove_image") as mock_rmi:
+                        # Make the smoke test report missing flashinfer_jit_cache.
+                        smoke_proc = mock.Mock(returncode=1, stderr="ModuleNotFoundError: flashinfer_jit_cache\n")
+                        with mock.patch("subprocess.run", return_value=smoke_proc):
+                            with mock.patch.object(builder, "_save_build_metadata") as mock_save:
+                                with pytest.raises(RuntimeError, match="without flashinfer"):
+                                    builder.prepare_image("my-image", recipe, ["10.0.0.1"])
+
+        mock_rmi.assert_called_once_with("my-image", host=None, ssh_kwargs=None)
+        mock_save.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -403,22 +500,25 @@ class TestEugrDelegatedMode:
         )
         with mock.patch.object(builder, "_ensure_repo_remote", return_value="/remote/repo"):
             with mock.patch.object(builder, "_build_image_remote") as mock_remote_build:
-                result = builder.prepare_image(
-                    "my-image",
-                    recipe,
-                    ["head-host"],
-                    transfer_mode="delegated",
-                    ssh_kwargs={"ssh_user": "u"},
-                )
+                with mock.patch.object(builder, "_verify_image_imports"):
+                    with mock.patch.object(builder, "_save_build_metadata"):
+                        result = builder.prepare_image(
+                            "my-image",
+                            recipe,
+                            ["head-host"],
+                            transfer_mode="delegated",
+                            ssh_kwargs={"ssh_user": "u"},
+                        )
         mock_remote_build.assert_called_once_with(
             "my-image",
             [
                 "--flag",
-                "--cleanup",  # cleanup flag is injected!
+                "--cleanup",  # cleanup flag is injected (issue #164)
             ],
             "head-host",
             {"ssh_user": "u"},
             False,
+            config=None,
         )
         assert result == "my-image"
 
@@ -562,3 +662,211 @@ class TestEugrDelegatedMode:
                 result = builder.prepare_image("my-image", recipe, ["10.0.0.1"])
         mock_run.assert_not_called()
         assert result == "my-image"
+
+
+# ---------------------------------------------------------------------------
+# EugrBuilder — build logging and phase identification helpers (issue #164)
+# ---------------------------------------------------------------------------
+
+
+class TestEugrBuildLogging:
+    """Tests for build-log capture and phase-aware error context."""
+
+    def test_safe_image_name_replaces_unsafe_chars(self):
+        from sparkrun.builders.eugr import _safe_image_name
+
+        assert _safe_image_name("ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest") == ("ghcr.io-spark-arena-dgx-vllm-eugr-nightly-latest")
+        # Already-safe input is preserved (modulo trailing strip).
+        assert _safe_image_name("sparkrun-eugr-vllm") == "sparkrun-eugr-vllm"
+        assert _safe_image_name("///") == "image"
+
+    def test_identify_phase_flashinfer_build_failure(self):
+        from sparkrun.builders.eugr import _identify_build_phase
+
+        output = (
+            "Cleaning up wheels directory...\n"
+            "FlashInfer build command: docker build --target flashinfer-export ...\n"
+            "FlashInfer build failed — restoring previous wheels...\n"
+        )
+        assert _identify_build_phase(output) == "flashinfer-build (failed)"
+
+    def test_identify_phase_vllm_build_failure(self):
+        from sparkrun.builders.eugr import _identify_build_phase
+
+        output = (
+            "FlashInfer wheels ready.\n"
+            "vLLM build command: docker build --target vllm-export ...\n"
+            "vLLM build failed — restoring previous wheels...\n"
+        )
+        assert _identify_build_phase(output) == "vllm-build (failed)"
+
+    def test_identify_phase_no_assets(self):
+        from sparkrun.builders.eugr import _identify_build_phase
+
+        output = "Could not fetch release metadata for 'prebuilt-flashinfer-current' — skipping download.\n"
+        assert _identify_build_phase(output) == "wheel-download (release metadata)"
+
+    def test_identify_phase_runner_no_wheels(self):
+        from sparkrun.builders.eugr import _identify_build_phase
+
+        output = "FlashInfer wheels ready.\nvLLM wheels ready.\nError: No wheel files found in ./wheels/ — cannot build runner image.\n"
+        assert _identify_build_phase(output) == "runner-build (no wheels)"
+
+    def test_identify_phase_latest_marker_wins_when_no_explicit_failure(self):
+        from sparkrun.builders.eugr import _identify_build_phase
+
+        # No failure marker -> falls back to the last phase reached.
+        output = "Cleaning up wheels directory...\nFlashInfer wheels ready.\nvLLM build command: docker build ...\n"
+        assert _identify_build_phase(output) == "vllm-build"
+
+    def test_build_error_tail_returns_last_n_nonempty_lines(self):
+        from sparkrun.builders.eugr import _build_error_tail
+
+        output = "first\n\nsecond\nthird\n\nfourth\n"
+        assert _build_error_tail(output, n=2) == "third\nfourth"
+        assert _build_error_tail(output, n=10) == "first\nsecond\nthird\nfourth"
+
+    def test_run_build_capturing_writes_log_file(self, tmp_path):
+        """_run_build_capturing captures combined output to memory and to disk."""
+        from sparkrun.builders.eugr import _run_build_capturing
+
+        log = tmp_path / "build.log"
+        rc, out = _run_build_capturing(
+            ["bash", "-c", "echo hello; echo error >&2; exit 0"],
+            log_path=log,
+            stream=False,
+        )
+        assert rc == 0
+        assert "hello" in out
+        assert "error" in out  # stderr merged into stdout
+        # log file contains the same content
+        assert "hello" in log.read_text()
+        assert "error" in log.read_text()
+
+    def test_run_build_capturing_handles_nonzero_exit(self, tmp_path):
+        from sparkrun.builders.eugr import _run_build_capturing
+
+        rc, out = _run_build_capturing(
+            ["bash", "-c", "echo phase-marker; exit 5"],
+            log_path=tmp_path / "x.log",
+            stream=False,
+        )
+        assert rc == 5
+        assert "phase-marker" in out
+
+    def test_run_build_capturing_tolerates_unwritable_log(self, tmp_path):
+        """If the log file can't be opened, the build still runs and returns output."""
+        from sparkrun.builders.eugr import _run_build_capturing
+
+        # Point at a directory that doesn't exist and can't be created (read-only parent).
+        # Use a file *as* a parent so the mkdir fails.
+        not_a_dir = tmp_path / "not-a-dir"
+        not_a_dir.write_text("blocker")
+        bad_log = not_a_dir / "child" / "build.log"
+
+        rc, out = _run_build_capturing(
+            ["bash", "-c", "echo ok"],
+            log_path=bad_log,
+            stream=False,
+        )
+        assert rc == 0
+        assert "ok" in out
+
+    def test_build_log_path_uses_cache_dir(self, tmp_path):
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        with mock.patch.object(builder, "_resolve_cache_dir", return_value=tmp_path):
+            p = builder._build_log_path("ghcr.io/foo:bar")
+        assert p is not None
+        assert p.parent == tmp_path / "eugr-builds"
+        assert p.suffix == ".log"
+        assert "ghcr.io-foo-bar" in p.name
+
+    def test_build_log_path_returns_none_when_no_cache(self):
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        with mock.patch.object(builder, "_resolve_cache_dir", return_value=None):
+            assert builder._build_log_path("img") is None
+
+    def test_build_log_path_includes_host_for_remote(self, tmp_path):
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        with mock.patch.object(builder, "_resolve_cache_dir", return_value=tmp_path):
+            p = builder._build_log_path("img", host="head.example.com")
+        assert p is not None
+        assert "remote-head.example.com" in p.name
+
+
+# ---------------------------------------------------------------------------
+# EugrBuilder — flashinfer smoke test (_verify_image_imports)
+# ---------------------------------------------------------------------------
+
+
+class TestEugrVerifyImageImports:
+    """Tests for the post-build flashinfer importability check."""
+
+    def test_verify_image_imports_local_success(self):
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        with mock.patch("subprocess.run", return_value=mock.Mock(returncode=0, stderr="")) as mock_run:
+            builder._verify_image_imports("my-image")
+        # Verify the command shape: docker run --rm --entrypoint= <image> python3 -c "<imports>"
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ["docker", "run", "--rm", "--entrypoint="]
+        assert cmd[4] == "my-image"
+        assert cmd[5:7] == ["python3", "-c"]
+        check = cmd[7]
+        assert "import flashinfer" in check
+        assert "import flashinfer_cubin" in check
+        assert "import flashinfer_jit_cache" in check
+
+    def test_verify_image_imports_local_failure_raises_and_removes_image(self):
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        bad = mock.Mock(returncode=1, stderr="ModuleNotFoundError: flashinfer_jit_cache")
+        with mock.patch("subprocess.run", return_value=bad):
+            with mock.patch.object(builder, "_remove_image") as mock_rmi:
+                with pytest.raises(RuntimeError, match="without flashinfer"):
+                    builder._verify_image_imports("my-image")
+        mock_rmi.assert_called_once_with("my-image", host=None, ssh_kwargs=None)
+
+    def test_verify_image_imports_local_timeout_treated_as_failure(self):
+        import subprocess as _sp
+
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        with mock.patch("subprocess.run", side_effect=_sp.TimeoutExpired(cmd="docker", timeout=60)):
+            with mock.patch.object(builder, "_remove_image"):
+                with pytest.raises(RuntimeError, match="without flashinfer"):
+                    builder._verify_image_imports("my-image")
+
+    def test_verify_image_imports_remote_success(self):
+        from sparkrun.builders.eugr import EugrBuilder
+        from sparkrun.orchestration.ssh import RemoteResult
+
+        builder = EugrBuilder()
+        ok = RemoteResult(host="head", returncode=0, stdout="", stderr="")
+        with mock.patch("sparkrun.orchestration.primitives.run_script_on_host", return_value=ok) as mock_ssh:
+            builder._verify_image_imports("my-image", host="head", ssh_kwargs={"ssh_user": "u"})
+        script = mock_ssh.call_args[0][1]
+        assert "docker run --rm --entrypoint=" in script
+        assert "python3 -c" in script
+        assert "import flashinfer" in script
+
+    def test_verify_image_imports_remote_failure_removes_image(self):
+        from sparkrun.builders.eugr import EugrBuilder
+        from sparkrun.orchestration.ssh import RemoteResult
+
+        builder = EugrBuilder()
+        bad = RemoteResult(host="head", returncode=1, stdout="", stderr="ModuleNotFoundError: flashinfer")
+        with mock.patch("sparkrun.orchestration.primitives.run_script_on_host", return_value=bad):
+            with mock.patch.object(builder, "_remove_image") as mock_rmi:
+                with pytest.raises(RuntimeError, match="without flashinfer"):
+                    builder._verify_image_imports("my-image", host="head", ssh_kwargs={"ssh_user": "u"})
+        mock_rmi.assert_called_once_with("my-image", host="head", ssh_kwargs={"ssh_user": "u"})

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -698,7 +698,7 @@ class TestDistributeImageTransferHosts:
 class TestDistributeImageFromHead:
     """Test distribute_image_from_head."""
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_single_host(self, mock_run):
         """Single host: pull only, no distribution."""
         mock_run.return_value = RemoteResult(
@@ -713,7 +713,7 @@ class TestDistributeImageFromHead:
         assert failed == []
         assert mock_run.call_count == 1
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_multi_host(self, mock_run):
         """Multi host: pull on head, then distribute script."""
         mock_run.return_value = RemoteResult(
@@ -733,7 +733,7 @@ class TestDistributeImageFromHead:
         assert "w1" in dist_script
         assert "w2" in dist_script
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_pull_fails(self, mock_run):
         """If pull on head fails, all hosts are returned as failed."""
         mock_run.return_value = RemoteResult(
@@ -747,7 +747,7 @@ class TestDistributeImageFromHead:
         failed = distribute_image_from_head("img:latest", ["head", "w1"])
         assert failed == ["head", "w1"]
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_distribute_fails(self, mock_run):
         """If distribution script fails, target hosts are returned as failed."""
         mock_run.side_effect = [
@@ -765,7 +765,7 @@ class TestDistributeImageFromHead:
         failed = distribute_image_from_head("img:latest", [])
         assert failed == []
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_ssh_params_forwarded(self, mock_run):
         """SSH parameters are forwarded to remote script calls."""
         mock_run.return_value = RemoteResult(
@@ -786,7 +786,7 @@ class TestDistributeImageFromHead:
         assert call_kwargs["ssh_user"] == "admin"
         assert call_kwargs["ssh_key"] == "/mykey"
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_worker_transfer_hosts(self, mock_run):
         """worker_transfer_hosts are used for distribution targets."""
         mock_run.return_value = RemoteResult(
@@ -877,7 +877,7 @@ class TestDistributeImageFromHead:
         assert call_kwargs["hosts"] == ["head", "w1", "w2"]
 
     @mock.patch("sparkrun.containers.distribute._check_remote_image_identities")
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_dry_run_skips_precheck(self, mock_run, mock_check):
         """dry_run skips the pre-check entirely."""
         mock_run.return_value = RemoteResult(
@@ -1025,7 +1025,7 @@ class TestDistributeModelFromLocal:
 class TestDistributeModelFromHead:
     """Test distribute_model_from_head."""
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_single_host(self, mock_run):
         """Single host: download only, no distribution."""
         mock_run.return_value = RemoteResult(
@@ -1040,7 +1040,7 @@ class TestDistributeModelFromHead:
         assert failed == []
         assert mock_run.call_count == 1
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_multi_host(self, mock_run):
         """Multi host: download on head, then distribute script."""
         mock_run.return_value = RemoteResult(
@@ -1060,7 +1060,7 @@ class TestDistributeModelFromHead:
         assert "w2" in dist_script
         assert "models--org--model" in dist_script
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_download_fails(self, mock_run):
         """If download on head fails, all hosts are returned as failed."""
         mock_run.return_value = RemoteResult(
@@ -1074,7 +1074,7 @@ class TestDistributeModelFromHead:
         failed = distribute_model_from_head("org/model", ["head", "w1"])
         assert failed == ["head", "w1"]
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_distribute_fails(self, mock_run):
         """If distribution script fails, target hosts are returned as failed."""
         mock_run.side_effect = [
@@ -1092,7 +1092,7 @@ class TestDistributeModelFromHead:
         failed = distribute_model_from_head("org/model", [])
         assert failed == []
 
-    @mock.patch("sparkrun.orchestration.ssh.run_remote_script")
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_worker_transfer_hosts(self, mock_run):
         """worker_transfer_hosts are used for distribution targets."""
         mock_run.return_value = RemoteResult(
@@ -1801,3 +1801,104 @@ class TestDistributeResourcesTransferMode:
         )
         mock_mdl_head.assert_called_once()
         mock_mdl_push.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _subset_transfer_hosts + _distribute_single_image IB routing
+# Regression: a positional-vs-value confusion was silently downgrading
+# local-mode transfers from IB IPs to management IPs.
+# ---------------------------------------------------------------------------
+
+
+class TestSubsetTransferHosts:
+    def test_subset_returns_none_when_no_transfer_hosts(self):
+        from sparkrun.orchestration.distribution import _subset_transfer_hosts
+
+        assert _subset_transfer_hosts(["a", "b"], None, {"a"}) is None
+        assert _subset_transfer_hosts(["a", "b"], [], {"a"}) is None
+
+    def test_subset_filters_by_paired_host_value(self):
+        """When the source host is in target_set, the *aligned* transfer entry is kept."""
+        from sparkrun.orchestration.distribution import _subset_transfer_hosts
+
+        # mgmt IPs → IB IPs, positionally aligned.
+        host_list = ["10.24.11.13", "10.24.11.14"]
+        transfer_hosts = ["192.168.11.13", "192.168.11.14"]
+
+        # Subset = entire cluster
+        out = _subset_transfer_hosts(host_list, transfer_hosts, set(host_list))
+        assert out == ["192.168.11.13", "192.168.11.14"]
+
+        # Subset = single host
+        out = _subset_transfer_hosts(host_list, transfer_hosts, {"10.24.11.13"})
+        assert out == ["192.168.11.13"]
+
+        # Subset = empty intersection (e.g. transfer_hosts values mistakenly compared)
+        out = _subset_transfer_hosts(host_list, transfer_hosts, {"192.168.11.13"})
+        assert out == []  # not None, but empty (no mgmt-IP match)
+
+    def test_subset_handles_workers_only_slice(self):
+        from sparkrun.orchestration.distribution import _subset_transfer_hosts
+
+        # full_hosts[1:] is the worker slice; aligned with worker_transfer_hosts
+        worker_hosts = ["10.24.11.14", "10.24.11.15"]
+        worker_transfer = ["192.168.11.14", "192.168.11.15"]
+        out = _subset_transfer_hosts(worker_hosts, worker_transfer, {"10.24.11.15"})
+        assert out == ["192.168.11.15"]
+
+
+class TestDistributeSingleImageIbRouting:
+    """Regression: local-mode image distribution must SSH to IB IPs, not mgmt IPs."""
+
+    def test_local_mode_passes_ib_transfer_hosts_to_distribute_image_from_local(self):
+        from sparkrun.orchestration.distribution import _distribute_single_image
+
+        targets = ["10.24.11.13"]
+        full_hosts = ["10.24.11.13"]
+        transfer_hosts = ["192.168.11.13"]  # IB IP, positionally aligned with full_hosts
+
+        with mock.patch(
+            "sparkrun.containers.distribute.distribute_image_from_local",
+            return_value=[],
+        ) as mock_dist:
+            _distribute_single_image(
+                "img:latest",
+                targets,
+                full_hosts,
+                transfer_mode="local",
+                transfer_hosts=transfer_hosts,
+                worker_transfer_hosts=None,
+                ssh_kwargs={},
+                dry_run=False,
+                auto_delegated=False,
+            )
+
+        # Critical assertion: the IB IP was forwarded as transfer_hosts.
+        kwargs = mock_dist.call_args.kwargs
+        assert kwargs["transfer_hosts"] == ["192.168.11.13"]
+
+    def test_local_mode_subsets_transfer_hosts_to_targets(self):
+        """When targets is a strict subset of full_hosts, the matching IB IPs are kept."""
+        from sparkrun.orchestration.distribution import _distribute_single_image
+
+        full_hosts = ["10.24.11.13", "10.24.11.14"]
+        transfer_hosts = ["192.168.11.13", "192.168.11.14"]
+        targets = ["10.24.11.14"]  # only the worker
+
+        with mock.patch(
+            "sparkrun.containers.distribute.distribute_image_from_local",
+            return_value=[],
+        ) as mock_dist:
+            _distribute_single_image(
+                "img:latest",
+                targets,
+                full_hosts,
+                transfer_mode="local",
+                transfer_hosts=transfer_hosts,
+                worker_transfer_hosts=None,
+                ssh_kwargs={},
+                dry_run=False,
+                auto_delegated=False,
+            )
+
+        assert mock_dist.call_args.kwargs["transfer_hosts"] == ["192.168.11.14"]

--- a/tests/test_eugr_build_cache.py
+++ b/tests/test_eugr_build_cache.py
@@ -584,7 +584,11 @@ class TestPrepareImageCacheIntegration:
         mock_build.assert_not_called()
 
     def test_delegated_build_saves_metadata(self, tmp_path):
-        """After a delegated build, metadata is saved with host param."""
+        """After a delegated build, metadata is saved with host param.
+
+        The cache stores the recipe's canonical build_args (without the implicit
+        ``--cleanup`` hygiene flag) so subsequent cache checks can match.
+        """
         builder = EugrBuilder()
         recipe = mock.MagicMock()
         recipe.runtime_config = {"build_args": [], "mods": []}
@@ -608,7 +612,17 @@ class TestPrepareImageCacheIntegration:
                 ssh_kwargs={"user": "u"},
             )
 
-        mock_build.assert_called_once()
+        # _build_image_remote receives the augmented args (with --cleanup) so the
+        # actual build still gets the hygiene flag.
+        mock_build.assert_called_once_with(
+            "my-image",
+            ["--cleanup"],
+            "head1",
+            {"user": "u"},
+            False,
+        )
+        # _save_build_metadata receives the canonical args (without --cleanup) so the
+        # cache entry remains comparable to future recipe-driven cache checks.
         mock_save.assert_called_once_with(
             "my-image",
             [],
@@ -616,3 +630,42 @@ class TestPrepareImageCacheIntegration:
             host="head1",
             ssh_kwargs={"user": "u"},
         )
+        # The recipe's build_args list must not be mutated by the implicit append.
+        assert recipe.runtime_config["build_args"] == []
+
+    def test_cache_round_trip_survives_implicit_cleanup(self, tmp_path):
+        """Regression: a build → save → check cycle must produce a cache hit.
+
+        Before this fix, the implicit ``--cleanup`` append was written into the cache
+        entry's build_args, causing every subsequent _can_skip_build check (driven
+        by the recipe's original build_args=[]) to mismatch and force a rebuild.
+        """
+        builder = _make_builder(tmp_path)
+        config = _mock_config(tmp_path)
+
+        with (
+            mock.patch("subprocess.run") as mock_run,
+            mock.patch("sparkrun.containers.registry.get_image_id", return_value="sha256:img"),
+            mock.patch.object(
+                builder,
+                "process_version_info",
+                return_value={
+                    "build_vllm_commit": "cd7643015",
+                    "build_flashinfer_commit": "ede7a275",
+                },
+            ),
+        ):
+            mock_run.return_value = mock.MagicMock(returncode=0, stdout="abc123def456\n")
+            builder._save_build_metadata("sparkrun-eugr-vllm", [], config)
+
+        # Subsequent cache check with the recipe's original build_args must hit.
+        with (
+            mock.patch("sparkrun.containers.registry.get_image_id", return_value="sha256:img"),
+            mock.patch("subprocess.run") as mock_run,
+            mock.patch(
+                "sparkrun.builders.eugr._fetch_upstream_wheel_hashes",
+                return_value={"vllm_commit": "cd7643015", "flashinfer_commit": "ede7a275"},
+            ),
+        ):
+            mock_run.return_value = mock.MagicMock(returncode=0, stdout="abc123def456\n")
+            assert builder._can_skip_build("sparkrun-eugr-vllm", [], config) is True

--- a/tests/test_eugr_build_cache.py
+++ b/tests/test_eugr_build_cache.py
@@ -512,6 +512,7 @@ class TestPrepareImageCacheIntegration:
             mock.patch.object(builder, "ensure_repo", return_value=tmp_path / "repo"),
             mock.patch.object(builder, "_can_skip_build", return_value=False),
             mock.patch.object(builder, "_build_image") as mock_build,
+            mock.patch.object(builder, "_verify_image_imports"),
             mock.patch.object(builder, "_save_build_metadata") as mock_save,
             mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False),
         ):
@@ -599,6 +600,7 @@ class TestPrepareImageCacheIntegration:
             mock.patch.object(builder, "_ensure_repo_remote", return_value="/remote/path"),
             mock.patch.object(builder, "_can_skip_build", return_value=False),
             mock.patch.object(builder, "_build_image_remote") as mock_build,
+            mock.patch.object(builder, "_verify_image_imports"),
             mock.patch.object(builder, "_save_build_metadata") as mock_save,
             mock.patch.object(builder, "_image_exists_on_host", return_value=False),
         ):
@@ -620,6 +622,7 @@ class TestPrepareImageCacheIntegration:
             "head1",
             {"user": "u"},
             False,
+            config=config,
         )
         # _save_build_metadata receives the canonical args (without --cleanup) so the
         # cache entry remains comparable to future recipe-driven cache checks.

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -944,13 +944,12 @@ class TestEugrPrepare:
         )
         with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
             with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                with mock.patch("subprocess.run") as mock_run:
-                    mock_run.return_value = mock.Mock(returncode=0)
-                    with mock.patch.object(builder, "_save_build_metadata"):
-                        builder.prepare_image("my-image", recipe, ["10.0.0.1"])
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")) as mock_build:
+                    with mock.patch.object(builder, "_verify_image_imports"):
+                        with mock.patch.object(builder, "_save_build_metadata"):
+                            builder.prepare_image("my-image", recipe, ["10.0.0.1"])
 
-                    # Should call build-and-copy.sh with -t and build_args
-                    cmd = mock_run.call_args[0][0]
+                    cmd = mock_build.call_args[0][0]
                     assert str(repo_dir / "build-and-copy.sh") in cmd[0]
                     assert "-t" in cmd
                     assert "my-image" in cmd
@@ -985,12 +984,12 @@ class TestEugrPrepare:
         )
         with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
             with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                with mock.patch("subprocess.run") as mock_run:
-                    mock_run.return_value = mock.Mock(returncode=0)
-                    with mock.patch.object(builder, "_save_build_metadata"):
-                        builder.prepare_image("my-image", recipe, ["10.0.0.1"])
-                    mock_run.assert_called_once()
-                    cmd = mock_run.call_args[0][0]
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")) as mock_build:
+                    with mock.patch.object(builder, "_verify_image_imports"):
+                        with mock.patch.object(builder, "_save_build_metadata"):
+                            builder.prepare_image("my-image", recipe, ["10.0.0.1"])
+                    mock_build.assert_called_once()
+                    cmd = mock_build.call_args[0][0]
                     assert str(repo_dir / "build-and-copy.sh") in cmd[0]
                     assert "-t" in cmd
                     assert "my-image" in cmd
@@ -1008,10 +1007,9 @@ class TestEugrPrepare:
         )
         with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
             with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-                with mock.patch("subprocess.run") as mock_run:
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing") as mock_build:
                     builder.prepare_image("vllm-node", recipe, ["10.0.0.1"], dry_run=True)
-                    # subprocess.run should not be called in dry-run
-                    mock_run.assert_not_called()
+                    mock_build.assert_not_called()
 
     # Note: mod -> pre_exec injection moved out of the eugr builder into the
     # generic core/mods.py resolver. See tests/test_mods.py for that coverage.
@@ -1027,11 +1025,14 @@ class TestEugrPrepare:
                 "runtime_config": {"build_args": ["--flag"]},
             }
         )
-        with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
-            with mock.patch("subprocess.run") as mock_run:
-                mock_run.return_value = mock.Mock(returncode=1)
-                with pytest.raises(RuntimeError, match="eugr container build failed"):
-                    builder.prepare_image("vllm-node", recipe, ["10.0.0.1"])
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+                with mock.patch(
+                    "sparkrun.builders.eugr._run_build_capturing",
+                    return_value=(1, "FlashInfer build failed — restoring previous wheels...\n"),
+                ):
+                    with pytest.raises(RuntimeError, match="eugr container build failed"):
+                        builder.prepare_image("vllm-node", recipe, ["10.0.0.1"])
 
 
 class TestEugrPreServe:

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.2.33
+sparkrun: 0.2.34
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
This pull request introduces major improvements to the build and distribution workflow for Docker-based inference workloads in `sparkrun`. The main changes focus on enhancing build error visibility, logging, and robustness, especially for the `eugr` image builder. Build logs are now persisted for each build, error reporting is much more informative, and a new smoke test ensures images are not silently corrupted. Additionally, resource distribution now streams progress to the terminal at higher verbosity, improving user feedback during long operations.

Key changes include:

**Build Logging and Error Reporting Enhancements:**

* Added per-build log file support for `eugr` builds, storing logs under a dedicated cache subdirectory, and improved build error reporting with phase identification and log tails in error messages (`src/sparkrun/builders/eugr.py`). [[1]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR59-R181) [[2]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL682-R946) [[3]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL700-R978) [[4]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR1066) [[5]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR1076-R1086) [[6]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR1097-R1144)
* Introduced helper functions to safely name log files, extract error context, and identify the build phase from log output (`src/sparkrun/builders/eugr.py`).

**Image Integrity and Robustness:**

* Enforced cleanup of wheels + commit data from cached eugr spark-vllm-docker on build (since sparkrun already has its own check to determine if build needed, there should only be benefit).
* Added a post-build smoke test to verify that the built image correctly imports all required `flashinfer` sub-packages, catching silent corruption and removing invalid images from the cache if verification fails (`src/sparkrun/builders/eugr.py`). [[1]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR361-R379) [[2]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR647-R762)

**Remote Build Improvements:**

* Remote builds now also write logs locally, always capture output, and echo logs to the terminal at higher verbosity. Error reporting for remote builds is now consistent with local builds, including phase and context information (`src/sparkrun/builders/eugr.py`). [[1]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR1076-R1086) [[2]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR1097-R1144)

**Resource Distribution Feedback:**

* Resource distribution scripts now use streaming SSH so progress bars and logs are visible in real time at INFO+ verbosity; at default verbosity, output is captured and surfaced on failure for easier troubleshooting (`src/sparkrun/orchestration/distribution.py`). [[1]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573R140-R144) [[2]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573L155-R184) [[3]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573L177-R201) [[4]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573R212-R216)

**Miscellaneous:**

* Bumped the package version from `0.2.33` to `0.2.34` in `pyproject.toml`.
* Added extra debug logging for InfiniBand transfer host mapping (`src/sparkrun/orchestration/distribution.py`).