### PR TITLE
Add API key support for sparkrun inference (and pass-thru to sparkrun proxy)

### DIFF
--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -294,6 +294,7 @@ def launch_inference(
                 cache_dir=str(config.cache_dir),
                 recipe_ref=recipe_ref,
                 container_image=container_image,
+                runtime=runtime,
             )
         except Exception:
             logger.debug("Failed to save job metadata: %s", cluster_id, exc_info=True)
@@ -343,6 +344,7 @@ def launch_inference(
                     ib_ip_map=ib_ip_map,
                     mgmt_ip_map=mgmt_ip_map,
                     recipe_ref=recipe_ref,
+                    runtime=runtime,
                 )
             except Exception:
                 logger.debug("Failed to update job metadata: %s", cluster_id, exc_info=True)
@@ -559,6 +561,7 @@ def launch_inference(
                         recipe_ref=recipe_ref,
                         runtime_info=runtime_info,
                         container_image=container_image,
+                        runtime=runtime,
                     )
                 except Exception:
                     logger.debug("Failed to save runtime_info to job metadata", exc_info=True)

--- a/src/sparkrun/orchestration/job_metadata.py
+++ b/src/sparkrun/orchestration/job_metadata.py
@@ -17,6 +17,7 @@ import yaml
 
 if TYPE_CHECKING:
     from sparkrun.core.recipe import Recipe
+    from sparkrun.runtimes.base import RuntimePlugin
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +181,7 @@ def save_job_metadata(
     recipe_ref: str | None = None,
     runtime_info: dict[str, str] | None = None,
     container_image: Optional[str] = None,
+    runtime: "RuntimePlugin | None" = None,
 ) -> None:
     """Persist job metadata so ``cluster status`` can display recipe info.
 
@@ -229,6 +231,18 @@ def save_job_metadata(
         served_name = recipe.defaults.get("served_model_name")
     if served_name is not None:
         meta["served_model_name"] = str(served_name)
+
+    # Resolve upstream API key via the runtime plugin so proxy discovery
+    # can authenticate to the inference endpoint.  Runtimes that don't
+    # support api-keys return None from resolve_api_key().
+    if runtime is not None:
+        try:
+            api_key = runtime.resolve_api_key(recipe, overrides)
+        except Exception:
+            logger.debug("resolve_api_key failed for %s", cluster_id, exc_info=True)
+            api_key = None
+        if api_key:
+            meta["api_key"] = str(api_key)
 
     if ib_ip_map:
         meta["ib_ip_map"] = ib_ip_map

--- a/src/sparkrun/proxy/discovery.py
+++ b/src/sparkrun/proxy/discovery.py
@@ -38,6 +38,7 @@ class DiscoveredEndpoint:
     actual_models: list[str] = field(default_factory=list)
     recipe_name: str = ""
     tensor_parallel: int = 1
+    api_key: str | None = None
 
 
 def discover_endpoints(
@@ -158,6 +159,7 @@ def _endpoint_from_meta(
         healthy=False,
         recipe_name=meta.get("recipe", meta.get("recipe_ref", "")),
         tensor_parallel=int(meta.get("tensor_parallel", 1)),
+        api_key=meta.get("api_key") or None,
     )
 
 
@@ -244,6 +246,7 @@ def _discover_from_metadata(
             healthy=False,
             recipe_name=recipe_name,
             tensor_parallel=tp,
+            api_key=meta.get("api_key") or None,
         )
 
     endpoints = list(candidates.values())
@@ -307,12 +310,18 @@ def _deduplicate_by_identity(endpoints: list[DiscoveredEndpoint]) -> list[Discov
 def _check_single_health(ep: DiscoveredEndpoint) -> tuple[bool, list[str]]:
     """Check a single endpoint's health via GET /v1/models.
 
+    Sends an ``Authorization: Bearer`` header when the endpoint has an
+    ``api_key`` set, so backends that require auth still report healthy.
+
     Returns:
         Tuple of (healthy, list_of_model_ids).
     """
     url = "http://%s:%d/v1/models" % (ep.host, ep.port)
+    headers: dict[str, str] = {}
+    if ep.api_key:
+        headers["Authorization"] = "Bearer %s" % ep.api_key
     try:
-        req = urllib.request.Request(url, method="GET")
+        req = urllib.request.Request(url, method="GET", headers=headers)
         with urllib.request.urlopen(req, timeout=_HEALTH_TIMEOUT) as resp:
             if resp.status == 200:
                 body = json.loads(resp.read())

--- a/src/sparkrun/proxy/engine.py
+++ b/src/sparkrun/proxy/engine.py
@@ -63,7 +63,7 @@ def build_litellm_config(
                     "litellm_params": {
                         "model": "openai/%s" % model_name,
                         "api_base": "http://%s:%d/v1" % (ep.host, ep.port),
-                        "api_key": "not-needed",
+                        "api_key": ep.api_key or "not-needed",
                     },
                 }
             )
@@ -387,7 +387,7 @@ class ProxyEngine:
                 "litellm_params": {
                     "model": "openai/%s" % model_name,
                     "api_base": "http://%s:%d/v1" % (endpoint.host, endpoint.port),
-                    "api_key": "not-needed",
+                    "api_key": endpoint.api_key or "not-needed",
                 },
             }
 
@@ -522,7 +522,7 @@ class ProxyEngine:
                 "litellm_params": {
                     "model": "openai/%s" % target_model,
                     "api_base": api_base,
-                    "api_key": "not-needed",
+                    "api_key": params.get("api_key") or "not-needed",
                 },
             }
             try:

--- a/src/sparkrun/runtimes/_util.py
+++ b/src/sparkrun/runtimes/_util.py
@@ -11,22 +11,21 @@ def default_env_hf_offline(env: dict[str, str] = None, **kwargs) -> dict[str, st
     }
 
 
-# `--api-key value` or `--api-key=value`.  Stops at whitespace, line
-# continuation backslash, or shell metacharacters that wouldn't appear
-# in a real key.  Both vLLM and SGLang use the same flag spelling.
-_API_KEY_RE = re.compile(r"--api-key(?:=|\s+)([^\s\\]+)")
+def parse_flag_value_from_command(command: str | None, flag: str) -> str | None:
+    """Extract a literal ``<flag> <value>`` or ``<flag>=<value>`` from a command.
 
