### PR TITLE
v0.2.35

### DIFF
--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -287,8 +287,21 @@ class EugrBuilder(BuilderPlugin):
         build_args = recipe.runtime_config.get("build_args", [])
         needs_build = False  # assume False at first
 
+        # Builder-level user defaults from `defaults.builders.eugr` in the user config.
+        # `use_sentinel_image` (default True) controls whether ":latest" tags on the
+        # eugr nightly GHCR images are interpreted as "build locally from upstream
+        # wheels" (the historical behavior) — power users can set this to False to
+        # treat ":latest" as a regular pullable image instead.
+        builder_defaults = config.get_defaults_builder("eugr") if config is not None else {}
+        use_sentinel_image = bool(builder_defaults.get("use_sentinel_image", True))
+
         # ~~ SPECIAL CASES: map pullable eugr nightly images to use direct build ~~~
-        if image.strip() == GHCR_EUGR_NIGHTLY_TF5 + ":latest" and (build_args == ["--tf5"] or not build_args):
+        if not use_sentinel_image:
+            logger.debug(
+                "eugr sentinel image handling disabled (defaults.builders.eugr.use_sentinel_image=false); "
+                "':latest' will be treated as a regular pullable image"
+            )
+        elif image.strip() == GHCR_EUGR_NIGHTLY_TF5 + ":latest" and (build_args == ["--tf5"] or not build_args):
             # use sparkrun prefixed names to avoid collisions with other user images
             image = LOCAL_EUGR_NIGHTLY_TF5
             build_args = ["--tf5"]

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -120,6 +120,18 @@ def _build_error_tail(output: str, n: int = _BUILD_ERROR_TAIL_LINES) -> str:
     return "\n".join(lines[-n:])
 
 
+def _build_log_hint(log_path: Path | None) -> str:
+    """Format the trailing log-file hint included in build failure messages.
+
+    When the log was persisted, point the user at the file.  Otherwise nudge them
+    toward enabling ``defaults.builders.eugr.save_build_logs`` so the next run
+    captures a complete record on disk.
+    """
+    if log_path is not None:
+        return "\n(full log: %s)" % log_path
+    return "\n(set defaults.builders.eugr.save_build_logs: true in ~/.config/sparkrun/config.yaml to persist the full log on the next run)"
+
+
 def _run_build_capturing(
     cmd: list[str],
     cwd: str | None = None,
@@ -292,8 +304,14 @@ class EugrBuilder(BuilderPlugin):
         # eugr nightly GHCR images are interpreted as "build locally from upstream
         # wheels" (the historical behavior) — power users can set this to False to
         # treat ":latest" as a regular pullable image instead.
+        # `save_build_logs` (default False) controls whether build-and-copy.sh output
+        # is persisted to a log file under <cache_dir>/eugr-builds/.  When False the
+        # output is still captured in memory so failure-mode error context is intact;
+        # enable it before re-running when a build is misbehaving and you want a
+        # persistent record to investigate.
         builder_defaults = config.get_defaults_builder("eugr") if config is not None else {}
         use_sentinel_image = bool(builder_defaults.get("use_sentinel_image", True))
+        save_build_logs = bool(builder_defaults.get("save_build_logs", False))
 
         # ~~ SPECIAL CASES: map pullable eugr nightly images to use direct build ~~~
         if not use_sentinel_image:
@@ -379,7 +397,7 @@ class EugrBuilder(BuilderPlugin):
                 effective_build_args.append("--cleanup")
 
             if delegated:
-                self._build_image_remote(image, effective_build_args, head, ssh_kwargs, dry_run, config=config)
+                self._build_image_remote(image, effective_build_args, head, ssh_kwargs, dry_run, config=config, save_logs=save_build_logs)
                 # Verify the freshly built image has flashinfer before we cache the
                 # metadata — a missing flashinfer triplet is the most common silent
                 # corruption mode the rebuild path produces (see issue #164).
@@ -387,7 +405,7 @@ class EugrBuilder(BuilderPlugin):
                     self._verify_image_imports(image, host=head, ssh_kwargs=ssh_kwargs)
                     self._save_build_metadata(image, build_args, config, host=head, ssh_kwargs=ssh_kwargs)
             else:
-                self._build_image(image, effective_build_args, dry_run, config=config)
+                self._build_image(image, effective_build_args, dry_run, config=config, save_logs=save_build_logs)
                 if not dry_run:
                     self._verify_image_imports(image)
                     self._save_build_metadata(image, build_args, config)
@@ -949,6 +967,7 @@ class EugrBuilder(BuilderPlugin):
         build_args: list[str],
         dry_run: bool = False,
         config: SparkrunConfig | None = None,
+        save_logs: bool = False,
     ) -> None:
         """Build container image via eugr's build-and-copy.sh.
 
@@ -957,6 +976,9 @@ class EugrBuilder(BuilderPlugin):
             build_args: Additional build arguments forwarded to the script.
             dry_run: Show what would be done without executing.
             config: SparkrunConfig (for resolving the build log directory).
+            save_logs: When True, persist the captured build output to a per-build
+                log file under ``<cache_dir>/eugr-builds/``.  Default False —
+                output is still captured in memory for failure error context.
         """
         build_script = self._repo_dir / "build-and-copy.sh"
         if not build_script.exists():