+    Matches the value up to the next whitespace or line-continuation
+    backslash.  Returns ``None`` when *flag* is absent, when the value
+    is empty, or when the value is a ``{placeholder}`` (the defaults
+    path handles those).  Surrounding quotes are stripped.
 
-def parse_api_key_from_command(command: str | None) -> str | None:
-    """Extract a literal ``--api-key <value>`` value from a serve command.
-
-    Returns ``None`` when no flag is present, or when the value is a
-    ``{placeholder}`` (the defaults path handles those).  Surrounding
-    quotes are stripped.
+    Used to recover an api/auth key from recipes that embed it directly
+    in their ``command:`` text rather than going through ``defaults``.
     """
     if not command:
         return None
-    match = _API_KEY_RE.search(command)
+    pattern = re.escape(flag) + r"(?:=|\s+)([^\s\\]+)"
+    match = re.search(pattern, command)
     if not match:
         return None
     val = match.group(1).strip()
@@ -37,3 +36,8 @@ def parse_api_key_from_command(command: str | None) -> str | None:
     if val.startswith("{") and val.endswith("}"):
         return None
     return val
+
+
+def parse_api_key_from_command(command: str | None) -> str | None:
+    """Backward-compatible alias for ``parse_flag_value_from_command(command, "--api-key")``."""
+    return parse_flag_value_from_command(command, "--api-key")

--- a/src/sparkrun/runtimes/_util.py
+++ b/src/sparkrun/runtimes/_util.py
@@ -1,3 +1,6 @@
+import re
+
+
 def default_env_hf_offline(env: dict[str, str] = None, **kwargs) -> dict[str, str]:
     return {
         # DEFAULT: disable online HF/transformers checks -- we've already copied all data locally!
@@ -6,3 +9,31 @@ def default_env_hf_offline(env: dict[str, str] = None, **kwargs) -> dict[str, st
         **(env or {}),
         **kwargs,
     }
+
+
+# `--api-key value` or `--api-key=value`.  Stops at whitespace, line
+# continuation backslash, or shell metacharacters that wouldn't appear
+# in a real key.  Both vLLM and SGLang use the same flag spelling.
+_API_KEY_RE = re.compile(r"--api-key(?:=|\s+)([^\s\\]+)")
+
+
+def parse_api_key_from_command(command: str | None) -> str | None:
+    """Extract a literal ``--api-key <value>`` value from a serve command.
+
+    Returns ``None`` when no flag is present, or when the value is a
+    ``{placeholder}`` (the defaults path handles those).  Surrounding
+    quotes are stripped.
+    """
+    if not command:
+        return None
+    match = _API_KEY_RE.search(command)
+    if not match:
+        return None
+    val = match.group(1).strip()
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+        val = val[1:-1]
+    if not val:
+        return None
+    if val.startswith("{") and val.endswith("}"):
+        return None
+    return val

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -3,40 +3,11 @@
 from __future__ import annotations
 
 import json
-import re
 from typing import TYPE_CHECKING
-from sparkrun.runtimes._util import default_env_hf_offline
+from sparkrun.runtimes._util import default_env_hf_offline, parse_api_key_from_command
 
 if TYPE_CHECKING:
     from sparkrun.core.recipe import Recipe
-
-
-# `--api-key value` or `--api-key=value`.  Stops at whitespace, line
-# continuation backslash, or shell metacharacters that wouldn't appear
-# in a real key.
-_VLLM_API_KEY_RE = re.compile(r"--api-key(?:=|\s+)([^\s\\]+)")
-
-
-def _parse_api_key_from_command(command: str | None) -> str | None:
-    """Extract a literal ``--api-key <value>`` value from a vLLM command.
-
-    Returns ``None`` when no flag is present, or when the value is a
-    ``{placeholder}`` (the defaults path handles those).  Surrounding
-    quotes are stripped.
-    """
-    if not command:
-        return None
-    match = _VLLM_API_KEY_RE.search(command)
-    if not match:
-        return None
-    val = match.group(1).strip()
-    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
-        val = val[1:-1]
-    if not val:
-        return None
-    if val.startswith("{") and val.endswith("}"):
-        return None
-    return val
 
 
 class VllmMixin:
@@ -91,7 +62,7 @@ class VllmMixin:
         val = recipe.env.get("VLLM_API_KEY")
         if val:
             return str(val)
-        parsed = _parse_api_key_from_command(recipe.command)
+        parsed = parse_api_key_from_command(recipe.command)
         if parsed:
             return parsed
         return None

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -39,6 +39,28 @@ class VllmMixin:
         cmds["vllm"] = "python3 -c 'import vllm; print(vllm.__version__)' 2>/dev/null || echo unknown"
         return cmds
 
+    def resolve_api_key(
+        self,
+        recipe: "Recipe",
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the vLLM ``--api-key`` value for proxy/discovery use.
+
+        Checks, in order: CLI override, ``defaults.api_key`` placeholder,
+        and ``env.VLLM_API_KEY``.  Returns ``None`` when none are set.
+        """
+        if overrides:
+            val = overrides.get("api_key")
+            if val:
+                return str(val)
+        val = recipe.defaults.get("api_key")
+        if val:
+            return str(val)
+        val = recipe.env.get("VLLM_API_KEY")
+        if val:
+            return str(val)
+        return None
+
     def detect_spec_config_draft_model(self, recipe: "Recipe") -> str | None:
         try:
             # TODO: support various ways that speculative config can be specified

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -3,11 +3,40 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING
 from sparkrun.runtimes._util import default_env_hf_offline
 
 if TYPE_CHECKING:
     from sparkrun.core.recipe import Recipe
+
+
+# `--api-key value` or `--api-key=value`.  Stops at whitespace, line
+# continuation backslash, or shell metacharacters that wouldn't appear
+# in a real key.
+_VLLM_API_KEY_RE = re.compile(r"--api-key(?:=|\s+)([^\s\\]+)")
+
+
+def _parse_api_key_from_command(command: str | None) -> str | None:
+    """Extract a literal ``--api-key <value>`` value from a vLLM command.
+
+    Returns ``None`` when no flag is present, or when the value is a
+    ``{placeholder}`` (the defaults path handles those).  Surrounding
+    quotes are stripped.
+    """
+    if not command:
+        return None
+    match = _VLLM_API_KEY_RE.search(command)
+    if not match:
+        return None
+    val = match.group(1).strip()
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+        val = val[1:-1]
+    if not val:
+        return None
+    if val.startswith("{") and val.endswith("}"):
+        return None
+    return val
 
 
 class VllmMixin:
@@ -46,8 +75,11 @@ class VllmMixin:
     ) -> str | None:
         """Resolve the vLLM ``--api-key`` value for proxy/discovery use.
 
-        Checks, in order: CLI override, ``defaults.api_key`` placeholder,
-        and ``env.VLLM_API_KEY``.  Returns ``None`` when none are set.
+        Checks, in order: CLI override, ``defaults.api_key`` (also
+        emitted as ``--api-key`` via :data:`VLLM_FLAG_MAP` for structured
+        commands), ``env.VLLM_API_KEY``, and finally a literal
+        ``--api-key`` flag parsed from the recipe's ``command`` field.
+        Returns ``None`` when none are set.
         """
         if overrides:
             val = overrides.get("api_key")
@@ -59,6 +91,9 @@ class VllmMixin:
         val = recipe.env.get("VLLM_API_KEY")
         if val:
             return str(val)
+        parsed = _parse_api_key_from_command(recipe.command)
+        if parsed:
+            return parsed
         return None
 
     def detect_spec_config_draft_model(self, recipe: "Recipe") -> str | None:
@@ -93,6 +128,7 @@ VLLM_FLAG_MAP = {
     "data_parallel": "--data-parallel-size",
     "kv_cache_dtype": "--kv-cache-dtype",
     "otlp_traces_endpoint": "--otlp-traces-endpoint",
+    "api_key": "--api-key",
 }
 
 # Boolean flags (present = True, absent = False)

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 from typing import Any, TYPE_CHECKING
 
-from sparkrun.runtimes._util import default_env_hf_offline
+from sparkrun.runtimes._util import default_env_hf_offline, parse_flag_value_from_command
 from sparkrun.runtimes.base import RuntimePlugin
 
 if TYPE_CHECKING:
@@ -84,6 +84,11 @@ _ATLAS_FLAG_MAP = {
     "disable_thinking": "--disable-thinking",
     "high_speed_swap": "--high-speed-swap",
     "require_auth": "--require-auth",
+    # Atlas calls the proxy auth credential ``--auth-token``.  We accept
+    # the cross-runtime portable name ``api_key`` as the canonical key;
+    # ``auth_token`` is supported as an alias and folded into ``api_key``
+    # by ``_normalize_config`` before flag-map iteration.
+    "api_key": "--auth-token",
 }
 
 _ATLAS_BOOL_FLAGS = frozenset(
@@ -117,6 +122,39 @@ class AtlasRuntime(RuntimePlugin):
         """Atlas handles its own multi-rank distribution via NCCL, not Ray."""
         return "native"
 
+    def resolve_api_key(
+        self,
+        recipe: "Recipe",
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the Atlas ``--auth-token`` value for proxy/discovery use.
+
+        Atlas uses ``--auth-token`` (not ``--api-key``) on the wire, but
+        sparkrun accepts the portable ``api_key`` recipe key and the
+        runtime-native ``auth_token`` alias as equivalent sources.
+
+        Checks, in order: CLI override (``api_key`` then ``auth_token``),
+        ``defaults.api_key`` then ``defaults.auth_token``, and finally a
+        literal ``--auth-token`` flag parsed from the recipe's ``command``
+        field.  The ``auth_token`` alias is folded into ``api_key`` by
+        :meth:`_normalize_config` before flag emission, so structured
+        commands always emit ``--auth-token`` exactly once.  Atlas has
+        no documented env-var equivalent, so ``env`` is not consulted.
+        """
+        if overrides:
+            for key in ("api_key", "auth_token"):
+                val = overrides.get(key)
+                if val:
+                    return str(val)
+        for key in ("api_key", "auth_token"):
+            val = recipe.defaults.get(key)
+            if val:
+                return str(val)
+        parsed = parse_flag_value_from_command(recipe.command, "--auth-token")
+        if parsed:
+            return parsed
+        return None
+
     def prefer_ib_for_init_addr(self) -> bool:
         """Added to give option to usb IB IP for Atlas instead of MGMT IP during troubleshooting"""
         return False
@@ -141,6 +179,19 @@ class AtlasRuntime(RuntimePlugin):
 
     # --- Command generation ---
 
+    @staticmethod
+    def _normalize_config(config) -> None:
+        """Apply pre-render config normalizations (auth-token alias).
+
+        Accepts ``auth_token`` as an alias for the canonical ``api_key``
+        key so users can use either in recipe defaults; flag emission
+        only looks at the canonical key.
+        """
+        if not config.get("api_key"):
+            alias = config.get("auth_token")
+            if alias:
+                config.set("api_key", alias)
+
     def generate_command(
         self,
         recipe: Recipe,
@@ -156,6 +207,7 @@ class AtlasRuntime(RuntimePlugin):
         ranks are produced by :meth:`generate_node_command`.
         """
         config = recipe.build_config_chain(overrides)
+        self._normalize_config(config)
 
         rendered = recipe.render_command(config)
         if rendered:
@@ -193,6 +245,7 @@ class AtlasRuntime(RuntimePlugin):
         the HTTP listener — only rank 0 exposes the OpenAI API.
         """
         config = recipe.build_config_chain(overrides)
+        self._normalize_config(config)
 
         rendered = recipe.render_command(config)
         if rendered:

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -166,6 +166,21 @@ class RuntimePlugin(Plugin):
         """
         return self.runtime_name
 
+    # noinspection PyMethodMayBeStatic,PyUnusedLocal
+    def resolve_api_key(
+        self,
+        recipe: Recipe,
+        overrides: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Return the upstream API key the proxy should use to reach this runtime, or None.
+
+        Base implementation returns ``None``.  Runtimes that accept an
+        api-key on their serve command (e.g. vLLM's ``--api-key``) should
+        override this to surface the configured value so proxy discovery
+        can health-check the endpoint and register it with litellm.
+        """
+        return None
+
     def generate_node_command(
         self,
         recipe: Recipe,

--- a/src/sparkrun/runtimes/llama_cpp.py
+++ b/src/sparkrun/runtimes/llama_cpp.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, TYPE_CHECKING
 
 from sparkrun.core.config import SparkrunConfig
+from sparkrun.runtimes._util import parse_api_key_from_command
 from sparkrun.runtimes.base import RuntimePlugin
 
 if TYPE_CHECKING:
@@ -26,6 +27,7 @@ _LLAMA_CPP_FLAG_MAP = {
     "reasoning_format": "--reasoning-format",
     "split_mode": "--split-mode",
     "served_model_name": "--alias",
+    "api_key": "--api-key",
 }
 
 # Defaults injected when not set in recipe config
@@ -83,6 +85,34 @@ class LlamaCppRuntime(RuntimePlugin):
     def cluster_strategy(self) -> str:
         """llama.cpp uses native RPC-based distribution, not Ray."""
         return "native"
+
+    def resolve_api_key(
+        self,
+        recipe: "Recipe",
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the llama-server ``--api-key`` value for proxy/discovery use.
+
+        Checks, in order: CLI override, ``defaults.api_key`` (also
+        emitted as ``--api-key`` via :data:`_LLAMA_CPP_FLAG_MAP` for
+        structured commands), ``env.LLAMA_API_KEY``, and finally a
+        literal ``--api-key`` flag parsed from the recipe's ``command``
+        field.  Returns ``None`` when none are set.
+        """
+        if overrides:
+            val = overrides.get("api_key")
+            if val:
+                return str(val)
+        val = recipe.defaults.get("api_key")
+        if val:
+            return str(val)
+        val = recipe.env.get("LLAMA_API_KEY")
+        if val:
+            return str(val)
+        parsed = parse_api_key_from_command(recipe.command)
+        if parsed:
+            return parsed
+        return None
 
     # --- Parallelism helpers ---
 

--- a/src/sparkrun/runtimes/sglang.py
+++ b/src/sparkrun/runtimes/sglang.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, TYPE_CHECKING
 
-from sparkrun.runtimes._util import default_env_hf_offline
+from sparkrun.runtimes._util import default_env_hf_offline, parse_api_key_from_command
 from sparkrun.runtimes.base import RuntimePlugin
 
 if TYPE_CHECKING:
@@ -32,6 +32,7 @@ _SGLANG_FLAG_MAP = {
     "kv_cache_dtype": "--kv-cache-dtype",
     "tokenizer_path": "--tokenizer-path",
     "speculative_draft_model_path": "--speculative-draft-model-path",
+    "api_key": "--api-key",
 }
 
 _SGLANG_BOOL_FLAGS = {
@@ -55,6 +56,34 @@ class SglangRuntime(RuntimePlugin):
     def cluster_strategy(self) -> str:
         """SGLang uses native multi-node distribution, not Ray."""
         return "native"
+
+    def resolve_api_key(
+        self,
+        recipe: "Recipe",
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the SGLang ``--api-key`` value for proxy/discovery use.
+
+        Checks, in order: CLI override, ``defaults.api_key`` (also
+        emitted as ``--api-key`` via :data:`_SGLANG_FLAG_MAP` for
+        structured commands), ``env.SGLANG_API_KEY``, and finally a
+        literal ``--api-key`` flag parsed from the recipe's ``command``
+        field.  Returns ``None`` when none are set.
+        """
+        if overrides:
+            val = overrides.get("api_key")
+            if val:
+                return str(val)
+        val = recipe.defaults.get("api_key")
+        if val:
+            return str(val)
+        val = recipe.env.get("SGLANG_API_KEY")
+        if val:
+            return str(val)
+        parsed = parse_api_key_from_command(recipe.command)
+        if parsed:
+            return parsed
+        return None
 
     def prepare(
         self,

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -350,3 +350,85 @@ def test_atlas_draft_model_flag_still_renders():
     recipe = _recipe(defaults={"draft_model": "Sehyo/Qwen3.5-35B-Draft", "speculative": True})
     cmd = runtime.generate_command(recipe, {}, is_cluster=False)
     assert "--draft-model Sehyo/Qwen3.5-35B-Draft" in cmd
+
+
+# --- Atlas resolve_api_key / --auth-token ---
+
+
+def test_atlas_resolve_api_key_from_defaults_api_key():
+    """defaults.api_key (portable key) is honored."""
+    recipe = _recipe(defaults={"api_key": "sk-portable"})
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-portable"
+
+
+def test_atlas_resolve_api_key_from_defaults_auth_token_alias():
+    """defaults.auth_token (runtime-native alias) is honored."""
+    recipe = _recipe(defaults={"auth_token": "sk-native"})
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-native"
+
+
+def test_atlas_resolve_api_key_canonical_beats_alias():
+    """api_key wins over auth_token when both are set."""
+    recipe = _recipe(defaults={"api_key": "sk-portable", "auth_token": "sk-native"})
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-portable"
+
+
+def test_atlas_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults."""
+    recipe = _recipe(defaults={"api_key": "sk-default"})
+    assert AtlasRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_atlas_resolve_api_key_none_when_unset():
+    """Returns None when no auth source is configured."""
+    assert AtlasRuntime().resolve_api_key(_recipe()) is None
+
+
+def test_atlas_resolve_api_key_no_env_fallback():
+    """Atlas has no documented env-var equivalent — env is not consulted."""
+    recipe = _recipe(env={"ATLAS_API_KEY": "sk-env"})
+    assert AtlasRuntime().resolve_api_key(recipe) is None
+
+
+def test_atlas_resolve_api_key_parses_inline_auth_token_flag():
+    """Literal --auth-token in a fixed command string is extracted."""
+    recipe = _recipe(
+        command="spark serve m --auth-token sk-inline --port 8080",
+    )
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_atlas_resolve_api_key_ignores_placeholder_in_command():
+    """`--auth-token {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = _recipe(
+        command="spark serve m --auth-token {api_key}",
+        defaults={"api_key": "sk-default"},
+    )
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_atlas_api_key_emitted_as_auth_token_flag():
+    """defaults.api_key auto-emits as --auth-token on structured commands."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"port": 8080, "api_key": "sk-flag"})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--auth-token sk-flag" in cmd
+
+
+def test_atlas_auth_token_alias_emitted_as_auth_token_flag():
+    """defaults.auth_token alias also auto-emits as --auth-token."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"port": 8080, "auth_token": "sk-alias"})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--auth-token sk-alias" in cmd
+
+
+def test_atlas_no_duplicate_auth_token_when_both_keys_set():
+    """When both api_key and auth_token are set, --auth-token is emitted once."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"api_key": "sk-canonical", "auth_token": "sk-alias"})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert cmd.count("--auth-token") == 1
+    # Canonical api_key wins
+    assert "--auth-token sk-canonical" in cmd
+    assert "sk-alias" not in cmd

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -316,6 +316,63 @@ class TestSaveJobMetadata:
         assert "port" not in meta
         assert "served_model_name" not in meta
 
+    def test_api_key_persisted_via_runtime(self, tmp_path: Path):
+        """Runtime's resolve_api_key result is persisted to metadata."""
+        from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+        recipe = _make_recipe(defaults={"api_key": "sk-abc"})
+
+        class _Rt:
+            def resolve_api_key(self, recipe, overrides=None):
+                return recipe.defaults.get("api_key")
+
+        save_job_metadata(
+            "sparkrun_authkey",
+            recipe,
+            ["10.0.0.1"],
+            cache_dir=str(tmp_path),
+            runtime=_Rt(),
+        )
+        meta = load_job_metadata("sparkrun_authkey", cache_dir=str(tmp_path))
+        assert meta is not None
+        assert meta["api_key"] == "sk-abc"
+
+    def test_api_key_omitted_when_runtime_returns_none(self, tmp_path: Path):
+        """No api_key field when resolve_api_key returns None."""
+        from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+        recipe = _make_recipe()
+
+        class _Rt:
+            def resolve_api_key(self, recipe, overrides=None):
+                return None
+
+        save_job_metadata(
+            "sparkrun_nokey",
+            recipe,
+            ["10.0.0.1"],
+            cache_dir=str(tmp_path),
+            runtime=_Rt(),
+        )
+        meta = load_job_metadata("sparkrun_nokey", cache_dir=str(tmp_path))
+        assert meta is not None
+        assert "api_key" not in meta
+
+    def test_api_key_skipped_when_no_runtime(self, tmp_path: Path):
+        """Backward compat: no runtime arg means no api_key resolution."""
+        from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+        recipe = _make_recipe(defaults={"api_key": "sk-ignored"})
+        save_job_metadata(
+            "sparkrun_noruntime",
+            recipe,
+            ["10.0.0.1"],
+            cache_dir=str(tmp_path),
+        )
+        meta = load_job_metadata("sparkrun_noruntime", cache_dir=str(tmp_path))
+        assert meta is not None
+        assert "api_key" not in meta
+
 
 # =====================================================================
 # Tests: Discovery
@@ -424,6 +481,95 @@ class TestDiscovery:
         healthy = [ep for ep in endpoints if ep.healthy]
         assert len(healthy) == 2
         assert "Qwen/Qwen3-1.7B" in healthy[0].actual_models
+
+    def test_api_key_threaded_into_endpoint(self, jobs_dir: Path):
+        """api_key from job metadata flows into DiscoveredEndpoint."""
+        from sparkrun.proxy.discovery import discover_endpoints
+
+        meta = {
+            "cluster_id": "sparkrun_apikey",
+            "recipe": "vllm-auth",
+            "model": "Org/Authed",
+            "runtime": "vllm",
+            "hosts": ["10.0.0.5"],
+            "port": 8000,
+            "api_key": "sk-upstream",
+        }
+        with open(jobs_dir / "apikey.yaml", "w") as f:
+            yaml.safe_dump(meta, f)
+
+        endpoints = discover_endpoints(
+            cache_dir=str(jobs_dir.parent),
+            check_health=False,
+        )
+        assert len(endpoints) == 1
+        assert endpoints[0].api_key == "sk-upstream"
+
+    def test_health_check_sends_bearer_header(self, jobs_dir: Path):
+        """Health check uses Bearer auth when api_key is set on the endpoint."""
+        from sparkrun.proxy.discovery import discover_endpoints
+
+        meta = {
+            "cluster_id": "sparkrun_authed",
+            "recipe": "vllm-auth",
+            "model": "Org/Authed",
+            "runtime": "vllm",
+            "hosts": ["10.0.0.7"],
+            "port": 8000,
+            "api_key": "sk-bearer",
+        }
+        with open(jobs_dir / "authed.yaml", "w") as f:
+            yaml.safe_dump(meta, f)
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"data": [{"id": "Org/Authed"}]}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        captured: list = []
+
+        def _spy(req, timeout=None):
+            captured.append(req)
+            return mock_response
+
+        with patch("sparkrun.proxy.discovery.urllib.request.urlopen", side_effect=_spy):
+            endpoints = discover_endpoints(
+                cache_dir=str(jobs_dir.parent),
+                check_health=True,
+            )
+
+        healthy = [ep for ep in endpoints if ep.healthy]
+        assert len(healthy) == 1
+        assert captured, "urlopen was not called"
+        # urllib normalises header keys: Authorization → "Authorization"
+        auth_value = captured[0].get_header("Authorization")
+        assert auth_value == "Bearer sk-bearer"
+
+    def test_health_check_no_auth_when_no_api_key(self, populated_jobs_dir: Path):
+        """No Authorization header is sent when endpoint has no api_key."""
+        from sparkrun.proxy.discovery import discover_endpoints
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"data": []}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        captured: list = []
+
+        def _spy(req, timeout=None):
+            captured.append(req)
+            return mock_response
+
+        with patch("sparkrun.proxy.discovery.urllib.request.urlopen", side_effect=_spy):
+            discover_endpoints(
+                cache_dir=str(populated_jobs_dir),
+                check_health=True,
+            )
+
+        for req in captured:
+            assert req.get_header("Authorization") is None
 
     def test_health_check_failure(self, populated_jobs_dir: Path):
         """Failed health check sets healthy=False."""
@@ -800,6 +946,39 @@ class TestEngineConfig:
         config = build_litellm_config(endpoints)
         assert len(config["model_list"]) == 1
         assert config["model_list"][0]["model_name"] == "model-a"
+
+    def test_build_config_uses_endpoint_api_key(self):
+        """Endpoint api_key flows through to litellm_params; absent → 'not-needed'."""
+        from sparkrun.proxy.discovery import DiscoveredEndpoint
+        from sparkrun.proxy.engine import build_litellm_config
+
+        endpoints = [
+            DiscoveredEndpoint(
+                cluster_id="sparkrun_auth",
+                model="Org/Authed",
+                served_model_name=None,
+                runtime="vllm",
+                host="10.0.0.5",
+                port=8000,
+                healthy=True,
+                actual_models=["Org/Authed"],
+                api_key="sk-upstream",
+            ),
+            DiscoveredEndpoint(
+                cluster_id="sparkrun_open",
+                model="Org/Open",
+                served_model_name=None,
+                runtime="vllm",
+                host="10.0.0.6",
+                port=8000,
+                healthy=True,
+                actual_models=["Org/Open"],
+            ),
+        ]
+
+        config = build_litellm_config(endpoints)
+        keys = {m["model_name"]: m["litellm_params"]["api_key"] for m in config["model_list"]}
+        assert keys == {"Org/Authed": "sk-upstream", "Org/Open": "not-needed"}
 
     def test_build_config_deduplicates(self):
         """Same model on same host:port is deduplicated."""

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -281,6 +281,75 @@ def test_vllm_resolve_api_key_none_when_unset():
     assert VllmRayRuntime().resolve_api_key(recipe) is None
 
 
+def test_vllm_resolve_api_key_parses_inline_command_flag():
+    """Literal --api-key in a fixed command string is extracted."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --api-key sk-inline --port 8000",
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_vllm_resolve_api_key_parses_equals_form():
+    """`--api-key=value` form is also extracted."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --api-key=sk-eq --port 8000",
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-eq"
+
+
+def test_vllm_resolve_api_key_ignores_placeholder_in_command():
+    """`--api-key {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --api-key {api_key} --port 8000",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    # defaults.api_key wins over the (rejected) placeholder
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_vllm_resolve_api_key_defaults_beat_inline_command():
+    """defaults.api_key takes precedence over inline --api-key in command."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --api-key sk-inline",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_vllm_api_key_emitted_as_flag_for_structured_command():
+    """defaults.api_key auto-emits as --api-key on structured (no-template) commands."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"port": 8000, "api_key": "sk-flag"},
+        }
+    )
+    cmd = VllmRayRuntime().generate_command(recipe, {}, is_cluster=False)
+    assert "--api-key sk-flag" in cmd
+
+
 # --- SglangRuntime Tests ---
 
 
@@ -348,6 +417,110 @@ def test_sglang_cluster_env():
     env = runtime.get_cluster_env(head_ip="192.168.1.100", num_nodes=2)
 
     assert env["NCCL_CUMEM_ENABLE"] == "0"
+
+
+# --- SGLang resolve_api_key Tests ---
+
+
+def test_sglang_resolve_api_key_from_defaults():
+    """defaults.api_key is the recommended source for sglang too."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_sglang_resolve_api_key_from_env():
+    """env.SGLANG_API_KEY is honored when defaults.api_key is absent."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "env": {"SGLANG_API_KEY": "sk-env"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-env"
+
+
+def test_sglang_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults and env."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"SGLANG_API_KEY": "sk-env"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_sglang_resolve_api_key_defaults_beat_env():
+    """defaults.api_key takes precedence over env.SGLANG_API_KEY."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"SGLANG_API_KEY": "sk-env"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_sglang_resolve_api_key_none_when_unset():
+    """Returns None when no api_key is configured anywhere."""
+    recipe = Recipe.from_dict({"name": "r", "model": "m", "runtime": "sglang"})
+    assert SglangRuntime().resolve_api_key(recipe) is None
+
+
+def test_sglang_resolve_api_key_parses_inline_command_flag():
+    """Literal --api-key in a fixed command string is extracted."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "command": "python -m sglang.launch_server --model-path m --api-key sk-inline --port 30000",
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_sglang_resolve_api_key_ignores_placeholder_in_command():
+    """`--api-key {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "command": "python -m sglang.launch_server --api-key {api_key} --port 30000",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_sglang_api_key_emitted_as_flag_for_structured_command():
+    """defaults.api_key auto-emits as --api-key on structured (no-template) commands."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "defaults": {"port": 30000, "api_key": "sk-flag"},
+        }
+    )
+    cmd = SglangRuntime().generate_command(recipe, {}, is_cluster=False)
+    assert "--api-key sk-flag" in cmd
 
 
 def test_sglang_validate_recipe():

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -1636,6 +1636,110 @@ def test_llama_cpp_cluster_strategy():
     assert runtime.cluster_strategy() == "native"
 
 
+# --- llama.cpp resolve_api_key Tests ---
+
+
+def test_llama_cpp_resolve_api_key_from_defaults():
+    """defaults.api_key is the recommended source for llama.cpp too."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_llama_cpp_resolve_api_key_from_env():
+    """env.LLAMA_API_KEY is honored when defaults.api_key is absent."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "env": {"LLAMA_API_KEY": "sk-env"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-env"
+
+
+def test_llama_cpp_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults and env."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"LLAMA_API_KEY": "sk-env"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_llama_cpp_resolve_api_key_defaults_beat_env():
+    """defaults.api_key takes precedence over env.LLAMA_API_KEY."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"LLAMA_API_KEY": "sk-env"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_llama_cpp_resolve_api_key_none_when_unset():
+    """Returns None when no api_key is configured anywhere."""
+    recipe = Recipe.from_dict({"name": "r", "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M", "runtime": "llama-cpp"})
+    assert LlamaCppRuntime().resolve_api_key(recipe) is None
+
+
+def test_llama_cpp_resolve_api_key_parses_inline_command_flag():
+    """Literal --api-key in a fixed command string is extracted."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "command": "llama-server -hf m --api-key sk-inline --port 8080",
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_llama_cpp_resolve_api_key_ignores_placeholder_in_command():
+    """`--api-key {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "command": "llama-server -hf m --api-key {api_key} --port 8080",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_llama_cpp_api_key_emitted_as_flag_for_structured_command():
+    """defaults.api_key auto-emits as --api-key on structured (no-template) commands."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "defaults": {"port": 8080, "api_key": "sk-flag"},
+        }
+    )
+    cmd = LlamaCppRuntime().generate_command(recipe, {}, is_cluster=False)
+    assert "--api-key sk-flag" in cmd
+
+
 def test_llama_cpp_resolve_container_from_recipe():
     """Recipe with container field."""
     recipe_data = {

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -204,6 +204,83 @@ def test_vllm_cluster_env():
     assert env["RAY_memory_monitor_refresh_ms"] == "0"
 
 
+# --- resolve_api_key Tests ---
+
+
+def test_base_resolve_api_key_returns_none():
+    """Base RuntimePlugin returns None — runtimes opt in by overriding."""
+
+    class _Stub(RuntimePlugin):
+        runtime_name = "stub"
+
+        def generate_command(self, *args, **kwargs):
+            return ""
+
+    recipe = Recipe.from_dict({"name": "r", "model": "m", "runtime": "stub", "defaults": {"api_key": "abc"}})
+    assert _Stub().resolve_api_key(recipe) is None
+
+
+def test_vllm_resolve_api_key_from_defaults():
+    """defaults.api_key is the recommended source."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-default"
+    assert VllmDistributedRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_vllm_resolve_api_key_from_env():
+    """env.VLLM_API_KEY is honored when defaults.api_key is absent."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "env": {"VLLM_API_KEY": "sk-env"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-env"
+
+
+def test_vllm_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults and env."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"VLLM_API_KEY": "sk-env"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_vllm_resolve_api_key_defaults_beat_env():
+    """defaults.api_key takes precedence over env.VLLM_API_KEY."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"VLLM_API_KEY": "sk-env"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_vllm_resolve_api_key_none_when_unset():
+    """Returns None when no api_key is configured anywhere."""
+    recipe = Recipe.from_dict({"name": "r", "model": "m", "runtime": "vllm"})
+    assert VllmRayRuntime().resolve_api_key(recipe) is None
+
+
 # --- SglangRuntime Tests ---
 
 


### PR DESCRIPTION
This pull request introduces a unified mechanism for resolving and propagating API keys (or equivalent authentication tokens) from runtime recipes to the proxy/discovery layer, enabling authenticated health checks and registration of endpoints. This is meant to address #187 . The implementation includes new methods for extracting API keys from various sources, updates to job metadata handling, and integration across all major runtime plugins (vLLM, sglang, llama.cpp, and atlas). Additionally, the proxy and engine code are updated to utilize and forward these credentials when communicating with endpoints.

**API Key Resolution and Propagation**

* Introduced a standard `resolve_api_key` method to `RuntimePlugin` (and implemented it for vLLM, sglang, llama.cpp, and atlas) to extract authentication credentials from CLI overrides, recipe defaults, environment variables, or directly from the command string. This enables consistent retrieval of API keys or tokens for use by the proxy/discovery layer. [[1]](diffhunk://#diff-0c65883179e7c5488f6cb37101feaddef94a4507d5aeb0dad4b2003d36fcffd6R169-R183) [[2]](diffhunk://#diff-c2ccc54c69c38fdc4c9c3680a1fdcb7d5de78d838902f2a6b6547d3911a2952cR42-R69) [[3]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0R125-R157) [[4]](diffhunk://#diff-956fbd2dc39b034a5d2762d5ee83fb0313fad2213f295f58f019b9ef317ae62fR89-R116)
* Added utility functions `parse_flag_value_from_command` and `parse_api_key_from_command` in `src/sparkrun/runtimes/_util.py` to reliably extract flag values (such as API keys) from command-line strings, supporting both `--flag value` and `--flag=value` formats. [[1]](diffhunk://#diff-8dd5dbeff2d823aaee45bd4af5cd1177232377b69bf86b51d414c77bfc325e3cR1-R3) [[2]](diffhunk://#diff-8dd5dbeff2d823aaee45bd4af5cd1177232377b69bf86b51d414c77bfc325e3cR12-R43)

**Job Metadata and Discovery Integration**

* Updated `save_job_metadata` in `src/sparkrun/orchestration/job_metadata.py` to call the runtime's `resolve_api_key` and persist the API key (when available) in job metadata, so it is accessible during proxy/discovery. [[1]](diffhunk://#diff-095aed9fb27b0a8fc8c1d09778ae192da8c01e5cf978100920a3ce1981e8eae8R184) [[2]](diffhunk://#diff-095aed9fb27b0a8fc8c1d09778ae192da8c01e5cf978100920a3ce1981e8eae8R235-R246)
* Modified `DiscoveredEndpoint` and the discovery process to include the `api_key` field, ensuring the proxy is aware of any required authentication for endpoints. [[1]](diffhunk://#diff-91b3c2ff2a7fad1b651b18150ff8bd90ee25a6dd5a4e0baa0d311e0612ec0599R41) [[2]](diffhunk://#diff-91b3c2ff2a7fad1b651b18150ff8bd90ee25a6dd5a4e0baa0d311e0612ec0599R162) [[3]](diffhunk://#diff-91b3c2ff2a7fad1b651b18150ff8bd90ee25a6dd5a4e0baa0d311e0612ec0599R249)

**Proxy and Engine Usage**

* Updated proxy health checks to send an `Authorization: Bearer` header when an endpoint has an `api_key`, allowing authenticated endpoints to be health-checked and registered.
* Adjusted proxy engine code to forward the resolved `api_key` to litellm and when adding models/aliases via API, ensuring downstream consumers receive the correct credentials. [[1]](diffhunk://#diff-1ba7a7142d600f5827e71468aaa7d3533f130a229e8c675c3d0818aa16a1cbceL66-R66) [[2]](diffhunk://#diff-1ba7a7142d600f5827e71468aaa7d3533f130a229e8c675c3d0818aa16a1cbceL390-R390) [[3]](diffhunk://#diff-1ba7a7142d600f5827e71468aaa7d3533f130a229e8c675c3d0818aa16a1cbceL525-R525)

**Runtime Plugin Enhancements**

* For Atlas, added normalization logic to treat `auth_token` and `api_key` as aliases, ensuring compatibility and portability across runtimes and recipes. [[1]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0R87-R91) [[2]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0R182-R194) [[3]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0R210) [[4]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0R248)
* Updated flag maps for all runtimes to include the appropriate API key flags (`--api-key` or `--auth-token`). [[1]](diffhunk://#diff-c2ccc54c69c38fdc4c9c3680a1fdcb7d5de78d838902f2a6b6547d3911a2952cR102) [[2]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0R87-R91) [[3]](diffhunk://#diff-956fbd2dc39b034a5d2762d5ee83fb0313fad2213f295f58f019b9ef317ae62fR30)

**Internal Integration and Imports**

* Updated imports across runtime plugins to use the new utility functions for API key parsing. [[1]](diffhunk://#diff-c2ccc54c69c38fdc4c9c3680a1fdcb7d5de78d838902f2a6b6547d3911a2952cL7-R7) [[2]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0L28-R28) [[3]](diffhunk://#diff-956fbd2dc39b034a5d2762d5ee83fb0313fad2213f295f58f019b9ef317ae62fR9) [[4]](diffhunk://#diff-905d0787c089848b200c7ddefd52a7e41a437b4ceb809d6a6deb255ea62f0f86L8-R8)
* Passed the `runtime` object to job metadata functions in the launcher to enable API key resolution. [[1]](diffhunk://#diff-c52669c725e09ea433cd88d773b412bf68812178deba2cbca1da56f9ab6ef4aaR297) [[2]](diffhunk://#diff-c52669c725e09ea433cd88d773b412bf68812178deba2cbca1da56f9ab6ef4aaR347) [[3]](diffhunk://#diff-c52669c725e09ea433cd88d773b412bf68812178deba2cbca1da56f9ab6ef4aaR564)