@@ -968,7 +990,7 @@ class EugrBuilder(BuilderPlugin):
         if dry_run:
             return
 
-        log_path = self._build_log_path(image, config=config)
+        log_path = self._build_log_path(image, config=config) if save_logs else None
         stream = logging.getLogger().isEnabledFor(logging.INFO)
         if log_path is not None:
             logger.info("Build log: %s", log_path)
@@ -978,7 +1000,7 @@ class EugrBuilder(BuilderPlugin):
         if rc != 0:
             phase = _identify_build_phase(captured)
             tail = _build_error_tail(captured)
-            log_hint = ("\n(full log: %s)" % log_path) if log_path else ""
+            log_hint = _build_log_hint(log_path)
             # Surface failure context at ERROR level so the user sees it even at default verbosity.
             logger.error(
                 "eugr container build failed (exit %d); phase=%s%s\n--- last %d lines ---\n%s",
@@ -1077,6 +1099,7 @@ class EugrBuilder(BuilderPlugin):
         ssh_kwargs: dict | None = None,
         dry_run: bool = False,
         config: SparkrunConfig | None = None,
+        save_logs: bool = False,
     ) -> None:
         """Build container image on the head node via SSH.
 
@@ -1087,6 +1110,10 @@ class EugrBuilder(BuilderPlugin):
             ssh_kwargs: SSH connection kwargs.
             dry_run: Show what would be done without executing.
             config: SparkrunConfig (for resolving the build log directory).
+            save_logs: When True, persist the captured remote build output to a
+                per-build log file under ``<cache_dir>/eugr-builds/`` on the
+                control machine.  Default False — output is still captured in
+                memory for failure error context.
         """
         from sparkrun.orchestration.ssh import run_remote_script_streaming
 
@@ -1107,7 +1134,7 @@ class EugrBuilder(BuilderPlugin):
         if dry_run:
             return
 
-        log_path = self._build_log_path(image, config=config, host=head)
+        log_path = self._build_log_path(image, config=config, host=head) if save_logs else None
         if log_path is not None:
             logger.info("Build log: %s", log_path)
 
@@ -1142,7 +1169,7 @@ class EugrBuilder(BuilderPlugin):
         if not result.success:
             phase = _identify_build_phase(captured)
             tail = _build_error_tail(captured)
-            log_hint = ("\n(full log: %s)" % log_path) if log_path else ""
+            log_hint = _build_log_hint(log_path)
             logger.error(
                 "eugr remote container build failed on %s (exit %d); phase=%s%s\n--- last %d lines ---\n%s",
                 head,

--- a/src/sparkrun/core/config.py
+++ b/src/sparkrun/core/config.py
@@ -147,6 +147,47 @@ class SparkrunConfig:
                 return default
         return current
 
+    def _get_defaults_section(self, section: str, name: str) -> dict[str, Any]:
+        """Return ``defaults.<section>.<name>`` as a dict, or ``{}`` when missing or malformed."""
+        defaults = self._data.get("defaults", {})
+        if not isinstance(defaults, dict):
+            return {}
+        bucket = defaults.get(section, {})
+        if not isinstance(bucket, dict):
+            return {}
+        entry = bucket.get(name, {})
+        return entry if isinstance(entry, dict) else {}
+
+    def get_defaults_builder(self, name: str) -> dict[str, Any]:
+        """Return per-builder defaults from ``defaults.builders.<name>``.
+
+        Example user config::
+
+            defaults:
+              builders:
+                eugr:
+                  use_sentinel_image: false
+
+        Builders should treat the returned dict as a soft default — recipe
+        fields and explicit overrides still win.
+        """
+        return self._get_defaults_section("builders", name)
+
+    def get_defaults_runtime(self, name: str) -> dict[str, Any]:
+        """Return per-runtime defaults from ``defaults.runtimes.<name>``.
+
+        Example user config::
+
+            defaults:
+              runtimes:
+                vllm-distributed:
+                  some_option: value
+
+        Runtimes should treat the returned dict as a soft default — recipe
+        fields and explicit overrides still win.
+        """
+        return self._get_defaults_section("runtimes", name)
+
     @property
     def monitor_backend(self) -> str | None:
         """Monitoring backend preference: ``"bash"`` or ``"nv-monitor"``."""

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -364,6 +364,57 @@ class TestEugrPrepareImage:
         mock_verify.assert_not_called()
         config.get_defaults_builder.assert_called_with("eugr")
 
+    def test_eugr_prepare_save_build_logs_default_off(self, eugr_builder_with_repo, tmp_path):
+        """By default, `_build_image` is called with save_logs=False (no log file written)."""
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": "my-image",
+                "runtime_config": {"build_args": ["--flag"]},
+            }
+        )
+        config = mock.Mock()
+        config.cache_dir = tmp_path
+        config.get_defaults_builder = mock.Mock(return_value={})
+
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+                with mock.patch.object(builder, "_build_image") as mock_build:
+                    with mock.patch.object(builder, "_verify_image_imports"):
+                        with mock.patch.object(builder, "_save_build_metadata"):
+                            builder.prepare_image("my-image", recipe, ["10.0.0.1"], config=config)
+
+        mock_build.assert_called_once()
+        assert mock_build.call_args.kwargs["save_logs"] is False
+
+    def test_eugr_prepare_save_build_logs_when_enabled(self, eugr_builder_with_repo, tmp_path):
+        """With `defaults.builders.eugr.save_build_logs: true`, `_build_image` gets save_logs=True."""
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": "my-image",
+                "runtime_config": {"build_args": ["--flag"]},
+            }
+        )
+        config = mock.Mock()
+        config.cache_dir = tmp_path
+        config.get_defaults_builder = mock.Mock(return_value={"save_build_logs": True})
+
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+                with mock.patch.object(builder, "_build_image") as mock_build:
+                    with mock.patch.object(builder, "_verify_image_imports"):
+                        with mock.patch.object(builder, "_save_build_metadata"):
+                            builder.prepare_image("my-image", recipe, ["10.0.0.1"], config=config)
+
+        assert mock_build.call_args.kwargs["save_logs"] is True
+
     def test_eugr_prepare_sentinel_default_is_on(self, eugr_builder_with_repo, tmp_path):
         """With config returning empty builder defaults, sentinel behavior stays ON."""
         builder, repo_dir = eugr_builder_with_repo
@@ -584,6 +635,7 @@ class TestEugrDelegatedMode:
             {"ssh_user": "u"},
             False,
             config=None,
+            save_logs=False,
         )
         assert result == "my-image"
 
@@ -863,6 +915,84 @@ class TestEugrBuildLogging:
             p = builder._build_log_path("img", host="head.example.com")
         assert p is not None
         assert "remote-head.example.com" in p.name
+
+    def test_build_log_hint_when_persisted(self, tmp_path):
+        from sparkrun.builders.eugr import _build_log_hint
+
+        path = tmp_path / "build.log"
+        hint = _build_log_hint(path)
+        assert str(path) in hint
+        assert "save_build_logs" not in hint
+
+    def test_build_log_hint_when_not_persisted(self):
+        from sparkrun.builders.eugr import _build_log_hint
+
+        hint = _build_log_hint(None)
+        assert "save_build_logs" in hint
+        assert "defaults.builders.eugr" in hint
+
+    def test_build_image_writes_log_when_save_logs_true(self, tmp_path):
+        """`_build_image` with save_logs=True populates the per-build log file."""
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        builder._repo_dir = tmp_path / "repo"
+        builder._repo_dir.mkdir()
+        (builder._repo_dir / "build-and-copy.sh").write_text("#!/bin/bash\nexit 0\n")
+        (builder._repo_dir / "build-and-copy.sh").chmod(0o755)
+
+        config = mock.Mock()
+        with mock.patch.object(builder, "_resolve_cache_dir", return_value=tmp_path):
+            with mock.patch(
+                "sparkrun.builders.eugr._run_build_capturing", return_value=(0, "Cleaning up wheels directory...\n")
+            ) as mock_run:
+                builder._build_image("my-image", ["--cleanup"], config=config, save_logs=True)
+
+        # The helper got a real Path (not None) → log file persistence requested.
+        log_path = mock_run.call_args.kwargs["log_path"]
+        assert log_path is not None
+        assert "eugr-builds" in str(log_path)
+
+    def test_build_image_skips_log_when_save_logs_false(self, tmp_path):
+        """`_build_image` with save_logs=False passes log_path=None (no file written)."""
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        builder._repo_dir = tmp_path / "repo"
+        builder._repo_dir.mkdir()
+        (builder._repo_dir / "build-and-copy.sh").write_text("#!/bin/bash\nexit 0\n")
+        (builder._repo_dir / "build-and-copy.sh").chmod(0o755)
+
+        config = mock.Mock()
+        with mock.patch.object(builder, "_resolve_cache_dir", return_value=tmp_path):
+            with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")) as mock_run:
+                builder._build_image("my-image", ["--cleanup"], config=config, save_logs=False)
+
+        # log_path is None → _run_build_capturing won't write to disk.
+        assert mock_run.call_args.kwargs["log_path"] is None
+
+    def test_build_image_failure_message_includes_enable_hint_when_logs_off(self, tmp_path):
+        """When save_logs is off and the build fails, the error mentions how to enable logs."""
+        from sparkrun.builders.eugr import EugrBuilder
+
+        builder = EugrBuilder()
+        builder._repo_dir = tmp_path / "repo"
+        builder._repo_dir.mkdir()
+        (builder._repo_dir / "build-and-copy.sh").write_text("#!/bin/bash\nexit 1\n")
+        (builder._repo_dir / "build-and-copy.sh").chmod(0o755)
+
+        config = mock.Mock()
+        with mock.patch.object(builder, "_resolve_cache_dir", return_value=tmp_path):
+            with mock.patch(
+                "sparkrun.builders.eugr._run_build_capturing",
+                return_value=(1, "FlashInfer build failed — restoring previous wheels...\n"),
+            ):
+                with pytest.raises(RuntimeError) as excinfo:
+                    builder._build_image("my-image", ["--cleanup"], config=config, save_logs=False)
+
+        msg = str(excinfo.value)
+        assert "save_build_logs" in msg
+        assert "defaults.builders.eugr" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -329,6 +329,71 @@ class TestEugrPrepareImage:
         mock_rmi.assert_called_once_with("my-image", host=None, ssh_kwargs=None)
         mock_save.assert_not_called()
 
+    def test_eugr_prepare_respects_use_sentinel_image_false(self, eugr_builder_with_repo):
+        """When `defaults.builders.eugr.use_sentinel_image=false`, `:latest` is NOT remapped.
+
+        Power-user escape hatch: the user opts out of the historical force-rebuild
+        behavior so `:latest` is treated as a regular pullable GHCR image.
+        """
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": "ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest",
+            }
+        )
+        config = mock.Mock()
+        config.get_defaults_builder = mock.Mock(return_value={"use_sentinel_image": False})
+
+        with mock.patch.object(builder, "ensure_repo") as mock_ensure:
+            with mock.patch("sparkrun.builders.eugr._run_build_capturing") as mock_build:
+                with mock.patch.object(builder, "_verify_image_imports") as mock_verify:
+                    result = builder.prepare_image(
+                        "ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest",
+                        recipe,
+                        ["10.0.0.1"],
+                        config=config,
+                    )
+
+        # No remap, no build, no smoke test: image flows through as pullable.
+        assert result == "ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest"
+        mock_ensure.assert_not_called()
+        mock_build.assert_not_called()
+        mock_verify.assert_not_called()
+        config.get_defaults_builder.assert_called_with("eugr")
+
+    def test_eugr_prepare_sentinel_default_is_on(self, eugr_builder_with_repo, tmp_path):
+        """With config returning empty builder defaults, sentinel behavior stays ON."""
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": "ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest",
+            }
+        )
+        config = mock.Mock()
+        config.cache_dir = tmp_path  # real path so Path(config.cache_dir) works
+        config.get_defaults_builder = mock.Mock(return_value={})
+
+        with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+            with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")) as mock_build:
+                with mock.patch.object(builder, "_verify_image_imports"):
+                    with mock.patch.object(builder, "_save_build_metadata"):
+                        result = builder.prepare_image(
+                            "ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest",
+                            recipe,
+                            ["10.0.0.1"],
+                            config=config,
+                        )
+
+        # Sentinel remap fired: image renamed to local tag, build happened.
+        assert result == "sparkrun-eugr-vllm"
+        mock_build.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Bootstrap integration — get_builder / list_builders

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -331,6 +331,72 @@ def test_config_empty_defaults_section(tmp_path: Path):
     assert config.default_transformers_tag == "t4"  # Default value
 
 
+def test_get_defaults_builder_returns_dict(tmp_path: Path):
+    """`defaults.builders.<name>` is returned as a dict for builders that read soft defaults."""
+    config_file = tmp_path / "config.yaml"
+    yaml.dump(
+        {
+            "defaults": {
+                "builders": {
+                    "eugr": {"use_sentinel_image": False, "extra_flag": "x"},
+                    "docker-pull": {},
+                },
+            },
+        },
+        open(config_file, "w"),
+    )
+
+    config = SparkrunConfig(config_path=config_file)
+    assert config.get_defaults_builder("eugr") == {"use_sentinel_image": False, "extra_flag": "x"}
+    assert config.get_defaults_builder("docker-pull") == {}
+    # Missing builder name returns an empty dict (not None).
+    assert config.get_defaults_builder("does-not-exist") == {}
+
+
+def test_get_defaults_runtime_returns_dict(tmp_path: Path):
+    """`defaults.runtimes.<name>` is returned as a dict."""
+    config_file = tmp_path / "config.yaml"
+    yaml.dump(
+        {
+            "defaults": {
+                "runtimes": {
+                    "vllm-distributed": {"some_option": 42},
+                },
+            },
+        },
+        open(config_file, "w"),
+    )
+
+    config = SparkrunConfig(config_path=config_file)
+    assert config.get_defaults_runtime("vllm-distributed") == {"some_option": 42}
+    assert config.get_defaults_runtime("sglang") == {}
+
+
+def test_get_defaults_section_handles_missing_or_malformed(tmp_path: Path):
+    """Missing `defaults` section or non-dict bucket values return empty dict, not crash."""
+    cf = tmp_path / "config.yaml"
+    # No defaults section at all.
+    yaml.dump({"cache_dir": "/tmp"}, open(cf, "w"))
+    config = SparkrunConfig(config_path=cf)
+    assert config.get_defaults_builder("eugr") == {}
+    assert config.get_defaults_runtime("vllm") == {}
+
+    # Malformed: defaults is a non-dict.
+    yaml.dump({"defaults": "not-a-dict"}, open(cf, "w"))
+    config = SparkrunConfig(config_path=cf)
+    assert config.get_defaults_builder("eugr") == {}
+
+    # Malformed: bucket is a non-dict.
+    yaml.dump({"defaults": {"builders": "not-a-dict"}}, open(cf, "w"))
+    config = SparkrunConfig(config_path=cf)
+    assert config.get_defaults_builder("eugr") == {}
+
+    # Malformed: entry itself is a non-dict.
+    yaml.dump({"defaults": {"builders": {"eugr": "not-a-dict"}}}, open(cf, "w"))
+    config = SparkrunConfig(config_path=cf)
+    assert config.get_defaults_builder("eugr") == {}
+
+
 def test_get_config_root_without_variables():
     """get_config_root without Variables returns DEFAULT_CONFIG_DIR."""
     from sparkrun.core.config import get_config_root, DEFAULT_CONFIG_DIR

--- a/tests/test_eugr_build_cache.py
+++ b/tests/test_eugr_build_cache.py
@@ -145,6 +145,11 @@ def _write_cache(tmp_path, image="sparkrun-eugr-vllm", entry=None):
 def _mock_config(tmp_path):
     cfg = mock.MagicMock()
     cfg.cache_dir = str(tmp_path)
+    # Return an empty dict so builders see their canonical "no overrides" defaults
+    # (use_sentinel_image=True, save_build_logs=False) instead of inheriting
+    # MagicMock's truthy auto-generated attributes.
+    cfg.get_defaults_builder = mock.Mock(return_value={})
+    cfg.get_defaults_runtime = mock.Mock(return_value={})
     return cfg
 
 
@@ -623,6 +628,7 @@ class TestPrepareImageCacheIntegration:
             {"user": "u"},
             False,
             config=config,
+            save_logs=False,
         )
         # _save_build_metadata receives the canonical args (without --cleanup) so the
         # cache entry remains comparable to future recipe-driven cache checks.

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.2.34
+sparkrun: 0.2.35
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
This pull request introduces new user-configurable builder defaults to the `eugr` builder, enabling power users to control sentinel image remapping and build log persistence. The changes also improve error messaging around build failures and add comprehensive tests for the new configuration options.

**Configurable builder defaults and build log handling:**

* Added support for per-builder user defaults in `SparkrunConfig`, specifically for `eugr`, allowing users to configure `use_sentinel_image` (controls whether `:latest` images are force-rebuilt or pulled as-is) and `save_build_logs` (controls whether build logs are persisted to disk). [[1]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR302-R322) [[2]](diffhunk://#diff-ae5de156cce618cddbb45018abb7ddb30a2034140965b59d4d174961a3cf9a97R150-R190)
* Modified `prepare_image`, `_build_image`, and `_build_image_remote` to respect the new `use_sentinel_image` and `save_build_logs` settings, ensuring builds and log persistence behave according to user configuration. [[1]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR302-R322) [[2]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL369-R408) [[3]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR970) [[4]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR979-R981) [[5]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL958-R993) [[6]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR1102) [[7]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR1113-R1116) [[8]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL1097-R1137)
* Added the `_build_log_hint` helper to provide actionable hints in build failure messages, including instructions for enabling log persistence if not already enabled. [[1]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR123-R134) [[2]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL968-R1003) [[3]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL1132-R1172)

**Testing and validation:**

* Added comprehensive tests to verify the new builder defaults, including tests for sentinel image handling, build log persistence, and error message content when logs are not saved. [[1]](diffhunk://#diff-dcfe6b9ffa9797a45d099987427f0f8039f07988f6d068aa554f079e08e99adcR332-R447) [[2]](diffhunk://#diff-dcfe6b9ffa9797a45d099987427f0f8039f07988f6d068aa554f079e08e99adcR638) [[3]](diffhunk://#diff-dcfe6b9ffa9797a45d099987427f0f8039f07988f6d068aa554f079e08e99adcR919-R996)

These changes give users more control over build behaviors and improve troubleshooting by making persistent logs opt-in and clearly guiding users on how to enable them when needed.