### PR TITLE
v0.2.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.35"
+version = "0.2.36"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -561,7 +561,28 @@ def _run_benchmark(
             click.echo("Error: --bench-option must be key=value, got: %s" % opt_str, err=True)
             sys.exit(1)
         key, _, val = opt_str.partition("=")
-        bench_args[key.strip()] = fw.interpret_arg(key.strip(), val.strip())
+        stripped_key = key.strip()
+        if "api_key" in stripped_key.lower():
+            click.echo(
+                f"Error: Passing '{stripped_key}' via --bench-option is insecure. "
+                "Please set the OPENAI_API_KEY environment variable or use a .env file instead.",
+                err=True,
+            )
+            sys.exit(1)
+        bench_args[stripped_key] = fw.interpret_arg(stripped_key, val.strip())
+
+    if "api_key" not in bench_args:
+        import os
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            try:
+                from dotenv import load_dotenv
+                load_dotenv()
+                api_key = os.environ.get("OPENAI_API_KEY")
+            except ImportError:
+                pass
+        if api_key:
+            bench_args["api_key"] = api_key
 
     if exit_on_first_fail:
         bench_args["exit_on_first_fail"] = True
@@ -652,7 +673,8 @@ def _run_benchmark(
     click.echo("")
     click.echo("Benchmark args:")
     for k, bv in bench_args.items():
-        click.echo("  %-35s %s" % (k + ":", bv))
+        display_val = "***REDACTED***" if "api_key" in k.lower() else bv
+        click.echo("  %-35s %s" % (k + ":", display_val))
     click.echo("=" * 60)
     click.echo("")
 

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -573,7 +573,7 @@ def _run_benchmark(
         if "api_key" in stripped_key.lower():
             click.echo(
                 f"Error: Passing '{stripped_key}' via --bench-option is insecure. "
-                "Please set the OPENAI_API_KEY environment variable or use a .env file instead.",
+                "Please use the --api-key-env flag to pass it via an environment variable instead.",
                 err=True,
             )
             sys.exit(1)

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -580,21 +580,19 @@ def _run_benchmark(
         bench_args[stripped_key] = fw.interpret_arg(stripped_key, val.strip())
 
     if "api_key" not in bench_args and api_key_env:
-        import os
-        api_key = os.environ.get(api_key_env)
+        api_key = v.get(api_key_env)
         if not api_key:
+            from scitrera_app_framework import add_env_file_source
+
             try:
-                from dotenv import load_dotenv
-                load_dotenv()
-                api_key = os.environ.get(api_key_env)
+                add_env_file_source(".env", v)
+                api_key = v.get(api_key_env)
             except ImportError:
                 pass
         if api_key:
             bench_args["api_key"] = api_key
         else:
-            click.echo(
-                f"Warning: --api-key-env '{api_key_env}' specified, but not found in environment.", err=True
-            )
+            click.echo(f"Warning: --api-key-env '{api_key_env}' specified, but not found in environment.", err=True)
 
     if exit_on_first_fail:
         bench_args["exit_on_first_fail"] = True

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -135,6 +135,11 @@ def benchmark(ctx):
 @click.option("--output", "output_file", default=None, type=click.Path(), help="Output file for results YAML")
 @click.option("-b", "--benchmark-option", "bench_options", multiple=True, help="Override benchmark arg: -b key=value (repeatable)")
 @click.option(
+    "--api-key-env",
+    default=None,
+    help="Name of the environment variable to read the API key from (e.g. OPENAI_API_KEY).",
+)
+@click.option(
     "--exit-on-first-fail/--no-exit-on-first-fail",
     "exit_on_first_fail",
     default=True,
@@ -180,6 +185,7 @@ def benchmark_run(
     framework,
     output_file,
     bench_options,
+    api_key_env,
     exit_on_first_fail,
     no_stop,
     skip_run,
@@ -211,6 +217,7 @@ def benchmark_run(
         framework,
         output_file,
         bench_options,
+        api_key_env,
         exit_on_first_fail,
         no_stop,
         skip_run,
@@ -464,6 +471,7 @@ def _run_benchmark(
     framework,
     output_file,
     bench_options,
+    api_key_env,
     exit_on_first_fail,
     no_stop,
     skip_run,
@@ -571,18 +579,22 @@ def _run_benchmark(
             sys.exit(1)
         bench_args[stripped_key] = fw.interpret_arg(stripped_key, val.strip())
 
-    if "api_key" not in bench_args:
+    if "api_key" not in bench_args and api_key_env:
         import os
-        api_key = os.environ.get("OPENAI_API_KEY")
+        api_key = os.environ.get(api_key_env)
         if not api_key:
             try:
                 from dotenv import load_dotenv
                 load_dotenv()
-                api_key = os.environ.get("OPENAI_API_KEY")
+                api_key = os.environ.get(api_key_env)
             except ImportError:
                 pass
         if api_key:
             bench_args["api_key"] = api_key
+        else:
+            click.echo(
+                f"Warning: --api-key-env '{api_key_env}' specified, but not found in environment.", err=True
+            )
 
     if exit_on_first_fail:
         bench_args["exit_on_first_fail"] = True

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -907,9 +907,12 @@ def _run_benchmark(
         # Pass served_model_name as an argument if defined, satisfying llama-benchy's
         # requirement to maintain the original huggingface model ID for tokenization.
         # Check config_chain to capture both CLI overrides and recipe definitions natively.
-        served_model_name = config_chain.get("served_model_name")
-        if served_model_name and "served_model_name" not in bench_args:
+        if (served_model_name := config_chain.get("served_model_name")) and "served_model_name" not in bench_args:
             bench_args["served_model_name"] = served_model_name
+
+        # pass api key to model if specified by recipe and not already in bench_args (e.g., via --api-key-env)
+        if (api_key := runtime.resolve_api_key(recipe, overrides)) and "api_key" not in bench_args:
+            bench_args["api_key"] = api_key
 
         stdout_text = ""
         stderr_text = ""

--- a/src/sparkrun/cli/_cluster.py
+++ b/src/sparkrun/cli/_cluster.py
@@ -814,12 +814,10 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
         sys.exit(1)
     if name:
         cluster_name = name
-    from concurrent.futures import ThreadPoolExecutor, as_completed
 
     from sparkrun.core.cluster_manager import resolve_cluster_config
     from sparkrun.core.launcher import resolve_effective_cache_dir
     from sparkrun.orchestration.primitives import build_ssh_kwargs
-    from sparkrun.orchestration.ssh import run_remote_command
 
     config = _get_context(ctx).config
     host_list, cluster_mgr = _resolve_hosts_or_exit(hosts, hosts_file, cluster_name, config)
@@ -867,67 +865,27 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
         click.echo("[dry-run] Would inspect cluster config and cache dirs on %d host(s)" % len(host_list))
         return
 
-    # Build a script that checks existence and disk usage for both dirs.
-    # We derive remote sparkrun cache the same way: ~/.cache/sparkrun on the remote user.
+    # TODO: remote sparkrun cache path should go through same effective route as remote hf cache resolution
+    # Resolve remote sparkrun cache path the same way as before: explicit
+    # for a known cluster user, otherwise $HOME-relative.
     if cluster_cfg.user:
         remote_sparkrun = "/home/%s/.cache/sparkrun" % cluster_cfg.user
     else:
         remote_sparkrun = "$HOME/.cache/sparkrun"
 
-    check_cmd = (
-        'sr_dir="%s"; hf_dir="%s"; '
-        'sr_exists="no"; hf_exists="no"; sr_du="-"; hf_du="-"; '
-        'if [ -d "$sr_dir" ]; then sr_exists="yes"; sr_du=$(du -sh "$sr_dir" 2>/dev/null | cut -f1); fi; '
-        'if [ -d "$hf_dir" ]; then hf_exists="yes"; hf_du=$(du -sh "$hf_dir" 2>/dev/null | cut -f1); fi; '
-        'free_space=$(df -h / 2>/dev/null | awk "NR==2{print \\$4}"); '
-        'echo "sr_exists=$sr_exists|sr_du=$sr_du|hf_exists=$hf_exists|hf_du=$hf_du|sr_dir=$sr_dir|hf_dir=$hf_dir|free_space=${free_space:--}"'
-    ) % (remote_sparkrun, remote_hf)
+    from sparkrun.orchestration.disk_info import probe_cache_status, probe_local_cache_status
+    from sparkrun.utils.cli_formatters import format_cache_status_table
 
-    # Query all hosts in parallel
-    host_info: dict[str, dict] = {}
-    with ThreadPoolExecutor(max_workers=len(host_list)) as executor:
-        futures = {
-            executor.submit(
-                run_remote_command,
-                host,
-                check_cmd,
-                ssh_user=ssh_kwargs.get("ssh_user"),
-                ssh_key=ssh_kwargs.get("ssh_key"),
-                ssh_options=ssh_kwargs.get("ssh_options"),
-                timeout=15,
-            ): host
-            for host in host_list
-        }
-        for future in as_completed(futures):
-            host = futures[future]
-            result = future.result()
-            if result.success and result.stdout.strip():
-                parts = dict(kv.split("=", 1) for kv in result.stdout.strip().split("|") if "=" in kv)
-                host_info[host] = parts
-            else:
-                host_info[host] = {"error": result.stderr.strip() or "SSH failed"}
-
-    # Check local directories
-    import os
-    import subprocess as _sp
-
-    def _local_dir_info(path: str) -> tuple[str, str]:
-        if not os.path.isdir(path):
-            return "no", "-"
-        du_result = _sp.run(["du", "-sh", path], capture_output=True, text=True)
-        size = du_result.stdout.split()[0] if du_result.returncode == 0 and du_result.stdout.strip() else "-"
-        return "yes", size
-
-    local_sr_exists, local_sr_du = _local_dir_info(local_sparkrun)
-    local_hf_exists, local_hf_du = _local_dir_info(local_hf)
-
-    # Local free space on root partition
-    _df_result = _sp.run(["df", "-h", "/"], capture_output=True, text=True)
-    local_free_space = "-"
-    if _df_result.returncode == 0 and _df_result.stdout.strip():
-        _df_lines = _df_result.stdout.strip().splitlines()
-        if len(_df_lines) >= 2:
-            local_free_space = _df_lines[1].split()[3]
+    host_status = probe_cache_status(
+        host_list,
+        hf_cache_dir=remote_hf,
+        sparkrun_cache_dir=remote_sparkrun,
+        ssh_kwargs=ssh_kwargs,
+    )
+    local_status = probe_local_cache_status(
+        hf_cache_dir=local_hf,
+        sparkrun_cache_dir=local_sparkrun,
+    )
 
     # Collect effective config summary
     effective_config = {
@@ -949,25 +907,25 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
             "config": effective_config,
             "hosts": list(host_list),
             "local": {
-                "sparkrun_cache": {"path": local_sparkrun, "exists": local_sr_exists == "yes", "size": local_sr_du},
-                "hf_cache": {"path": local_hf, "exists": local_hf_exists == "yes", "size": local_hf_du},
-                "free_space": local_free_space,
+                "sparkrun_cache": {
+                    "path": local_status.sparkrun_dir,
+                    "exists": local_status.sparkrun_exists,
+                    "size": local_status.sparkrun_size,
+                },
+                "hf_cache": {"path": local_status.hf_dir, "exists": local_status.hf_exists, "size": local_status.hf_size},
+                "free_space": local_status.free_space,
             },
             "remote": {},
         }
         for h in host_list:
-            info = host_info.get(h, {})
-            if "error" in info:
-                data["remote"][h] = {"error": info["error"]}
+            status = host_status.get(h)
+            if status is None or status.error:
+                data["remote"][h] = {"error": (status.error if status else "no result")}
             else:
                 data["remote"][h] = {
-                    "sparkrun_cache": {
-                        "path": info.get("sr_dir", "?"),
-                        "exists": info.get("sr_exists") == "yes",
-                        "size": info.get("sr_du", "-"),
-                    },
-                    "hf_cache": {"path": info.get("hf_dir", "?"), "exists": info.get("hf_exists") == "yes", "size": info.get("hf_du", "-")},
-                    "free_space": info.get("free_space", "-"),
+                    "sparkrun_cache": {"path": status.sparkrun_dir, "exists": status.sparkrun_exists, "size": status.sparkrun_size},
+                    "hf_cache": {"path": status.hf_dir, "exists": status.hf_exists, "size": status.hf_size},
+                    "free_space": status.free_space,
                 }
         print_json(data)
         return
@@ -1012,25 +970,7 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
         click.echo("  ⚠ local and remote HF cache paths differ")
     click.echo()
 
-    # Directory status table
+    # Directory status table (shared formatter — also used by the
+    # distribute_model_from_local error path on out-of-space failures).
     click.echo("Directory Status:")
-    click.echo(
-        "  %-30s %-10s %-10s %-10s %-10s %-12s %s" % ("Host", "SR exists", "SR size", "HF exists", "HF size", "Free Space", "HF path")
-    )
-    click.echo("  " + "-" * 112)
-    click.echo(
-        "  %-30s %-10s %-10s %-10s %-10s %-12s %s"
-        % ("(local)", local_sr_exists, local_sr_du, local_hf_exists, local_hf_du, local_free_space, local_hf)
-    )
-    for h in host_list:
-        info = host_info.get(h, {})
-        if "error" in info:
-            click.echo("  %-30s %s" % (h, "Error: %s" % info["error"]))
-        else:
-            sr_exists = info.get("sr_exists", "?")
-            sr_du = info.get("sr_du", "-")
-            hf_exists = info.get("hf_exists", "?")
-            hf_du = info.get("hf_du", "-")
-            free_space = info.get("free_space", "-")
-            hf_dir = info.get("hf_dir", "?")
-            click.echo("  %-30s %-10s %-10s %-10s %-10s %-12s %s" % (h, sr_exists, sr_du, hf_exists, hf_du, free_space, hf_dir))
+    click.echo(format_cache_status_table(host_status, local_status=local_status))

--- a/src/sparkrun/cli/_setup/_commands.py
+++ b/src/sparkrun/cli/_setup/_commands.py
@@ -1273,6 +1273,23 @@ def setup_docker_group(ctx, hosts, hosts_file, cluster_name, user, dry_run):
         click.echo("Note: Users newly added to the docker group must re-login")
         click.echo("(or run 'newgrp docker') for the change to take effect.")
 
+    # Storage-driver consistency probe (issue #152).  Heterogeneous
+    # drivers across hosts cause the same registry image to land with
+    # different local Image IDs, which trips unnecessary container
+    # re-syncs; warn so the user can normalize on overlay2.
+    if not dry_run and len(host_list) > 1:
+        from sparkrun.orchestration.docker_info import (
+            check_driver_consistency,
+            detect_docker_drivers,
+            format_driver_warning,
+        )
+
+        driver_map = detect_docker_drivers(host_list, ssh_kwargs=ssh_kwargs)
+        consistent, groups = check_driver_consistency(driver_map)
+        if not consistent:
+            click.echo()
+            click.echo(format_driver_warning(groups), err=True)
+
     if fail_count:
         sys.exit(1)
 

--- a/src/sparkrun/cli/_setup/_wizard.py
+++ b/src/sparkrun/cli/_setup/_wizard.py
@@ -794,6 +794,23 @@ def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
                             r = dg_result_map.get(h)
                             if r and r.success:
                                 click.echo("  %s: %s" % (h, _docker_group_summary(r.stdout, user=user)))
+
+                        # Storage-driver consistency probe (issue #152) —
+                        # warn when hosts use different drivers so users
+                        # can normalize on overlay2 before image syncs.
+                        if dg_ok and not dry_run and len(host_list) > 1:
+                            from sparkrun.orchestration.docker_info import (
+                                check_driver_consistency,
+                                detect_docker_drivers,
+                                format_driver_warning,
+                            )
+
+                            driver_map = detect_docker_drivers(host_list, ssh_kwargs=ssh_kwargs)
+                            consistent, groups = check_driver_consistency(driver_map)
+                            if not consistent:
+                                click.echo()
+                                click.echo(format_driver_warning(groups), err=True)
+                                results["docker"] = "%s (driver drift)" % results["docker"]
                 except Exception as e:
                     results["docker"] = "failed"
                     click.echo("Docker group error: %s" % e, err=True)

--- a/src/sparkrun/containers/distribute.py
+++ b/src/sparkrun/containers/distribute.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 
 from sparkrun.containers.registry import ensure_image, get_image_identity
-from sparkrun.orchestration.primitives import map_transfer_failures
+from sparkrun.orchestration.transfer import map_transfer_failures
 from sparkrun.orchestration.ssh import (
     RemoteResult,
     build_ssh_opts_string,

--- a/src/sparkrun/containers/registry.py
+++ b/src/sparkrun/containers/registry.py
@@ -111,17 +111,23 @@ def get_image_id(image: str) -> str | None:
     return get_image_identity(image)[0]
 
 
-def ensure_image(image: str, dry_run: bool = False) -> int:
+def ensure_image(image: str, dry_run: bool = False, force_pull: bool = False) -> int:
     """Ensure an image exists locally, pulling if needed.
 
     Args:
         image: Image reference.
         dry_run: If True, show what would be done without executing.
+        force_pull: If True, force pull even if it exists locally.
 
     Returns:
         Exit code (0 = success).
     """
-    if image_exists_locally(image):
-        logger.info("Image already available: %s", image)
-        return 0
+    is_latest_or_nightly = image.endswith(":latest") or "nightly" in image
+    if not force_pull and not is_latest_or_nightly:
+        if image_exists_locally(image):
+            logger.info("Image already available: %s", image)
+            return 0
+    elif is_latest_or_nightly:
+        logger.info("Image uses 'latest' or 'nightly' tag; forcing pull: %s", image)
+    
     return pull_image(image, dry_run=dry_run)

--- a/src/sparkrun/containers/registry.py
+++ b/src/sparkrun/containers/registry.py
@@ -13,12 +13,13 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 
-def pull_image(image: str, dry_run: bool = False) -> int:
+def pull_image(image: str, dry_run: bool = False, required: bool = True) -> int:
     """Pull a container image from a registry.
 
     Args:
         image: Image reference to pull (e.g. ``"nvcr.io/nvidia/vllm:latest"``).
         dry_run: If True, show what would be done without executing.
+        required: If False, suppress error output since this isn't "required"
 
     Returns:
         Exit code (0 = success).
@@ -34,7 +35,10 @@ def pull_image(image: str, dry_run: bool = False) -> int:
         text=True,
     )
     if result.returncode != 0:
-        logger.error("Failed to pull image %s: %s", image, result.stderr[:200])
+        if required:
+            logger.error("Failed to pull image %s: %s", image, result.stderr[:200])
+        else:
+            logger.info("[NON-CRITICAL] Failed to pull image %s: %s", image, result.stderr[:200])
     return result.returncode
 
 
@@ -127,13 +131,14 @@ def ensure_image(image: str, dry_run: bool = False, force_pull: bool = False) ->
         logger.info("Force pull requested for image: %s", image)
         return pull_image(image, dry_run=dry_run)
 
-    is_latest = image.endswith(":latest") or ":" not in image  # latest if explicit ":latest" or no tag
+    # latest if explicit ":latest" or no tag AND can be tied to registry (has slash)
+    is_latest = "/" in image and (image.endswith(":latest") or ":" not in image)
     exists_locally = image_exists_locally(image)
 
     # if image exists and uses latest tag, then we can opportunistically pull it but not failure mode without force_pull
     if exists_locally and is_latest:
         logger.info("Image uses 'latest' tag, attempting non-critical pull: %s", image)
-        attempt = pull_image(image, dry_run=dry_run)
+        attempt = pull_image(image, dry_run=dry_run, required=False)
         if attempt == 0:
             logger.info("Fresh Image pulled: %s", image)
         else:

--- a/src/sparkrun/containers/registry.py
+++ b/src/sparkrun/containers/registry.py
@@ -122,12 +122,28 @@ def ensure_image(image: str, dry_run: bool = False, force_pull: bool = False) ->
     Returns:
         Exit code (0 = success).
     """
-    is_latest_or_nightly = image.endswith(":latest") or "nightly" in image
-    if not force_pull and not is_latest_or_nightly:
-        if image_exists_locally(image):
-            logger.info("Image already available: %s", image)
-            return 0
-    elif is_latest_or_nightly:
-        logger.info("Image uses 'latest' or 'nightly' tag; forcing pull: %s", image)
-    
+    # if force_pull, then we pull regardless of local presence or tag; failure to pull on explicit force_pull is an error
+    if force_pull:
+        logger.info("Force pull requested for image: %s", image)
+        return pull_image(image, dry_run=dry_run)
+
+    is_latest = image.endswith(":latest") or ":" not in image  # latest if explicit ":latest" or no tag
+    exists_locally = image_exists_locally(image)
+
+    # if image exists and uses latest tag, then we can opportunistically pull it but not failure mode without force_pull
+    if exists_locally and is_latest:
+        logger.info("Image uses 'latest' tag, attempting non-critical pull: %s", image)
+        attempt = pull_image(image, dry_run=dry_run)
+        if attempt == 0:
+            logger.info("Fresh Image pulled: %s", image)
+        else:
+            logger.warning("Failed to pull updated image: %s", image)
+        return 0
+
+    # if otherwise image exists and not force_pull, then we're happy
+    if exists_locally:
+        logger.info("Image already available: %s", image)
+        return 0
+
+    # otherwise, we need to pull
     return pull_image(image, dry_run=dry_run)

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -294,6 +294,7 @@ def launch_inference(
                 cache_dir=str(config.cache_dir),
                 recipe_ref=recipe_ref,
                 container_image=container_image,
+                runtime=runtime,
             )
         except Exception:
             logger.debug("Failed to save job metadata: %s", cluster_id, exc_info=True)
@@ -343,6 +344,7 @@ def launch_inference(
                     ib_ip_map=ib_ip_map,
                     mgmt_ip_map=mgmt_ip_map,
                     recipe_ref=recipe_ref,
+                    runtime=runtime,
                 )
             except Exception:
                 logger.debug("Failed to update job metadata: %s", cluster_id, exc_info=True)
@@ -559,6 +561,7 @@ def launch_inference(
                         recipe_ref=recipe_ref,
                         runtime_info=runtime_info,
                         container_image=container_image,
+                        runtime=runtime,
                     )
                 except Exception:
                     logger.debug("Failed to save runtime_info to job metadata", exc_info=True)

--- a/src/sparkrun/models/distribute.py
+++ b/src/sparkrun/models/distribute.py
@@ -169,11 +169,29 @@ def distribute_model_from_local(
     # Map transfer IPs back to management hosts for failure reporting,
     # and classify each failure (out of disk space, permission denied, …)
     # so the caller can surface a meaningful error instead of a bare host
-    # name.  Issue #168.
+    # name.
     failures = map_transfer_failures_detailed(results, xfer, hosts)
     if failures:
         for f in failures:
             logger.error("  rsync failed on %s: %s", f.host, f.reason)
+        # When any failure was "out of disk space", probe free space on
+        # every cluster host and emit a small table so the user can see
+        # who's full and how much room the healthy hosts have.
+        oos_hosts = [f.host for f in failures if "disk space" in f.reason or "quota" in f.reason]
+        if oos_hosts:
+            from sparkrun.orchestration.disk_info import probe_cache_status
+            from sparkrun.utils.cli_formatters import format_cache_status_table
+
+            cache_status = probe_cache_status(
+                hosts,
+                hf_cache_dir=remote_cache,
+                ssh_kwargs={"ssh_user": ssh_user, "ssh_key": ssh_key, "ssh_options": ssh_options},
+            )
+            if cache_status:
+                logger.error(
+                    "  Cluster cache status:\n%s",
+                    format_cache_status_table(cache_status, highlight_hosts=oos_hosts),
+                )
     else:
         logger.log(PROGRESS, "  Model synced to %d host(s)", len(hosts))
 

--- a/src/sparkrun/models/distribute.py
+++ b/src/sparkrun/models/distribute.py
@@ -11,7 +11,10 @@ import logging
 
 from sparkrun.core.config import resolve_hf_cache_home
 from sparkrun.models.download import download_model, model_cache_path
-from sparkrun.orchestration.primitives import map_transfer_failures
+from sparkrun.orchestration.transfer import (
+    TransferFailure,
+    map_transfer_failures_detailed,
+)
 from sparkrun.orchestration.ssh import (
     build_ssh_opts_string,
     run_remote_scripts_parallel,
@@ -83,7 +86,7 @@ def distribute_model_from_local(
     timeout: int | None = None,
     dry_run: bool = False,
     transfer_hosts: list[str] | None = None,
-) -> list[str]:
+) -> list[TransferFailure]:
     """Download a model locally then rsync it to all hosts.
 
     1. Download the model to the local HF cache via :func:`download_model`.
@@ -113,8 +116,10 @@ def distribute_model_from_local(
             Falls back to *hosts* when ``None``.
 
     Returns:
-        List of hostnames (from *hosts*) where distribution failed
-        (empty = full success).
+        List of :class:`TransferFailure` records, one per host that
+        failed (empty = full success).  Each carries a classified
+        ``reason`` (e.g. "out of disk space on destination") so callers
+        can surface meaningful errors instead of bare host names.
     """
     local_cache = resolve_hf_cache_home(local_cache_dir or cache_dir)
     remote_cache = resolve_hf_cache_home(cache_dir)
@@ -124,7 +129,7 @@ def distribute_model_from_local(
     rc = download_model(model_id, cache_dir=local_cache, token=token, revision=revision, dry_run=dry_run)
     if rc != 0:
         logger.error("Failed to download model '%s' locally — aborting distribution", model_id)
-        return list(hosts)
+        return [TransferFailure(host=h, reason="local model download failed") for h in hosts]
 
     if not hosts:
         return []
@@ -161,14 +166,18 @@ def distribute_model_from_local(
         dry_run=dry_run,
     )
 
-    # Map transfer IPs back to management hosts for failure reporting
-    failed = map_transfer_failures(results, xfer, hosts)
-    if failed:
-        logger.warning("Model distribution failed on hosts: %s", failed)
+    # Map transfer IPs back to management hosts for failure reporting,
+    # and classify each failure (out of disk space, permission denied, …)
+    # so the caller can surface a meaningful error instead of a bare host
+    # name.  Issue #168.
+    failures = map_transfer_failures_detailed(results, xfer, hosts)
+    if failures:
+        for f in failures:
+            logger.error("  rsync failed on %s: %s", f.host, f.reason)
     else:
         logger.log(PROGRESS, "  Model synced to %d host(s)", len(hosts))
 
-    return failed
+    return failures
 
 
 def distribute_model_from_head(
@@ -183,7 +192,7 @@ def distribute_model_from_head(
     timeout: int | None = None,
     dry_run: bool = False,
     worker_transfer_hosts: list[str] | None = None,
-) -> list[str]:
+) -> list[TransferFailure]:
     """Download a model on the head node then distribute to remaining hosts.
 
     1. Download on ``hosts[0]`` using the existing ``model_sync.sh``.
@@ -256,7 +265,7 @@ def distribute_model_from_head(
         ssh_user=ssh_user or "",
     )
 
-    return _distribute_from_head(
+    failed_hosts = _distribute_from_head(
         head=head,
         hosts=hosts,
         ensure_script=ensure_script,
@@ -268,3 +277,8 @@ def distribute_model_from_head(
         timeout=timeout,
         dry_run=dry_run,
     )
+    # _distribute_from_head doesn't expose per-host rsync stderr, so we
+    # can't classify the cause here.  Surface a generic reason and let
+    # users consult the head's rsync log (already echoed above) for
+    # detail like "No space left on device".
+    return [TransferFailure(host=h, reason="rsync from head failed (see log above for stderr)") for h in failed_hosts]

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -220,11 +220,19 @@ def fetch_safetensors_size(
     revision: str | None = None,
     cache_dir: str | None = None,
 ) -> int | None:
-    """Fetch total parameter storage size from safetensors index metadata.
+    """Fetch total parameter storage size from safetensors metadata.
 
-    Downloads only the small ``model.safetensors.index.json`` file, which
-    contains a ``metadata.total_size`` field giving the total bytes of all
-    parameter tensors on disk.
+    Only consults metadata endpoints — never downloads weight files.  In
+    order of preference:
+
+    1. ``model.safetensors.index.json`` (small file) plus ``list_repo_tree``
+       LFS sizes for sharded models.
+    2. ``list_repo_tree`` for the size of a single ``model.safetensors`` file.
+    3. The HuggingFace ``model_info`` API for per-dtype byte counts.
+
+    The ``model_info`` per-dtype counts can be inaccurate for packed quant
+    formats, so the raw LFS file size from ``list_repo_tree`` is preferred
+    when available.
 
     Args:
         model_id: HuggingFace model identifier.
@@ -246,6 +254,10 @@ def fetch_safetensors_size(
             hub_kwargs["revision"] = revision
         if cache_dir:
             hub_kwargs["cache_dir"] = _hub_cache(cache_dir)
+
+        tree_kwargs: dict[str, Any] = {"repo_id": model_id}
+        if revision:
+            tree_kwargs["revision"] = revision
 
         _SAFETENSORS_DTYPE_BYTES: dict[str, int] = {
             "F64": 8,
@@ -303,9 +315,6 @@ def fetch_safetensors_size(
                 try:
                     from huggingface_hub import list_repo_tree
 
-                    tree_kwargs: dict[str, Any] = {"repo_id": model_id}
-                    if revision:
-                        tree_kwargs["revision"] = revision
                     file_total = 0
                     matched = 0
                     for entry in list_repo_tree(**tree_kwargs):
@@ -333,60 +342,32 @@ def fetch_safetensors_size(
         except Exception as e:
             logger.debug("safetensors index failed for %s: %s", model_id, e)
 
-        # Try 2: single-file model — read safetensors header for total param size
+        # Try 2: list_repo_tree for single-file model.safetensors size.
+        # Metadata-only LFS lookup — no weight files are downloaded.  Preferred
+        # over the model_info API because the on-disk file size reflects packed
+        # quant formats (e.g. NVFP4) accurately, whereas the API's per-dtype
+        # counts can mis-report for non-standard dtypes.
         try:
-            import os
+            from huggingface_hub import list_repo_tree
 
-            disable_progress_bars()
-            try:
-                sf_path = hf_hub_download(**hub_kwargs, filename="model.safetensors")
-            finally:
-                enable_progress_bars()
-            # safetensors header: first 8 bytes = header size (u64 LE),
-            # then JSON header with tensor metadata including shape/dtype
-            import struct
-
-            with open(sf_path, "rb") as f:
-                header_size = struct.unpack("<Q", f.read(8))[0]
-                header = json.loads(f.read(header_size))
-
-            total_bytes = 0
-            for key, info in header.items():
-                if key == "__metadata__":
-                    continue
-                shape = info.get("shape", [])
-                dtype = info.get("dtype", "")
-                elem_size = _SAFETENSORS_DTYPE_BYTES.get(dtype, 2)
-                num_elements = 1
-                for dim in shape:
-                    num_elements *= dim
-                total_bytes += num_elements * elem_size
-            if total_bytes > 0:
-                return total_bytes
+            for entry in list_repo_tree(**tree_kwargs):
+                if hasattr(entry, "rfilename") and entry.rfilename == "model.safetensors":
+                    if entry.size and entry.size > 0:
+                        logger.debug(
+                            "Using single-file size %d from list_repo_tree for %s",
+                            entry.size,
+                            model_id,
+                        )
+                        return int(entry.size)
+                    break
         except Exception as e:
-            logger.debug("safetensors header parse failed for %s: %s", model_id, e)
+            logger.debug("list_repo_tree single-file lookup failed for %s: %s", model_id, e)
 
-        # Try 3: API per-dtype for models without index or header
+        # Try 3: API per-dtype as a last resort when LFS metadata is unavailable.
         api_bytes = _compute_api_bytes()
         if api_bytes is not None:
             logger.debug("Got %d bytes from model_info API for %s", api_bytes, model_id)
             return api_bytes
-
-        # Try 4: fall back to file size as rough approximation
-        try:
-            import os
-
-            disable_progress_bars()
-            try:
-                sf_path = hf_hub_download(**hub_kwargs, filename="model.safetensors")
-            finally:
-                enable_progress_bars()
-            size = os.path.getsize(sf_path)
-            if size > 0:
-                logger.debug("Using file size as param size estimate for %s", model_id)
-                return size
-        except Exception as e:
-            logger.debug("safetensors file size fallback failed for %s: %s", model_id, e)
 
     except Exception as e:
         logger.debug("Could not fetch safetensors size for %s: %s", model_id, e)

--- a/src/sparkrun/orchestration/disk_info.py
+++ b/src/sparkrun/orchestration/disk_info.py
@@ -1,0 +1,165 @@
+"""Per-host cache directory status + free-space probe and table formatting.
+
+Shared between ``sparkrun cluster inspect`` (full directory status display)
+and the model-distribution error path (show disk-space table when rsync fails
+with "no space left").  The remote probe gathers sparkrun cache existence/size,
+HF cache existence/size, and root-FS free space in a single SSH round-trip;
+the table formatter renders them in the same layout used by ``cluster inspect``
+for consistency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheStatus:
+    """Per-host cache directory status and free-space readout."""
+
+    host: str
+    sparkrun_dir: str = "?"
+    sparkrun_exists: bool = False
+    sparkrun_size: str = "-"
+    hf_dir: str = "?"
+    hf_exists: bool = False
+    hf_size: str = "-"
+    free_space: str = "-"
+    error: str | None = None
+    """Populated when the probe itself failed (SSH error, command not found)."""
+
+
+# Single shell command that captures everything we care about in one round trip.
+# `du -sh` is portable; `df -h /` + awk handles busybox + GNU coreutils equally.
+_CACHE_STATUS_PROBE = (
+    'sr_dir="{sr_dir}"; hf_dir="{hf_dir}"; '
+    'sr_exists="no"; hf_exists="no"; sr_du="-"; hf_du="-"; '
+    'if [ -d "$sr_dir" ]; then sr_exists="yes"; sr_du=$(du -sh "$sr_dir" 2>/dev/null | cut -f1); fi; '
+    'if [ -d "$hf_dir" ]; then hf_exists="yes"; hf_du=$(du -sh "$hf_dir" 2>/dev/null | cut -f1); fi; '
+    'free_space=$(df -h / 2>/dev/null | awk "NR==2{{print \\$4}}"); '
+    'echo "sr_exists=$sr_exists|sr_du=$sr_du|hf_exists=$hf_exists|hf_du=$hf_du'
+    '|sr_dir=$sr_dir|hf_dir=$hf_dir|free_space=${{free_space:--}}"'
+)
+
+
+def _parse_probe_output(host: str, stdout: str) -> CacheStatus:
+    """Parse the single-line ``key=value|key=value`` output from the probe."""
+    parts: dict[str, str] = {}
+    line = stdout.strip().splitlines()[-1] if stdout.strip() else ""
+    for entry in line.split("|"):
+        if "=" in entry:
+            key, _, value = entry.partition("=")
+            parts[key.strip()] = value.strip()
+    return CacheStatus(
+        host=host,
+        sparkrun_dir=parts.get("sr_dir", "?"),
+        sparkrun_exists=parts.get("sr_exists") == "yes",
+        sparkrun_size=parts.get("sr_du", "-"),
+        hf_dir=parts.get("hf_dir", "?"),
+        hf_exists=parts.get("hf_exists") == "yes",
+        hf_size=parts.get("hf_du", "-"),
+        free_space=parts.get("free_space", "-"),
+    )
+
+
+def probe_cache_status(
+    hosts: list[str],
+    hf_cache_dir: str,
+    sparkrun_cache_dir: str | None = None,
+    ssh_kwargs: dict | None = None,
+    dry_run: bool = False,
+) -> dict[str, CacheStatus]:
+    """Probe each host for cache directory status and root-FS free space.
+
+    Args:
+        hosts: Remote hostnames (management IPs).
+        hf_cache_dir: HuggingFace cache path on the remote hosts.
+        sparkrun_cache_dir: Optional explicit sparkrun cache path; when
+            ``None``, the probe uses ``$HOME/.cache/sparkrun`` resolved on
+            each remote host.
+        ssh_kwargs: Standard SSH parameters.
+        dry_run: When ``True``, returns synthetic placeholders without
+            making any SSH calls.
+
+    Returns:
+        Map of ``host → CacheStatus``.  Hosts where the probe itself
+        failed have :attr:`CacheStatus.error` populated and remaining
+        fields left as default placeholders.
+    """
+    if not hosts:
+        return {}
+
+    sr_dir = sparkrun_cache_dir or "$HOME/.cache/sparkrun"
+    cmd = _CACHE_STATUS_PROBE.format(sr_dir=sr_dir, hf_dir=hf_cache_dir)
+
+    if dry_run:
+        return {h: CacheStatus(host=h, sparkrun_dir=sr_dir, hf_dir=hf_cache_dir) for h in hosts}
+
+    from sparkrun.orchestration.ssh import run_remote_scripts_parallel
+
+    kw = ssh_kwargs or {}
+    results = run_remote_scripts_parallel(
+        hosts,
+        cmd,
+        timeout=15,
+        quiet=True,
+        **kw,
+    )
+
+    out: dict[str, CacheStatus] = {}
+    for r in results:
+        if r.success and r.stdout.strip():
+            out[r.host] = _parse_probe_output(r.host, r.stdout)
+        else:
+            out[r.host] = CacheStatus(
+                host=r.host,
+                sparkrun_dir=sr_dir,
+                hf_dir=hf_cache_dir,
+                error=(r.stderr or "").strip() or "SSH failed",
+            )
+    return out
+
+
+def probe_local_cache_status(
+    hf_cache_dir: str,
+    sparkrun_cache_dir: str,
+) -> CacheStatus:
+    """Inspect the control machine's caches and free space.
+
+    Mirrors :func:`probe_cache_status` but uses local ``os.path.isdir`` +
+    ``du`` + ``df`` so callers (e.g. ``cluster inspect``) can include a
+    ``(local)`` row alongside the remote rows.
+    """
+
+    def _dir_info(path: str) -> tuple[bool, str]:
+        if not os.path.isdir(path):
+            return False, "-"
+        du = subprocess.run(["du", "-sh", path], capture_output=True, text=True)
+        size = du.stdout.split()[0] if du.returncode == 0 and du.stdout.strip() else "-"
+        return True, size
+
+    sr_exists, sr_du = _dir_info(sparkrun_cache_dir)
+    hf_exists, hf_du = _dir_info(hf_cache_dir)
+
+    free_space = "-"
+    df = subprocess.run(["df", "-h", "/"], capture_output=True, text=True)
+    if df.returncode == 0 and df.stdout.strip():
+        lines = df.stdout.strip().splitlines()
+        if len(lines) >= 2:
+            free_space = lines[1].split()[3]
+
+    return CacheStatus(
+        host="(local)",
+        sparkrun_dir=sparkrun_cache_dir,
+        sparkrun_exists=sr_exists,
+        sparkrun_size=sr_du,
+        hf_dir=hf_cache_dir,
+        hf_exists=hf_exists,
+        hf_size=hf_du,
+        free_space=free_space,
+    )

--- a/src/sparkrun/orchestration/distribution.py
+++ b/src/sparkrun/orchestration/distribution.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from sparkrun.core.config import SparkrunConfig
     from sparkrun.orchestration.comm_env import ClusterCommEnv
     from sparkrun.orchestration.infiniband import IBDetectionResult
+    from sparkrun.orchestration.transfer import TransferFailure
     from sparkrun.core.recipe import Recipe
 
 logger = logging.getLogger(__name__)
@@ -274,7 +275,7 @@ def _distribute_model_push(
     hf_token: str | None = None,
     dry_run: bool = False,
     local_cache_dir: str | None = None,
-) -> list[str]:
+) -> list["TransferFailure"]:
     """Push-mode model distribution: local → head, then head → workers via IB.
 
     1. Download model locally and rsync to head over management network.
@@ -282,10 +283,11 @@ def _distribute_model_push(
        workers over IB.
 
     Returns:
-        List of hostnames where distribution failed.
+        List of :class:`TransferFailure` records (empty = full success).
     """
     from sparkrun.models.distribute import distribute_model_from_local
     from sparkrun.models.distribute import distribute_model_from_head
+    from sparkrun.orchestration.transfer import TransferFailure
 
     head = hosts[0]
 
@@ -303,11 +305,15 @@ def _distribute_model_push(
     )
     if head_failed:
         logger.error("Push mode: failed to push model to head %s", head)
-        return list(hosts)
+        # Propagate the head-rsync classification to all hosts so the
+        # final error message still tells the user *why* (e.g. out of
+        # disk space) rather than just listing every host.
+        head_reason = head_failed[0].reason
+        return [TransferFailure(host=h, reason=head_reason) for h in hosts]
 
     # Step 2: if workers, distribute from head to workers
     if len(hosts) > 1:
-        worker_failed = distribute_model_from_head(
+        return distribute_model_from_head(
             model,
             hosts,
             cache_dir=cache_dir,
@@ -317,7 +323,6 @@ def _distribute_model_push(
             dry_run=dry_run,
             **ssh_kwargs,
         )
-        return worker_failed
 
     return []
 
@@ -633,7 +638,9 @@ def distribute_resources(
                 )
 
         if mdl_failed:
-            raise DistributionError("Model distribution failed on: %s" % ", ".join(mdl_failed))
+            from sparkrun.orchestration.transfer import format_transfer_failures
+
+            raise DistributionError("Model distribution failed: %s" % format_transfer_failures(mdl_failed))
 
     logger.info("Distribution complete.")
     return comm_env, ib_ip_map, mgmt_ip_map
@@ -822,7 +829,9 @@ def distribute_from_config(
                     _auto_delegated,
                 )
             if mdl_failed:
-                raise DistributionError("Model distribution failed on: %s" % ", ".join(mdl_failed))
+                from sparkrun.orchestration.transfer import format_transfer_failures
+
+                raise DistributionError("Model distribution failed: %s" % format_transfer_failures(mdl_failed))
 
     logger.info("Distribution complete.")
     return comm_env, ib_ip_map, mgmt_ip_map
@@ -908,9 +917,13 @@ def _distribute_single_model(
     hf_token: str | None,
     dry_run: bool,
     auto_delegated: bool,
-) -> list[str]:
-    """Distribute a single model to a subset of hosts."""
+) -> list["TransferFailure"]:
+    """Distribute a single model to a subset of hosts.
+
+    Returns the classified per-host failures; empty list means success.
+    """
     from sparkrun.models.distribute import distribute_model_from_local, distribute_model_from_head
+    from sparkrun.orchestration.transfer import TransferFailure
 
     # Position-aligned subset (see _subset_transfer_hosts docstring).
     target_set = set(targets)
@@ -943,7 +956,8 @@ def _distribute_single_model(
             **ssh_kwargs,
         )
         if head_failed:
-            return list(targets)
+            head_reason = head_failed[0].reason
+            return [TransferFailure(host=h, reason=head_reason) for h in targets]
         if len(targets) > 1:
             return distribute_model_from_head(
                 model,

--- a/src/sparkrun/orchestration/distribution.py
+++ b/src/sparkrun/orchestration/distribution.py
@@ -109,7 +109,7 @@ def resolve_auto_transfer_mode(
     from sparkrun.orchestration.infiniband import detect_ib_for_hosts, validate_ib_connectivity
 
     ib_result = detect_ib_for_hosts(host_list, ssh_kwargs=ssh_kwargs, dry_run=dry_run, topology=topology)
-    ib_validated = validate_ib_connectivity(ib_result.ib_ip_map, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
+    ib_validated = validate_ib_connectivity(ib_result.ib_candidates, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
 
     if ib_validated:
         logger.info("Auto-detected transfer mode: local (external control, IB reachable)")
@@ -452,7 +452,7 @@ def distribute_resources(
         _ib_validated: dict[str, str] | None = None
         if transfer_mode in ("auto", "local"):
             _ib_validated = validate_ib_connectivity(
-                ib_result.ib_ip_map,
+                ib_result.ib_candidates,
                 ssh_kwargs=ssh_kwargs,
                 dry_run=dry_run,
             )
@@ -732,7 +732,7 @@ def distribute_from_config(
         ib_result = detect_ib_for_hosts(host_list, ssh_kwargs=ssh_kwargs, dry_run=dry_run, topology=topology)
         _ib_validated = None
         if transfer_mode in ("auto", "local"):
-            _ib_validated = validate_ib_connectivity(ib_result.ib_ip_map, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
+            _ib_validated = validate_ib_connectivity(ib_result.ib_candidates, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
         _auto_delegated = False
         if transfer_mode == "auto":
             _cu = _is_cross_user(ssh_kwargs)

--- a/src/sparkrun/orchestration/docker_info.py
+++ b/src/sparkrun/orchestration/docker_info.py
@@ -1,0 +1,166 @@
+"""Docker storage-driver probe + consistency check.
+
+Detects each host's Docker storage driver and snapshotter so the CLI can
+warn when a cluster has heterogeneous drivers across hosts.  Different
+drivers (e.g. ``overlay2`` vs containerd-snapshotter ``overlayfs``)
+produce different local Image IDs for the same registry image, which
+causes ``sparkrun`` to unnecessarily re-sync containers — see
+`#152 <https://github.com/spark-arena/sparkrun/issues/152>`_.
+
+The runtime image-sync code (:func:`sparkrun.containers.distribute._images_match`)
+already falls back to RepoDigest comparison so the bug is non-blocking,
+but a proactive setup-time warning lets users normalize their fleet
+before they hit the slow path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+# `docker info` doesn't expose "is this the containerd snapshotter?" via
+# a stable top-level field.  We get the driver name and the DriverStatus
+# rows; the snapshotter shows itself as a row whose key is
+# ``driver-type`` and whose value starts with ``io.containerd.snapshotter``.
+_DOCKER_INFO_PROBE = (
+    "docker info --format \"{{.Driver}}|{{range .DriverStatus}}{{index . 0}}={{index . 1}};{{end}}\" 2>/dev/null || echo 'UNAVAILABLE|'"
+)
+
+
+@dataclass(frozen=True)
+class DockerDriverInfo:
+    """Parsed Docker storage driver info for a single host."""
+
+    driver: str
+    """The top-level driver name reported by ``docker info`` (e.g.
+    ``overlay2``, ``overlayfs``).  ``UNAVAILABLE`` when ``docker info``
+    failed (Docker not installed / daemon not running / not in group).
+    """
+
+    snapshotter: bool
+    """True when ``DriverStatus`` indicates the containerd snapshotter
+    is in use (driver-type starts with ``io.containerd.snapshotter``)."""
+
+    @property
+    def signature(self) -> str:
+        """Stable identifier for cross-host comparison.
+
+        Two hosts with the same signature are guaranteed to compute the
+        same local Image ID for any given registry image.  Hosts with
+        different signatures may not.
+        """
+        return "%s+snapshotter" % self.driver if self.snapshotter else self.driver
+
+    @property
+    def is_available(self) -> bool:
+        return self.driver != "UNAVAILABLE"
+
+
+def parse_docker_info_output(raw: str) -> DockerDriverInfo:
+    """Parse one host's stdout from :data:`_DOCKER_INFO_PROBE`."""
+    line = raw.strip().splitlines()[-1] if raw.strip() else ""
+    if "|" not in line:
+        return DockerDriverInfo(driver="UNAVAILABLE", snapshotter=False)
+    driver, status_blob = line.split("|", 1)
+    driver = driver.strip() or "UNAVAILABLE"
+    snapshotter = False
+    for entry in status_blob.split(";"):
+        entry = entry.strip()
+        if not entry or "=" not in entry:
+            continue
+        key, value = entry.split("=", 1)
+        if key.strip() == "driver-type" and value.strip().startswith("io.containerd.snapshotter"):
+            snapshotter = True
+            break
+    return DockerDriverInfo(driver=driver, snapshotter=snapshotter)
+
+
+def detect_docker_drivers(
+    hosts: list[str],
+    ssh_kwargs: dict | None = None,
+    dry_run: bool = False,
+) -> dict[str, DockerDriverInfo]:
+    """Probe each host's Docker storage driver in parallel.
+
+    Hosts where the probe fails (SSH error, Docker not running) are
+    returned with :attr:`DockerDriverInfo.driver` set to ``"UNAVAILABLE"``.
+    """
+    if not hosts:
+        return {}
+
+    from sparkrun.orchestration.ssh import run_remote_scripts_parallel
+
+    kw = ssh_kwargs or {}
+    results = run_remote_scripts_parallel(
+        hosts,
+        _DOCKER_INFO_PROBE,
+        timeout=15,
+        dry_run=dry_run,
+        quiet=True,
+        **kw,
+    )
+
+    out: dict[str, DockerDriverInfo] = {}
+    for result in results:
+        if dry_run:
+            out[result.host] = DockerDriverInfo(driver="overlay2", snapshotter=False)
+            continue
+        if not result.success:
+            out[result.host] = DockerDriverInfo(driver="UNAVAILABLE", snapshotter=False)
+            continue
+        out[result.host] = parse_docker_info_output(result.stdout)
+    return out
+
+
+def check_driver_consistency(
+    driver_map: dict[str, DockerDriverInfo],
+) -> tuple[bool, dict[str, list[str]]]:
+    """Group hosts by driver signature.
+
+    Returns ``(is_consistent, groups)`` where ``groups`` maps each
+    distinct signature to the list of hosts using it.  Hosts whose
+    probe came back ``UNAVAILABLE`` are excluded from the consistency
+    decision (we can't know what driver they'd use) but reported
+    separately under the ``"UNAVAILABLE"`` group.
+    """
+    groups: dict[str, list[str]] = {}
+    for host, info in driver_map.items():
+        groups.setdefault(info.signature, []).append(host)
+
+    distinct_available = {sig for sig in groups if sig != "UNAVAILABLE"}
+    is_consistent = len(distinct_available) <= 1
+    return is_consistent, groups
+
+
+def format_driver_warning(groups: dict[str, list[str]]) -> str:
+    """Render a multi-line remediation message for inconsistent drivers.
+
+    The caller is expected to print this via ``click.echo(... err=True)``
+    only when :func:`check_driver_consistency` reports inconsistency.
+    """
+    lines: list[str] = []
+    lines.append("Warning: Docker storage drivers are inconsistent across hosts.")
+    lines.append("")
+    lines.append("  Per-host driver:")
+    for sig in sorted(groups):
+        for host in sorted(groups[sig]):
+            lines.append("    %s: %s" % (host, sig))
+    lines.append("")
+    lines.append("  Different drivers compute different local Image IDs for the")
+    lines.append("  same registry image (issue #152), which can trigger unnecessary")
+    lines.append("  container re-syncs.  Sparkrun's RepoDigest fallback keeps things")
+    lines.append("  working, but to fully avoid the slow path, normalize every host")
+    lines.append("  on overlay2.  On each host using a different driver:")
+    lines.append("")
+    lines.append("    sudo systemctl stop docker docker.socket containerd")
+    lines.append("    sudo rm -rf /var/lib/docker /var/lib/containerd")
+    lines.append("    sudo mkdir -p /etc/docker")
+    lines.append('    echo \'{"storage-driver": "overlay2"}\' | sudo tee /etc/docker/daemon.json')
+    lines.append("    sudo systemctl start containerd docker")
+    lines.append("")
+    lines.append("  Note: the rm step deletes all local Docker data on that host;")
+    lines.append("  cached images will be re-pulled on next use.")
+    return "\n".join(lines)

--- a/src/sparkrun/orchestration/infiniband.py
+++ b/src/sparkrun/orchestration/infiniband.py
@@ -41,6 +41,19 @@ class IBDetectionResult:
     """Mapping of queried host → first IB interface IP.
 
     Empty for hosts where no IB was detected or no IB IP was found.
+    For switched fabrics this single IP is reachable from anywhere on
+    the fabric; for mesh/ring topologies it's only the *first* detected
+    candidate and may not be reachable from a given peer — see
+    :attr:`ib_candidates` for the full per-host list used by
+    :func:`validate_ib_connectivity` to find a working IP.
+    """
+    ib_candidates: dict[str, list[str]] = field(default_factory=dict)
+    """Mapping of queried host → all detected IB interface IPs, in detection order.
+
+    For switched topologies all entries are reachable from anywhere on
+    the fabric; for mesh/ring topologies only specific IPs are reachable
+    from specific peers, so :func:`validate_ib_connectivity` probes each
+    candidate rather than assuming the first one works.
     """
     mgmt_ip_map: dict[str, str] = field(default_factory=dict)
     """Mapping of queried host → management interface IP.
@@ -198,57 +211,122 @@ def extract_ib_ips(ib_info: dict[str, str]) -> list[str]:
 
 
 def validate_ib_connectivity(
-    ib_ip_map: dict[str, str],
+    ib_candidates: dict[str, str] | dict[str, list[str]],
     ssh_kwargs: dict | None = None,
     dry_run: bool = False,
 ) -> dict[str, str]:
     """Validate that the control machine can reach detected IB IPs.
 
-    Tests SSH connectivity from the control machine to a sample IB IP.
-    If the control machine is not on the InfiniBand network, the IB IPs
-    are unreachable and transfers must fall back to management IPs.
+    Tests SSH connectivity from the control machine to candidate IB
+    interface IPs.  In switched fabrics every IB IP is reachable from
+    anywhere on the fabric, so a single working probe suffices.  In
+    mesh/ring topologies each host has multiple IB IPs (one/two per
+    point-to-point link) and only some are reachable from a given
+    peer; this function iterates the per-host candidates and records
+    the first one that responds.
 
-    Only one IB IP is tested since all are on the same subnet — if one
-    is reachable, the rest should be too.
+    Accepts either the legacy ``dict[host, str]`` (single best-guess
+    IP per host) or the new ``dict[host, list[str]]`` (full per-host
+    candidate list from :class:`IBDetectionResult.ib_candidates`).
+    Returns an empty dict — signalling management-network fallback —
+    only when *every* host has zero reachable candidates.
 
     Args:
-        ib_ip_map: Mapping of management host → IB IP (from detection).
+        ib_candidates: Mapping of management host → candidate IB IP(s).
         ssh_kwargs: SSH connection parameters (user, key, options).
-        dry_run: Skip the check and return the map unchanged.
+        dry_run: Skip the check and return a single-IP-per-host map
+            without probing.
 
     Returns:
-        The original *ib_ip_map* if connectivity is confirmed, or an
-        empty dict if the IB network is unreachable from the control
-        machine (signalling fallback to management network).
+        Mapping of host → verified-reachable IB IP, or an empty dict
+        when no host has any reachable IB IP.
     """
-    if not ib_ip_map or dry_run:
-        return ib_ip_map
+    if not ib_candidates:
+        return {}
+
+    # Normalize legacy single-IP shape to per-host list.
+    normalized: dict[str, list[str]] = {}
+    for host, val in ib_candidates.items():
+        if isinstance(val, str):
+            normalized[host] = [val] if val else []
+        else:
+            normalized[host] = [ip for ip in val if ip]
+
+    if dry_run:
+        # Preserve legacy behavior: return a single-IP-per-host map
+        # without performing probes.
+        return {host: ips[0] for host, ips in normalized.items() if ips}
+
+    from concurrent.futures import ThreadPoolExecutor
 
     from sparkrun.orchestration.ssh import run_remote_command
 
-    # Test connectivity to the first IB IP
-    test_host, test_ip = next(iter(ib_ip_map.items()))
     kw = ssh_kwargs or {}
+    logger.info("Verifying IB network reachability from control machine...")
 
-    logger.info("Verifying IB network reachability from control machine (testing %s)...", test_ip)
-    result = run_remote_command(
-        test_ip,
-        "true",
-        connect_timeout=5,
-        timeout=10,
-        **kw,
-    )
+    # Flatten to (host, ip) work items so every candidate is probed
+    # concurrently — important for mesh/ring where the "wrong" candidate
+    # takes the full SSH timeout to fail and serial probing would stack
+    # 10s of latency per extra candidate per host.
+    work: list[tuple[str, str]] = []
+    for host, cands in normalized.items():
+        for ip in cands:
+            work.append((host, ip))
 
-    if result.success:
-        logger.info("  IB network reachable — will use IB IPs for transfers")
-        return ib_ip_map
+    probe_results: dict[tuple[str, str], bool] = {}
+    if work:
 
-    logger.warning(
-        "  Control machine cannot reach IB network (tested %s for host %s) — falling back to management network for transfers",
-        test_ip,
-        test_host,
-    )
-    return {}
+        def _probe(host_ip: tuple[str, str]) -> tuple[tuple[str, str], bool]:
+            _host, _ip = host_ip
+            result = run_remote_command(_ip, "true", connect_timeout=5, timeout=10, **kw)
+            return host_ip, result.success
+
+        # TODO: review parallelism limits!
+        with ThreadPoolExecutor(max_workers=len(work)) as pool:
+            for host_ip, ok in pool.map(_probe, work):
+                probe_results[host_ip] = ok
+
+    # For each host, pick the first candidate (in detection order) that
+    # responded; record the rest as unreachable for diagnostic logging.
+    verified: dict[str, str] = {}
+    unreachable: dict[str, list[str]] = {}
+    for host, cands in normalized.items():
+        if not cands:
+            unreachable[host] = []
+            continue
+        working = next((ip for ip in cands if probe_results.get((host, ip))), None)
+        if working is None:
+            unreachable[host] = list(cands)
+            continue
+        verified[host] = working
+        primary = cands[0]
+        if working == primary:
+            logger.info("  %s reachable via %s", host, working)
+        else:
+            logger.info("  %s reachable via %s", host, working)
+            failed_before = [ip for ip in cands if ip != working and not probe_results.get((host, ip))]
+            logger.debug(
+                "  %s reachable via %s (primary candidate %s unreachable)",
+                host,
+                working,
+                ", ".join(failed_before) if failed_before else primary,
+            )
+
+    if unreachable:
+        for host, tried in unreachable.items():
+            if tried:
+                logger.warning(
+                    "  Control machine cannot reach any IB IP for host %s (tried %s)",
+                    host,
+                    ", ".join(tried),
+                )
+            else:
+                logger.warning("  No IB candidates available for host %s", host)
+        logger.warning("  Falling back to management network for transfers")
+        return {}
+
+    logger.info("  IB network reachable — will use IB IPs for transfers")
+    return verified
 
 
 def detect_ib_for_hosts(
@@ -291,6 +369,7 @@ def detect_ib_for_hosts(
 
     per_host_env: dict[str, dict[str, str]] = {}
     ib_ip_map: dict[str, str] = {}
+    ib_candidates: dict[str, list[str]] = {}
     mgmt_ip_map: dict[str, str] = {}
 
     for result in ib_results:
@@ -305,11 +384,18 @@ def detect_ib_for_hosts(
             if result.host == head_host:
                 logger.info("  InfiniBand detected on %s, comm env configured", head_host)
 
-        # IB IP for transfer routing
+        # IB IP for transfer routing.  Preserve all detected IPs as
+        # candidates so validate_ib_connectivity() can try alternates
+        # in mesh/ring topologies where only specific point-to-point
+        # links are reachable from any given peer.
         ib_ips = extract_ib_ips(ib_info)
         if ib_ips:
             ib_ip_map[result.host] = ib_ips[0]
-            logger.debug("  %s IB transfer IP: %s", result.host, ib_ips[0])
+            ib_candidates[result.host] = list(ib_ips)
+            if len(ib_ips) > 1:
+                logger.debug("  %s IB transfer IP candidates: %s", result.host, ib_ips)
+            else:
+                logger.debug("  %s IB transfer IP: %s", result.host, ib_ips[0])
 
         # Management IP (from default route interface)
         mgmt_ip = ib_info.get("DETECTED_MGMT_IP", "").strip()
@@ -329,5 +415,6 @@ def detect_ib_for_hosts(
     return IBDetectionResult(
         comm_env=comm_env,
         ib_ip_map=ib_ip_map,
+        ib_candidates=ib_candidates,
         mgmt_ip_map=mgmt_ip_map,
     )

--- a/src/sparkrun/orchestration/job_metadata.py
+++ b/src/sparkrun/orchestration/job_metadata.py
@@ -17,6 +17,7 @@ import yaml
 
 if TYPE_CHECKING:
     from sparkrun.core.recipe import Recipe
+    from sparkrun.runtimes.base import RuntimePlugin
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +181,7 @@ def save_job_metadata(
     recipe_ref: str | None = None,
     runtime_info: dict[str, str] | None = None,
     container_image: Optional[str] = None,
+    runtime: "RuntimePlugin | None" = None,
 ) -> None:
     """Persist job metadata so ``cluster status`` can display recipe info.
 
@@ -229,6 +231,18 @@ def save_job_metadata(
         served_name = recipe.defaults.get("served_model_name")
     if served_name is not None:
         meta["served_model_name"] = str(served_name)
+
+    # Resolve upstream API key via the runtime plugin so proxy discovery
+    # can authenticate to the inference endpoint.  Runtimes that don't
+    # support api-keys return None from resolve_api_key().
+    if runtime is not None:
+        try:
+            api_key = runtime.resolve_api_key(recipe, overrides)
+        except Exception:
+            logger.debug("resolve_api_key failed for %s", cluster_id, exc_info=True)
+            api_key = None
+        if api_key:
+            meta["api_key"] = str(api_key)
 
     if ib_ip_map:
         meta["ib_ip_map"] = ib_ip_map

--- a/src/sparkrun/orchestration/primitives.py
+++ b/src/sparkrun/orchestration/primitives.py
@@ -171,30 +171,6 @@ def sync_resource_to_hosts(
     return failed
 
 
-def map_transfer_failures(
-    results: list[RemoteResult],
-    transfer_hosts: list[str],
-    management_hosts: list[str],
-) -> list[str]:
-    """Map failed transfer-host results back to management hostnames.
-
-    When fast-network IPs (InfiniBand) are used for data transfer,
-    failures are reported against those IPs. This maps them back to
-    the corresponding management hostnames for user-facing reporting.
-
-    Args:
-        results: Remote execution results (keyed by transfer host).
-        transfer_hosts: IPs/hostnames used for the actual transfer.
-        management_hosts: Corresponding management hostnames for reporting.
-
-    Returns:
-        List of management hostnames where transfer failed.
-    """
-    xfer_to_host = dict(zip(transfer_hosts, management_hosts))
-    failed = [xfer_to_host.get(r.host, r.host) for r in results if not r.success]
-    return failed
-
-
 # ---------------------------------------------------------------------------
 # InfiniBand detection flow
 # ---------------------------------------------------------------------------

--- a/src/sparkrun/orchestration/transfer.py
+++ b/src/sparkrun/orchestration/transfer.py
@@ -1,0 +1,131 @@
+"""Transfer-failure mapping, classification, and presentation.
+
+Helpers for turning a list of :class:`RemoteResult` from
+:func:`run_rsync_parallel` into user-facing diagnostics.  When fast-network
+IPs (InfiniBand) are used for the actual data transfer, failures are
+reported against those IPs; this module is responsible for mapping them
+back to management hostnames, classifying the rsync stderr into a short
+human-readable reason (e.g. ``"out of disk space on destination"``), and
+formatting summaries for error messages and logs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sparkrun.orchestration.ssh import RemoteResult
+
+
+@dataclass
+class TransferFailure:
+    """Classified information about a single failed transfer.
+
+    Used by callers that want a human-readable reason (e.g. "out of
+    disk space") alongside the host name, rather than just a bare list
+    of failed hosts.
+    """
+
+    host: str
+    """Management hostname (after transfer→management mapping)."""
+
+    reason: str
+    """Short classified reason — see :func:`classify_rsync_failure`."""
+
+    detail: str = ""
+    """Truncated stderr excerpt for diagnostics; may be empty."""
+
+
+# Common rsync stderr fragments mapped to short classified reasons.  Order
+# matters — earlier patterns take precedence so the most specific match
+# wins.  All patterns are matched case-insensitively.
+_RSYNC_FAILURE_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("no space left on device", "out of disk space"),
+    ("disk quota exceeded", "disk quota exceeded"),
+    ("permission denied", "permission denied"),
+    ("connection refused", "SSH connection refused"),
+    ("connection timed out", "SSH connection timed out"),
+    ("connection closed", "SSH connection closed unexpectedly"),
+    ("host key verification failed", "SSH host key verification failed"),
+    ("could not resolve hostname", "hostname resolution failed"),
+    ("rsync error: error in rsync protocol", "rsync protocol error"),
+)
+
+
+def classify_rsync_failure(result: RemoteResult) -> str:
+    """Return a short human-readable reason for an rsync failure.
+
+    Inspects the captured stderr for well-known fragments and returns a
+    short classification.  When no pattern matches, returns a generic
+    message that includes the return code so the user at least sees the
+    failure was real, even if its specific cause is unfamiliar.
+    """
+    stderr = (result.stderr or "").lower()
+    for needle, reason in _RSYNC_FAILURE_PATTERNS:
+        if needle in stderr:
+            return reason
+    return "rsync failed (rc=%d)" % result.returncode
+
+
+def map_transfer_failures(
+    results: list[RemoteResult],
+    transfer_hosts: list[str],
+    management_hosts: list[str],
+) -> list[str]:
+    """Map failed transfer-host results back to management hostnames.
+
+    When fast-network IPs (InfiniBand) are used for data transfer,
+    failures are reported against those IPs. This maps them back to
+    the corresponding management hostnames for user-facing reporting.
+
+    Args:
+        results: Remote execution results (keyed by transfer host).
+        transfer_hosts: IPs/hostnames used for the actual transfer.
+        management_hosts: Corresponding management hostnames for reporting.
+
+    Returns:
+        List of management hostnames where transfer failed.
+    """
+    xfer_to_host = dict(zip(transfer_hosts, management_hosts))
+    failed = [xfer_to_host.get(r.host, r.host) for r in results if not r.success]
+    return failed
+
+
+def map_transfer_failures_detailed(
+    results: list[RemoteResult],
+    transfer_hosts: list[str],
+    management_hosts: list[str],
+) -> list[TransferFailure]:
+    """Like :func:`map_transfer_failures` but with classified per-host detail.
+
+    Returns one :class:`TransferFailure` per failed result, with the
+    management hostname (after IB→mgmt mapping) and a short classified
+    reason derived from the rsync stderr.  The ``detail`` field carries
+    a truncated stderr excerpt so callers can include it in logs
+    without dumping multi-KB blobs.
+    """
+    xfer_to_host = dict(zip(transfer_hosts, management_hosts))
+    failures: list[TransferFailure] = []
+    for r in results:
+        if r.success:
+            continue
+        host = xfer_to_host.get(r.host, r.host)
+        reason = classify_rsync_failure(r)
+        stderr = (r.stderr or "").strip()
+        detail = stderr[-400:] if len(stderr) > 400 else stderr
+        failures.append(TransferFailure(host=host, reason=reason, detail=detail))
+    return failures
+
+
+def format_transfer_failures(failures: list[TransferFailure]) -> str:
+    """Render a list of :class:`TransferFailure` as a multi-host summary line.
+
+    Hosts sharing the same reason are grouped so the summary stays
+    readable even with large clusters.
+    """
+    by_reason: dict[str, list[str]] = {}
+    for f in failures:
+        by_reason.setdefault(f.reason, []).append(f.host)
+    parts: list[str] = []
+    for reason, hosts in by_reason.items():
+        parts.append("%s on %s" % (reason, ", ".join(hosts)))
+    return "; ".join(parts)

--- a/src/sparkrun/proxy/discovery.py
+++ b/src/sparkrun/proxy/discovery.py
@@ -38,6 +38,7 @@ class DiscoveredEndpoint:
     actual_models: list[str] = field(default_factory=list)
     recipe_name: str = ""
     tensor_parallel: int = 1
+    api_key: str | None = None
 
 
 def discover_endpoints(
@@ -158,6 +159,7 @@ def _endpoint_from_meta(
         healthy=False,
         recipe_name=meta.get("recipe", meta.get("recipe_ref", "")),
         tensor_parallel=int(meta.get("tensor_parallel", 1)),
+        api_key=meta.get("api_key") or None,
     )
 
 
@@ -244,6 +246,7 @@ def _discover_from_metadata(
             healthy=False,
             recipe_name=recipe_name,
             tensor_parallel=tp,
+            api_key=meta.get("api_key") or None,
         )
 
     endpoints = list(candidates.values())
@@ -307,12 +310,18 @@ def _deduplicate_by_identity(endpoints: list[DiscoveredEndpoint]) -> list[Discov
 def _check_single_health(ep: DiscoveredEndpoint) -> tuple[bool, list[str]]:
     """Check a single endpoint's health via GET /v1/models.
 
+    Sends an ``Authorization: Bearer`` header when the endpoint has an
+    ``api_key`` set, so backends that require auth still report healthy.
+
     Returns:
         Tuple of (healthy, list_of_model_ids).
     """
     url = "http://%s:%d/v1/models" % (ep.host, ep.port)
+    headers: dict[str, str] = {}
+    if ep.api_key:
+        headers["Authorization"] = "Bearer %s" % ep.api_key
     try:
-        req = urllib.request.Request(url, method="GET")
+        req = urllib.request.Request(url, method="GET", headers=headers)
         with urllib.request.urlopen(req, timeout=_HEALTH_TIMEOUT) as resp:
             if resp.status == 200:
                 body = json.loads(resp.read())

--- a/src/sparkrun/proxy/engine.py
+++ b/src/sparkrun/proxy/engine.py
@@ -63,7 +63,7 @@ def build_litellm_config(
                     "litellm_params": {
                         "model": "openai/%s" % model_name,
                         "api_base": "http://%s:%d/v1" % (ep.host, ep.port),
-                        "api_key": "not-needed",
+                        "api_key": ep.api_key or "not-needed",
                     },
                 }
             )
@@ -387,7 +387,7 @@ class ProxyEngine:
                 "litellm_params": {
                     "model": "openai/%s" % model_name,
                     "api_base": "http://%s:%d/v1" % (endpoint.host, endpoint.port),
-                    "api_key": "not-needed",
+                    "api_key": endpoint.api_key or "not-needed",
                 },
             }
 
@@ -522,7 +522,7 @@ class ProxyEngine:
                 "litellm_params": {
                     "model": "openai/%s" % target_model,
                     "api_base": api_base,
-                    "api_key": "not-needed",
+                    "api_key": params.get("api_key") or "not-needed",
                 },
             }
             try:

--- a/src/sparkrun/runtimes/_util.py
+++ b/src/sparkrun/runtimes/_util.py
@@ -11,22 +11,21 @@ def default_env_hf_offline(env: dict[str, str] = None, **kwargs) -> dict[str, st
     }
 
 
-# `--api-key value` or `--api-key=value`.  Stops at whitespace, line
-# continuation backslash, or shell metacharacters that wouldn't appear
-# in a real key.  Both vLLM and SGLang use the same flag spelling.
-_API_KEY_RE = re.compile(r"--api-key(?:=|\s+)([^\s\\]+)")
+def parse_flag_value_from_command(command: str | None, flag: str) -> str | None:
+    """Extract a literal ``<flag> <value>`` or ``<flag>=<value>`` from a command.
 
+    Matches the value up to the next whitespace or line-continuation
+    backslash.  Returns ``None`` when *flag* is absent, when the value
+    is empty, or when the value is a ``{placeholder}`` (the defaults
+    path handles those).  Surrounding quotes are stripped.
 
-def parse_api_key_from_command(command: str | None) -> str | None:
-    """Extract a literal ``--api-key <value>`` value from a serve command.
-
-    Returns ``None`` when no flag is present, or when the value is a
-    ``{placeholder}`` (the defaults path handles those).  Surrounding
-    quotes are stripped.
+    Used to recover an api/auth key from recipes that embed it directly
+    in their ``command:`` text rather than going through ``defaults``.
     """
     if not command:
         return None
-    match = _API_KEY_RE.search(command)
+    pattern = re.escape(flag) + r"(?:=|\s+)([^\s\\]+)"
+    match = re.search(pattern, command)
     if not match:
         return None
     val = match.group(1).strip()
@@ -37,3 +36,8 @@ def parse_api_key_from_command(command: str | None) -> str | None:
     if val.startswith("{") and val.endswith("}"):
         return None
     return val
+
+
+def parse_api_key_from_command(command: str | None) -> str | None:
+    """Backward-compatible alias for ``parse_flag_value_from_command(command, "--api-key")``."""
+    return parse_flag_value_from_command(command, "--api-key")

--- a/src/sparkrun/runtimes/_util.py
+++ b/src/sparkrun/runtimes/_util.py
@@ -1,3 +1,6 @@
+import re
+
+
 def default_env_hf_offline(env: dict[str, str] = None, **kwargs) -> dict[str, str]:
     return {
         # DEFAULT: disable online HF/transformers checks -- we've already copied all data locally!
@@ -6,3 +9,31 @@ def default_env_hf_offline(env: dict[str, str] = None, **kwargs) -> dict[str, st
         **(env or {}),
         **kwargs,
     }
+
+
+# `--api-key value` or `--api-key=value`.  Stops at whitespace, line
+# continuation backslash, or shell metacharacters that wouldn't appear
+# in a real key.  Both vLLM and SGLang use the same flag spelling.
+_API_KEY_RE = re.compile(r"--api-key(?:=|\s+)([^\s\\]+)")
+
+
+def parse_api_key_from_command(command: str | None) -> str | None:
+    """Extract a literal ``--api-key <value>`` value from a serve command.
+
+    Returns ``None`` when no flag is present, or when the value is a
+    ``{placeholder}`` (the defaults path handles those).  Surrounding
+    quotes are stripped.
+    """
+    if not command:
+        return None
+    match = _API_KEY_RE.search(command)
+    if not match:
+        return None
+    val = match.group(1).strip()
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+        val = val[1:-1]
+    if not val:
+        return None
+    if val.startswith("{") and val.endswith("}"):
+        return None
+    return val

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -3,40 +3,11 @@
 from __future__ import annotations
 
 import json
-import re
 from typing import TYPE_CHECKING
-from sparkrun.runtimes._util import default_env_hf_offline
+from sparkrun.runtimes._util import default_env_hf_offline, parse_api_key_from_command
 
 if TYPE_CHECKING:
     from sparkrun.core.recipe import Recipe
-
-
-# `--api-key value` or `--api-key=value`.  Stops at whitespace, line
-# continuation backslash, or shell metacharacters that wouldn't appear
-# in a real key.
-_VLLM_API_KEY_RE = re.compile(r"--api-key(?:=|\s+)([^\s\\]+)")
-
-
-def _parse_api_key_from_command(command: str | None) -> str | None:
-    """Extract a literal ``--api-key <value>`` value from a vLLM command.
-
-    Returns ``None`` when no flag is present, or when the value is a
-    ``{placeholder}`` (the defaults path handles those).  Surrounding
-    quotes are stripped.
-    """
-    if not command:
-        return None
-    match = _VLLM_API_KEY_RE.search(command)
-    if not match:
-        return None
-    val = match.group(1).strip()
-    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
-        val = val[1:-1]
-    if not val:
-        return None
-    if val.startswith("{") and val.endswith("}"):
-        return None
-    return val
 
 
 class VllmMixin:
@@ -91,7 +62,7 @@ class VllmMixin:
         val = recipe.env.get("VLLM_API_KEY")
         if val:
             return str(val)
-        parsed = _parse_api_key_from_command(recipe.command)
+        parsed = parse_api_key_from_command(recipe.command)
         if parsed:
             return parsed
         return None

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -39,6 +39,28 @@ class VllmMixin:
         cmds["vllm"] = "python3 -c 'import vllm; print(vllm.__version__)' 2>/dev/null || echo unknown"
         return cmds
 
+    def resolve_api_key(
+        self,
+        recipe: "Recipe",
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the vLLM ``--api-key`` value for proxy/discovery use.
+
+        Checks, in order: CLI override, ``defaults.api_key`` placeholder,
+        and ``env.VLLM_API_KEY``.  Returns ``None`` when none are set.
+        """
+        if overrides:
+            val = overrides.get("api_key")
+            if val:
+                return str(val)
+        val = recipe.defaults.get("api_key")
+        if val:
+            return str(val)
+        val = recipe.env.get("VLLM_API_KEY")
+        if val:
+            return str(val)
+        return None
+
     def detect_spec_config_draft_model(self, recipe: "Recipe") -> str | None:
         try:
             # TODO: support various ways that speculative config can be specified

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -3,11 +3,40 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING
 from sparkrun.runtimes._util import default_env_hf_offline
 
 if TYPE_CHECKING:
     from sparkrun.core.recipe import Recipe
+
+
+# `--api-key value` or `--api-key=value`.  Stops at whitespace, line
+# continuation backslash, or shell metacharacters that wouldn't appear
+# in a real key.
+_VLLM_API_KEY_RE = re.compile(r"--api-key(?:=|\s+)([^\s\\]+)")
+
+
+def _parse_api_key_from_command(command: str | None) -> str | None:
+    """Extract a literal ``--api-key <value>`` value from a vLLM command.
+
+    Returns ``None`` when no flag is present, or when the value is a
+    ``{placeholder}`` (the defaults path handles those).  Surrounding
+    quotes are stripped.
+    """
+    if not command:
+        return None
+    match = _VLLM_API_KEY_RE.search(command)
+    if not match:
+        return None
+    val = match.group(1).strip()
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+        val = val[1:-1]
+    if not val:
+        return None
+    if val.startswith("{") and val.endswith("}"):
+        return None
+    return val
 
 
 class VllmMixin:
@@ -46,8 +75,11 @@ class VllmMixin:
     ) -> str | None:
         """Resolve the vLLM ``--api-key`` value for proxy/discovery use.
 
-        Checks, in order: CLI override, ``defaults.api_key`` placeholder,
-        and ``env.VLLM_API_KEY``.  Returns ``None`` when none are set.
+        Checks, in order: CLI override, ``defaults.api_key`` (also
+        emitted as ``--api-key`` via :data:`VLLM_FLAG_MAP` for structured
+        commands), ``env.VLLM_API_KEY``, and finally a literal
+        ``--api-key`` flag parsed from the recipe's ``command`` field.
+        Returns ``None`` when none are set.
         """
         if overrides:
             val = overrides.get("api_key")
@@ -59,6 +91,9 @@ class VllmMixin:
         val = recipe.env.get("VLLM_API_KEY")
         if val:
             return str(val)
+        parsed = _parse_api_key_from_command(recipe.command)
+        if parsed:
+            return parsed
         return None
 
     def detect_spec_config_draft_model(self, recipe: "Recipe") -> str | None:
@@ -93,6 +128,7 @@ VLLM_FLAG_MAP = {
     "data_parallel": "--data-parallel-size",
     "kv_cache_dtype": "--kv-cache-dtype",
     "otlp_traces_endpoint": "--otlp-traces-endpoint",
+    "api_key": "--api-key",
 }
 
 # Boolean flags (present = True, absent = False)

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 from typing import Any, TYPE_CHECKING
 
-from sparkrun.runtimes._util import default_env_hf_offline
+from sparkrun.runtimes._util import default_env_hf_offline, parse_flag_value_from_command
 from sparkrun.runtimes.base import RuntimePlugin
 
 if TYPE_CHECKING:
@@ -84,6 +84,11 @@ _ATLAS_FLAG_MAP = {
     "disable_thinking": "--disable-thinking",
     "high_speed_swap": "--high-speed-swap",
     "require_auth": "--require-auth",
+    # Atlas calls the proxy auth credential ``--auth-token``.  We accept
+    # the cross-runtime portable name ``api_key`` as the canonical key;
+    # ``auth_token`` is supported as an alias and folded into ``api_key``
+    # by ``_normalize_config`` before flag-map iteration.
+    "api_key": "--auth-token",
 }
 
 _ATLAS_BOOL_FLAGS = frozenset(
@@ -117,6 +122,39 @@ class AtlasRuntime(RuntimePlugin):
         """Atlas handles its own multi-rank distribution via NCCL, not Ray."""
         return "native"
 
+    def resolve_api_key(
+        self,
+        recipe: "Recipe",
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the Atlas ``--auth-token`` value for proxy/discovery use.
+
+        Atlas uses ``--auth-token`` (not ``--api-key``) on the wire, but
+        sparkrun accepts the portable ``api_key`` recipe key and the
+        runtime-native ``auth_token`` alias as equivalent sources.
+
+        Checks, in order: CLI override (``api_key`` then ``auth_token``),
+        ``defaults.api_key`` then ``defaults.auth_token``, and finally a
+        literal ``--auth-token`` flag parsed from the recipe's ``command``
+        field.  The ``auth_token`` alias is folded into ``api_key`` by
+        :meth:`_normalize_config` before flag emission, so structured
+        commands always emit ``--auth-token`` exactly once.  Atlas has
+        no documented env-var equivalent, so ``env`` is not consulted.
+        """
+        if overrides:
+            for key in ("api_key", "auth_token"):
+                val = overrides.get(key)
+                if val:
+                    return str(val)
+        for key in ("api_key", "auth_token"):
+            val = recipe.defaults.get(key)
+            if val:
+                return str(val)
+        parsed = parse_flag_value_from_command(recipe.command, "--auth-token")
+        if parsed:
+            return parsed
+        return None
+
     def prefer_ib_for_init_addr(self) -> bool:
         """Added to give option to usb IB IP for Atlas instead of MGMT IP during troubleshooting"""
         return False
@@ -141,6 +179,19 @@ class AtlasRuntime(RuntimePlugin):
 
     # --- Command generation ---
 
+    @staticmethod
+    def _normalize_config(config) -> None:
+        """Apply pre-render config normalizations (auth-token alias).
+
+        Accepts ``auth_token`` as an alias for the canonical ``api_key``
+        key so users can use either in recipe defaults; flag emission
+        only looks at the canonical key.
+        """
+        if not config.get("api_key"):
+            alias = config.get("auth_token")
+            if alias:
+                config.set("api_key", alias)
+
     def generate_command(
         self,
         recipe: Recipe,
@@ -156,6 +207,7 @@ class AtlasRuntime(RuntimePlugin):
         ranks are produced by :meth:`generate_node_command`.
         """
         config = recipe.build_config_chain(overrides)
+        self._normalize_config(config)
 
         rendered = recipe.render_command(config)
         if rendered:
@@ -193,6 +245,7 @@ class AtlasRuntime(RuntimePlugin):
         the HTTP listener — only rank 0 exposes the OpenAI API.
         """
         config = recipe.build_config_chain(overrides)
+        self._normalize_config(config)
 
         rendered = recipe.render_command(config)
         if rendered:

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -166,6 +166,21 @@ class RuntimePlugin(Plugin):
         """
         return self.runtime_name
 
+    # noinspection PyMethodMayBeStatic,PyUnusedLocal
+    def resolve_api_key(
+        self,
+        recipe: Recipe,
+        overrides: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Return the upstream API key the proxy should use to reach this runtime, or None.
+
+        Base implementation returns ``None``.  Runtimes that accept an
+        api-key on their serve command (e.g. vLLM's ``--api-key``) should
+        override this to surface the configured value so proxy discovery
+        can health-check the endpoint and register it with litellm.
+        """
+        return None
+
     def generate_node_command(
         self,
         recipe: Recipe,

--- a/src/sparkrun/runtimes/llama_cpp.py
+++ b/src/sparkrun/runtimes/llama_cpp.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, TYPE_CHECKING
 
 from sparkrun.core.config import SparkrunConfig
+from sparkrun.runtimes._util import parse_api_key_from_command
 from sparkrun.runtimes.base import RuntimePlugin
 
 if TYPE_CHECKING:
@@ -26,6 +27,7 @@ _LLAMA_CPP_FLAG_MAP = {
     "reasoning_format": "--reasoning-format",
     "split_mode": "--split-mode",
     "served_model_name": "--alias",
+    "api_key": "--api-key",
 }
 
 # Defaults injected when not set in recipe config
@@ -83,6 +85,34 @@ class LlamaCppRuntime(RuntimePlugin):
     def cluster_strategy(self) -> str:
         """llama.cpp uses native RPC-based distribution, not Ray."""
         return "native"
+
+    def resolve_api_key(
+        self,
+        recipe: "Recipe",
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the llama-server ``--api-key`` value for proxy/discovery use.
+
+        Checks, in order: CLI override, ``defaults.api_key`` (also
+        emitted as ``--api-key`` via :data:`_LLAMA_CPP_FLAG_MAP` for
+        structured commands), ``env.LLAMA_API_KEY``, and finally a
+        literal ``--api-key`` flag parsed from the recipe's ``command``
+        field.  Returns ``None`` when none are set.
+        """
+        if overrides:
+            val = overrides.get("api_key")
+            if val:
+                return str(val)
+        val = recipe.defaults.get("api_key")
+        if val:
+            return str(val)
+        val = recipe.env.get("LLAMA_API_KEY")
+        if val:
+            return str(val)
+        parsed = parse_api_key_from_command(recipe.command)
+        if parsed:
+            return parsed
+        return None
 
     # --- Parallelism helpers ---
 

--- a/src/sparkrun/runtimes/sglang.py
+++ b/src/sparkrun/runtimes/sglang.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, TYPE_CHECKING
 
-from sparkrun.runtimes._util import default_env_hf_offline
+from sparkrun.runtimes._util import default_env_hf_offline, parse_api_key_from_command
 from sparkrun.runtimes.base import RuntimePlugin
 
 if TYPE_CHECKING:
@@ -32,6 +32,7 @@ _SGLANG_FLAG_MAP = {
     "kv_cache_dtype": "--kv-cache-dtype",
     "tokenizer_path": "--tokenizer-path",
     "speculative_draft_model_path": "--speculative-draft-model-path",
+    "api_key": "--api-key",
 }
 
 _SGLANG_BOOL_FLAGS = {
@@ -55,6 +56,34 @@ class SglangRuntime(RuntimePlugin):
     def cluster_strategy(self) -> str:
         """SGLang uses native multi-node distribution, not Ray."""
         return "native"
+
+    def resolve_api_key(
+        self,
+        recipe: "Recipe",
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the SGLang ``--api-key`` value for proxy/discovery use.
+
+        Checks, in order: CLI override, ``defaults.api_key`` (also
+        emitted as ``--api-key`` via :data:`_SGLANG_FLAG_MAP` for
+        structured commands), ``env.SGLANG_API_KEY``, and finally a
+        literal ``--api-key`` flag parsed from the recipe's ``command``
+        field.  Returns ``None`` when none are set.
+        """
+        if overrides:
+            val = overrides.get("api_key")
+            if val:
+                return str(val)
+        val = recipe.defaults.get("api_key")
+        if val:
+            return str(val)
+        val = recipe.env.get("SGLANG_API_KEY")
+        if val:
+            return str(val)
+        parsed = parse_api_key_from_command(recipe.command)
+        if parsed:
+            return parsed
+        return None
 
     def prepare(
         self,

--- a/src/sparkrun/utils/cli_formatters.py
+++ b/src/sparkrun/utils/cli_formatters.py
@@ -14,6 +14,67 @@ RUNTIME_DISPLAY: dict[str, str] = {
 
 if TYPE_CHECKING:
     from sparkrun.core.monitoring import HostMonitorState
+    from sparkrun.orchestration.disk_info import CacheStatus
+
+
+def format_cache_status_table(
+    host_status: dict[str, "CacheStatus"],
+    local_status: "CacheStatus | None" = None,
+    highlight_hosts: list[str] | set[str] | None = None,
+) -> str:
+    """Render the cache-status table used by ``cluster inspect``.
+
+    Layout matches the existing ``cluster inspect`` output so the same
+    eyes that have learned to read it work for the error-path display
+    in :func:`sparkrun.models.distribute.distribute_model_from_local`.
+
+    Args:
+        host_status: ``host → CacheStatus`` from
+            :func:`sparkrun.orchestration.disk_info.probe_cache_status`.
+        local_status: Optional ``(local)`` row from
+            :func:`sparkrun.orchestration.disk_info.probe_local_cache_status`.
+            Rendered first when present.
+        highlight_hosts: Hosts to mark with a leading ``→`` (typically
+            the ones that ran out of space).
+    """
+    if not host_status and local_status is None:
+        return ""
+
+    highlight = set(highlight_hosts or ())
+
+    # Width 30 matches the legacy cluster_inspect convention so the
+    # output is visually identical to what users already know.
+    row_fmt = "  %-2s %-30s %-10s %-10s %-10s %-10s %-12s %s"
+    lines: list[str] = []
+    lines.append(row_fmt % ("", "Host", "SR exists", "SR size", "HF exists", "HF size", "Free Space", "HF path"))
+    lines.append("  " + "-" * 112)
+
+    def _emit(status: "CacheStatus", marker: str) -> None:
+        if status.error:
+            lines.append("  %-2s %-30s Error: %s" % (marker, status.host, status.error))
+            return
+        lines.append(
+            row_fmt
+            % (
+                marker,
+                status.host,
+                "yes" if status.sparkrun_exists else "no",
+                status.sparkrun_size,
+                "yes" if status.hf_exists else "no",
+                status.hf_size,
+                status.free_space,
+                status.hf_dir,
+            )
+        )
+
+    if local_status is not None:
+        _emit(local_status, "  " if local_status.host not in highlight else "→ ")
+
+    for host in sorted(host_status):
+        marker = "→ " if host in highlight else "  "
+        _emit(host_status[host], marker)
+
+    return "\n".join(lines)
 
 
 def format_recipe_table(

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -350,3 +350,85 @@ def test_atlas_draft_model_flag_still_renders():
     recipe = _recipe(defaults={"draft_model": "Sehyo/Qwen3.5-35B-Draft", "speculative": True})
     cmd = runtime.generate_command(recipe, {}, is_cluster=False)
     assert "--draft-model Sehyo/Qwen3.5-35B-Draft" in cmd
+
+
+# --- Atlas resolve_api_key / --auth-token ---
+
+
+def test_atlas_resolve_api_key_from_defaults_api_key():
+    """defaults.api_key (portable key) is honored."""
+    recipe = _recipe(defaults={"api_key": "sk-portable"})
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-portable"
+
+
+def test_atlas_resolve_api_key_from_defaults_auth_token_alias():
+    """defaults.auth_token (runtime-native alias) is honored."""
+    recipe = _recipe(defaults={"auth_token": "sk-native"})
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-native"
+
+
+def test_atlas_resolve_api_key_canonical_beats_alias():
+    """api_key wins over auth_token when both are set."""
+    recipe = _recipe(defaults={"api_key": "sk-portable", "auth_token": "sk-native"})
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-portable"
+
+
+def test_atlas_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults."""
+    recipe = _recipe(defaults={"api_key": "sk-default"})
+    assert AtlasRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_atlas_resolve_api_key_none_when_unset():
+    """Returns None when no auth source is configured."""
+    assert AtlasRuntime().resolve_api_key(_recipe()) is None
+
+
+def test_atlas_resolve_api_key_no_env_fallback():
+    """Atlas has no documented env-var equivalent — env is not consulted."""
+    recipe = _recipe(env={"ATLAS_API_KEY": "sk-env"})
+    assert AtlasRuntime().resolve_api_key(recipe) is None
+
+
+def test_atlas_resolve_api_key_parses_inline_auth_token_flag():
+    """Literal --auth-token in a fixed command string is extracted."""
+    recipe = _recipe(
+        command="spark serve m --auth-token sk-inline --port 8080",
+    )
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_atlas_resolve_api_key_ignores_placeholder_in_command():
+    """`--auth-token {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = _recipe(
+        command="spark serve m --auth-token {api_key}",
+        defaults={"api_key": "sk-default"},
+    )
+    assert AtlasRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_atlas_api_key_emitted_as_auth_token_flag():
+    """defaults.api_key auto-emits as --auth-token on structured commands."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"port": 8080, "api_key": "sk-flag"})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--auth-token sk-flag" in cmd
+
+
+def test_atlas_auth_token_alias_emitted_as_auth_token_flag():
+    """defaults.auth_token alias also auto-emits as --auth-token."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"port": 8080, "auth_token": "sk-alias"})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--auth-token sk-alias" in cmd
+
+
+def test_atlas_no_duplicate_auth_token_when_both_keys_set():
+    """When both api_key and auth_token are set, --auth-token is emitted once."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"api_key": "sk-canonical", "auth_token": "sk-alias"})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert cmd.count("--auth-token") == 1
+    # Canonical api_key wins
+    assert "--auth-token sk-canonical" in cmd
+    assert "sk-alias" not in cmd

--- a/tests/test_disk_info.py
+++ b/tests/test_disk_info.py
@@ -1,0 +1,180 @@
+"""Tests for sparkrun.orchestration.disk_info — cache status probe."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from sparkrun.orchestration.disk_info import (
+    CacheStatus,
+    _parse_probe_output,
+    probe_cache_status,
+)
+from sparkrun.orchestration.ssh import RemoteResult
+
+
+def _r(host: str, stdout: str = "", returncode: int = 0, stderr: str = "") -> RemoteResult:
+    return RemoteResult(host=host, returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# _parse_probe_output
+# ---------------------------------------------------------------------------
+
+
+def test_parse_probe_full_output():
+    """Pipe-delimited key=value blob is parsed into a CacheStatus."""
+    out = "sr_exists=yes|sr_du=4G|hf_exists=yes|hf_du=120G|sr_dir=/home/u/.cache/sparkrun|hf_dir=/home/u/.cache/huggingface|free_space=812G"
+    status = _parse_probe_output("h1", out)
+    assert status.host == "h1"
+    assert status.sparkrun_exists is True
+    assert status.sparkrun_size == "4G"
+    assert status.hf_exists is True
+    assert status.hf_size == "120G"
+    assert status.sparkrun_dir == "/home/u/.cache/sparkrun"
+    assert status.hf_dir == "/home/u/.cache/huggingface"
+    assert status.free_space == "812G"
+
+
+def test_parse_probe_missing_dirs():
+    out = "sr_exists=no|sr_du=-|hf_exists=no|hf_du=-|sr_dir=/x|hf_dir=/y|free_space=-"
+    status = _parse_probe_output("h1", out)
+    assert status.sparkrun_exists is False
+    assert status.hf_exists is False
+    assert status.free_space == "-"
+
+
+def test_parse_probe_only_last_line_used():
+    """Real probes may emit warnings on earlier lines; only the last is the data line."""
+    out = "warning: foo\n\nsr_exists=yes|sr_du=1G|hf_exists=no|hf_du=-|sr_dir=/s|hf_dir=/h|free_space=10G"
+    status = _parse_probe_output("h1", out)
+    assert status.sparkrun_exists is True
+    assert status.hf_exists is False
+
+
+def test_parse_probe_empty():
+    status = _parse_probe_output("h1", "")
+    assert status.host == "h1"
+    # All fields revert to dataclass defaults
+    assert status.sparkrun_exists is False
+    assert status.free_space == "-"
+
+
+# ---------------------------------------------------------------------------
+# probe_cache_status
+# ---------------------------------------------------------------------------
+
+
+def test_probe_cache_status_returns_per_host_results():
+    results = [
+        _r("h1", "sr_exists=yes|sr_du=4G|hf_exists=yes|hf_du=12G|sr_dir=/s|hf_dir=/h|free_space=812G"),
+        _r("h2", "sr_exists=no|sr_du=-|hf_exists=no|hf_du=-|sr_dir=/s|hf_dir=/h|free_space=910G"),
+    ]
+    with patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel", return_value=results):
+        info = probe_cache_status(["h1", "h2"], hf_cache_dir="/h")
+    assert info["h1"].free_space == "812G"
+    assert info["h1"].sparkrun_exists is True
+    assert info["h2"].sparkrun_exists is False
+    assert info["h2"].free_space == "910G"
+
+
+def test_probe_cache_status_failed_host_carries_error():
+    """SSH failure populates the error field with stderr."""
+    results = [
+        _r("h1", "sr_exists=yes|sr_du=1G|hf_exists=yes|hf_du=2G|sr_dir=/s|hf_dir=/h|free_space=100G"),
+        _r("h2", "", returncode=255, stderr="ssh: connect refused"),
+    ]
+    with patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel", return_value=results):
+        info = probe_cache_status(["h1", "h2"], hf_cache_dir="/h")
+    assert info["h1"].error is None
+    assert info["h2"].error == "ssh: connect refused"
+
+
+def test_probe_cache_status_empty_hosts_returns_empty():
+    with patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel") as mock_run:
+        info = probe_cache_status([], hf_cache_dir="/h")
+    assert info == {}
+    mock_run.assert_not_called()
+
+
+def test_probe_cache_status_dry_run_returns_placeholders():
+    with patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel") as mock_run:
+        info = probe_cache_status(["h1", "h2"], hf_cache_dir="/h", dry_run=True)
+    assert set(info) == {"h1", "h2"}
+    assert info["h1"].hf_dir == "/h"
+    mock_run.assert_not_called()
+
+
+def test_probe_cache_status_default_sparkrun_path():
+    """Without explicit sparkrun_cache_dir the probe uses $HOME/.cache/sparkrun."""
+    captured: dict = {}
+
+    def _capture(hosts, cmd, **kw):
+        captured["cmd"] = cmd
+        return [_r(hosts[0], "sr_exists=yes|sr_du=1G|hf_exists=yes|hf_du=2G|sr_dir=$HOME/.cache/sparkrun|hf_dir=/h|free_space=100G")]
+
+    with patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel", side_effect=_capture):
+        probe_cache_status(["h1"], hf_cache_dir="/h")
+    assert "$HOME/.cache/sparkrun" in captured["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# format_cache_status_table (lives in cli_formatters)
+# ---------------------------------------------------------------------------
+
+
+def _status(host, **kw) -> CacheStatus:
+    return CacheStatus(host=host, hf_dir=kw.pop("hf_dir", "/h"), **kw)
+
+
+def test_format_table_renders_columns():
+    from sparkrun.utils.cli_formatters import format_cache_status_table
+
+    host_status = {
+        "h1": _status("h1", sparkrun_exists=True, sparkrun_size="4G", hf_exists=True, hf_size="12G", free_space="812G"),
+    }
+    table = format_cache_status_table(host_status)
+    assert "h1" in table
+    assert "812G" in table
+    assert "SR exists" in table
+    assert "Free Space" in table
+    assert "HF path" in table
+
+
+def test_format_table_marks_highlight_hosts_with_arrow():
+    from sparkrun.utils.cli_formatters import format_cache_status_table
+
+    host_status = {
+        "h1": _status("h1", free_space="812G"),
+        "h2": _status("h2", free_space="0"),
+    }
+    table = format_cache_status_table(host_status, highlight_hosts=["h2"])
+    h2_line = next(line for line in table.splitlines() if "h2" in line)
+    h1_line = next(line for line in table.splitlines() if "h1" in line and "Free" not in line)
+    assert "→" in h2_line
+    assert "→" not in h1_line
+
+
+def test_format_table_includes_local_row_first():
+    from sparkrun.utils.cli_formatters import format_cache_status_table
+
+    host_status = {"h1": _status("h1", free_space="500G")}
+    local = _status("(local)", free_space="200G", hf_dir="/local/hf")
+    table = format_cache_status_table(host_status, local_status=local)
+    lines = [line for line in table.splitlines() if "(local)" in line or "h1" in line]
+    assert "(local)" in lines[0]
+    assert "h1" in lines[1]
+
+
+def test_format_table_error_host_shows_error_row():
+    from sparkrun.utils.cli_formatters import format_cache_status_table
+
+    host_status = {"h2": _status("h2", error="ssh: connection refused")}
+    table = format_cache_status_table(host_status)
+    assert "h2" in table
+    assert "Error: ssh: connection refused" in table
+
+
+def test_format_table_empty_returns_empty_string():
+    from sparkrun.utils.cli_formatters import format_cache_status_table
+
+    assert format_cache_status_table({}) == ""

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -956,7 +956,7 @@ class TestDistributeModelFromLocal:
     @mock.patch("sparkrun.models.distribute.run_rsync_parallel")
     @mock.patch("sparkrun.models.distribute.download_model")
     def test_out_of_space_failure_is_classified(self, mock_dl, mock_rsync):
-        """Issue #168: rsync 'No space left on device' is classified clearly."""
+        """rsync 'No space left on device' is classified clearly."""
         mock_dl.return_value = 0
         mock_rsync.return_value = [
             RemoteResult(

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -936,7 +936,8 @@ class TestDistributeModelFromLocal:
         from sparkrun.models.distribute import distribute_model_from_local
 
         failed = distribute_model_from_local("org/model", ["h1", "h2"])
-        assert failed == ["h1", "h2"]
+        assert [f.host for f in failed] == ["h1", "h2"]
+        assert all("download" in f.reason for f in failed)
         mock_rsync.assert_not_called()
 
     @mock.patch("sparkrun.models.distribute.run_rsync_parallel")
@@ -950,7 +951,27 @@ class TestDistributeModelFromLocal:
         from sparkrun.models.distribute import distribute_model_from_local
 
         failed = distribute_model_from_local("org/model", ["h1", "h2"])
-        assert failed == ["h2"]
+        assert [f.host for f in failed] == ["h2"]
+
+    @mock.patch("sparkrun.models.distribute.run_rsync_parallel")
+    @mock.patch("sparkrun.models.distribute.download_model")
+    def test_out_of_space_failure_is_classified(self, mock_dl, mock_rsync):
+        """Issue #168: rsync 'No space left on device' is classified clearly."""
+        mock_dl.return_value = 0
+        mock_rsync.return_value = [
+            RemoteResult(
+                host="h2",
+                returncode=11,
+                stdout="",
+                stderr='rsync: [receiver] write failed on "/path": No space left on device (28)',
+            ),
+        ]
+        from sparkrun.models.distribute import distribute_model_from_local
+
+        failed = distribute_model_from_local("org/model", ["h2"])
+        assert len(failed) == 1
+        assert failed[0].host == "h2"
+        assert "disk space" in failed[0].reason
 
     @mock.patch("sparkrun.models.distribute.run_rsync_parallel")
     @mock.patch("sparkrun.models.distribute.download_model")
@@ -1019,7 +1040,7 @@ class TestDistributeModelFromLocal:
             ["mgmt1", "mgmt2"],
             transfer_hosts=["10.0.0.1", "10.0.0.2"],
         )
-        assert failed == ["mgmt2"]
+        assert [f.host for f in failed] == ["mgmt2"]
 
 
 class TestDistributeModelFromHead:
@@ -1072,7 +1093,7 @@ class TestDistributeModelFromHead:
         from sparkrun.models.distribute import distribute_model_from_head
 
         failed = distribute_model_from_head("org/model", ["head", "w1"])
-        assert failed == ["head", "w1"]
+        assert [f.host for f in failed] == ["head", "w1"]
 
     @mock.patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
     def test_distribute_fails(self, mock_run):
@@ -1084,7 +1105,7 @@ class TestDistributeModelFromHead:
         from sparkrun.models.distribute import distribute_model_from_head
 
         failed = distribute_model_from_head("org/model", ["head", "w1", "w2"])
-        assert set(failed) == {"w1", "w2"}
+        assert {f.host for f in failed} == {"w1", "w2"}
 
     def test_empty_hosts(self):
         from sparkrun.models.distribute import distribute_model_from_head
@@ -1384,8 +1405,10 @@ class TestDistributeModelPush:
     @mock.patch("sparkrun.models.distribute.distribute_model_from_head")
     @mock.patch("sparkrun.models.distribute.distribute_model_from_local")
     def test_head_push_fails(self, mock_local, mock_head):
-        """If push to head fails, all hosts are returned as failed."""
-        mock_local.return_value = ["head"]
+        """If push to head fails, all hosts are returned as failed with the head's classified reason."""
+        from sparkrun.orchestration.transfer import TransferFailure
+
+        mock_local.return_value = [TransferFailure(host="head", reason="out of disk space on destination")]
         from sparkrun.orchestration.distribution import _distribute_model_push
 
         failed = _distribute_model_push(
@@ -1396,7 +1419,11 @@ class TestDistributeModelPush:
             ssh_kwargs={},
             dry_run=False,
         )
-        assert failed == ["head", "w1"]
+        assert [f.host for f in failed] == ["head", "w1"]
+        # Head's classified reason propagates to all targets so the
+        # final user-facing error mentions disk space rather than a
+        # bare host name.
+        assert all("disk space" in f.reason for f in failed)
         mock_head.assert_not_called()
 
 

--- a/tests/test_docker_info.py
+++ b/tests/test_docker_info.py
@@ -1,0 +1,187 @@
+"""Tests for sparkrun.orchestration.docker_info (issue #152)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from sparkrun.orchestration.docker_info import (
+    DockerDriverInfo,
+    check_driver_consistency,
+    detect_docker_drivers,
+    format_driver_warning,
+    parse_docker_info_output,
+)
+from sparkrun.orchestration.ssh import RemoteResult
+
+
+# ---------------------------------------------------------------------------
+# parse_docker_info_output
+# ---------------------------------------------------------------------------
+
+
+def test_parse_overlay2_classic():
+    """overlay2 classic produces no snapshotter flag."""
+    out = "overlay2|Backing Filesystem=extfs;Supports d_type=true;Native Overlay Diff=true;"
+    info = parse_docker_info_output(out)
+    assert info.driver == "overlay2"
+    assert info.snapshotter is False
+    assert info.signature == "overlay2"
+
+
+def test_parse_containerd_snapshotter():
+    """overlayfs with containerd snapshotter is detected via driver-type."""
+    out = "overlayfs|driver-type=io.containerd.snapshotter.v1;"
+    info = parse_docker_info_output(out)
+    assert info.driver == "overlayfs"
+    assert info.snapshotter is True
+    assert info.signature == "overlayfs+snapshotter"
+
+
+def test_parse_empty_returns_unavailable():
+    """Empty stdout is reported as UNAVAILABLE rather than crashing."""
+    info = parse_docker_info_output("")
+    assert info.driver == "UNAVAILABLE"
+    assert info.snapshotter is False
+    assert info.is_available is False
+
+
+def test_parse_unavailable_marker():
+    """Probe failure path produces UNAVAILABLE."""
+    info = parse_docker_info_output("UNAVAILABLE|")
+    assert info.driver == "UNAVAILABLE"
+    assert info.is_available is False
+
+
+def test_parse_ignores_trailing_garbage_lines():
+    """Only the last non-empty line is parsed (defends against shell noise)."""
+    out = "warning: something\noverlay2|key=value;"
+    info = parse_docker_info_output(out)
+    assert info.driver == "overlay2"
+
+
+# ---------------------------------------------------------------------------
+# check_driver_consistency
+# ---------------------------------------------------------------------------
+
+
+def test_consistency_all_same_driver():
+    drivers = {
+        "h1": DockerDriverInfo(driver="overlay2", snapshotter=False),
+        "h2": DockerDriverInfo(driver="overlay2", snapshotter=False),
+    }
+    consistent, groups = check_driver_consistency(drivers)
+    assert consistent is True
+    assert groups == {"overlay2": ["h1", "h2"]}
+
+
+def test_consistency_overlay2_vs_snapshotter():
+    """Issue #152 case: same driver name, different snapshotter setting."""
+    drivers = {
+        "lenovo": DockerDriverInfo(driver="overlay2", snapshotter=False),
+        "msi": DockerDriverInfo(driver="overlayfs", snapshotter=True),
+    }
+    consistent, groups = check_driver_consistency(drivers)
+    assert consistent is False
+    assert set(groups) == {"overlay2", "overlayfs+snapshotter"}
+
+
+def test_consistency_excludes_unavailable():
+    """Hosts where docker info failed shouldn't make us flag drift."""
+    drivers = {
+        "h1": DockerDriverInfo(driver="overlay2", snapshotter=False),
+        "h2": DockerDriverInfo(driver="UNAVAILABLE", snapshotter=False),
+    }
+    consistent, groups = check_driver_consistency(drivers)
+    assert consistent is True
+    assert set(groups) == {"overlay2", "UNAVAILABLE"}
+
+
+def test_consistency_empty_map():
+    consistent, groups = check_driver_consistency({})
+    assert consistent is True
+    assert groups == {}
+
+
+# ---------------------------------------------------------------------------
+# format_driver_warning
+# ---------------------------------------------------------------------------
+
+
+def test_format_driver_warning_lists_hosts_and_remediation():
+    groups = {
+        "overlay2": ["lenovo"],
+        "overlayfs+snapshotter": ["msi"],
+    }
+    text = format_driver_warning(groups)
+    assert "inconsistent" in text.lower()
+    assert "lenovo: overlay2" in text
+    assert "msi: overlayfs+snapshotter" in text
+    # remediation instructions present
+    assert "/etc/docker/daemon.json" in text
+    assert "overlay2" in text
+    assert "issue #152" in text
+
+
+# ---------------------------------------------------------------------------
+# detect_docker_drivers
+# ---------------------------------------------------------------------------
+
+
+def _result(host: str, stdout: str = "", returncode: int = 0) -> RemoteResult:
+    return RemoteResult(host=host, returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_detect_docker_drivers_parses_each_host():
+    """Each host's stdout is parsed into a DockerDriverInfo entry."""
+    results = [
+        _result("h1", "overlay2|Backing Filesystem=extfs;"),
+        _result("h2", "overlayfs|driver-type=io.containerd.snapshotter.v1;"),
+    ]
+    with patch(
+        "sparkrun.orchestration.ssh.run_remote_scripts_parallel",
+        return_value=results,
+    ):
+        info = detect_docker_drivers(["h1", "h2"])
+
+    assert info["h1"].driver == "overlay2"
+    assert info["h1"].snapshotter is False
+    assert info["h2"].driver == "overlayfs"
+    assert info["h2"].snapshotter is True
+
+
+def test_detect_docker_drivers_failed_host_marked_unavailable():
+    """Hosts where the probe returns non-zero get UNAVAILABLE."""
+    results = [
+        _result("h1", "overlay2|", returncode=0),
+        _result("h2", "", returncode=255),
+    ]
+    with patch(
+        "sparkrun.orchestration.ssh.run_remote_scripts_parallel",
+        return_value=results,
+    ):
+        info = detect_docker_drivers(["h1", "h2"])
+
+    assert info["h1"].driver == "overlay2"
+    assert info["h2"].driver == "UNAVAILABLE"
+    assert info["h2"].is_available is False
+
+
+def test_detect_docker_drivers_empty_hosts():
+    """Empty host list short-circuits without any SSH calls."""
+    with patch(
+        "sparkrun.orchestration.ssh.run_remote_scripts_parallel",
+    ) as mock_run:
+        info = detect_docker_drivers([])
+    assert info == {}
+    mock_run.assert_not_called()
+
+
+def test_detect_docker_drivers_dry_run_returns_placeholder():
+    """Dry-run skips real probes and returns plausible placeholders."""
+    with patch(
+        "sparkrun.orchestration.ssh.run_remote_scripts_parallel",
+        return_value=[_result("h1", "[dry-run]")],
+    ):
+        info = detect_docker_drivers(["h1"], dry_run=True)
+    assert info["h1"].driver == "overlay2"
+    assert info["h1"].snapshotter is False

--- a/tests/test_infiniband.py
+++ b/tests/test_infiniband.py
@@ -235,7 +235,11 @@ class TestValidateIbConnectivity:
 
     @patch("sparkrun.orchestration.ssh.run_remote_command")
     def test_reachable_returns_original_map(self, mock_cmd):
-        """When IB IP is reachable, returns the original map."""
+        """When every host's first IB IP is reachable, returns the original map.
+
+        Probes once per host; in a switched fabric this confirms each
+        host is reachable on the IB network.
+        """
         mock_cmd.return_value = RemoteResult(
             host="10.0.0.1",
             returncode=0,
@@ -246,13 +250,10 @@ class TestValidateIbConnectivity:
         result = validate_ib_connectivity(ib_map, ssh_kwargs={"ssh_user": "user"})
 
         assert result == ib_map
-        mock_cmd.assert_called_once_with(
-            "10.0.0.1",
-            "true",
-            connect_timeout=5,
-            timeout=10,
-            ssh_user="user",
-        )
+        # Each host gets its own probe; both first-IP probes succeed.
+        assert mock_cmd.call_count == 2
+        probed_ips = {call.args[0] for call in mock_cmd.call_args_list}
+        assert probed_ips == {"10.0.0.1", "10.0.0.2"}
 
     @patch("sparkrun.orchestration.ssh.run_remote_command")
     def test_unreachable_returns_empty(self, mock_cmd):
@@ -267,6 +268,94 @@ class TestValidateIbConnectivity:
         result = validate_ib_connectivity(ib_map)
 
         assert result == {}
+
+    @patch("sparkrun.orchestration.ssh.run_remote_command")
+    def test_first_candidate_works(self, mock_cmd):
+        """Per-host candidate list: first IP responds → returned map uses first IP.
+
+        With parallel within-host probing every candidate is probed
+        simultaneously, but the result is still the first candidate
+        (in detection order) that responded.
+        """
+        mock_cmd.return_value = RemoteResult(host="x", returncode=0, stdout="", stderr="")
+        candidates = {"spark1": ["192.168.2.1", "192.168.3.1"]}
+
+        result = validate_ib_connectivity(candidates)
+
+        assert result == {"spark1": "192.168.2.1"}
+        probed = {c.args[0] for c in mock_cmd.call_args_list}
+        assert probed == {"192.168.2.1", "192.168.3.1"}
+
+    @patch("sparkrun.orchestration.ssh.run_remote_command")
+    def test_second_candidate_works_after_first_fails(self, mock_cmd):
+        """Regression for #176: first IP times out, second responds → map uses second IP."""
+
+        def _probe(ip, _cmd, **_kw):
+            if ip == "192.168.2.1":
+                return RemoteResult(host=ip, returncode=255, stdout="", stderr="timeout")
+            return RemoteResult(host=ip, returncode=0, stdout="", stderr="")
+
+        mock_cmd.side_effect = _probe
+        candidates = {"spark1": ["192.168.2.1", "192.168.3.1"]}
+
+        result = validate_ib_connectivity(candidates)
+
+        # The verified IP is the second candidate, not the first.
+        assert result == {"spark1": "192.168.3.1"}
+        probed = {c.args[0] for c in mock_cmd.call_args_list}
+        assert probed == {"192.168.2.1", "192.168.3.1"}
+
+    @patch("sparkrun.orchestration.ssh.run_remote_command")
+    def test_all_candidates_fail_for_host_returns_empty(self, mock_cmd):
+        """When every candidate for any host fails, returns {} (mgmt fallback)."""
+        mock_cmd.return_value = RemoteResult(host="x", returncode=255, stdout="", stderr="timeout")
+        candidates = {"spark1": ["192.168.2.1", "192.168.3.1"]}
+
+        result = validate_ib_connectivity(candidates)
+
+        assert result == {}
+        # All candidates were tried before giving up.
+        probed = {c.args[0] for c in mock_cmd.call_args_list}
+        assert probed == {"192.168.2.1", "192.168.3.1"}
+
+    @patch("sparkrun.orchestration.ssh.run_remote_command")
+    def test_mixed_reachable_and_unreachable_hosts_returns_empty(self, mock_cmd):
+        """All-or-nothing: one host with no reachable IB → entire map falls back."""
+
+        def _probe(ip, _cmd, **_kw):
+            # spark1 candidates reachable, spark2 candidates all unreachable
+            if ip.startswith("192.168.2."):
+                return RemoteResult(host=ip, returncode=0, stdout="", stderr="")
+            return RemoteResult(host=ip, returncode=255, stdout="", stderr="timeout")
+
+        mock_cmd.side_effect = _probe
+        candidates = {
+            "spark1": ["192.168.2.1"],
+            "spark2": ["192.168.3.2", "192.168.4.2"],
+        }
+        result = validate_ib_connectivity(candidates)
+
+        assert result == {}
+
+    @patch("sparkrun.orchestration.ssh.run_remote_command")
+    def test_per_host_candidates_each_resolved(self, mock_cmd):
+        """Multi-host mesh: each host's verified IP is the first working candidate."""
+
+        def _probe(ip, _cmd, **_kw):
+            # Per-host: simulate that only the *second* candidate is reachable
+            unreachable = {"192.168.2.1", "192.168.3.2"}
+            if ip in unreachable:
+                return RemoteResult(host=ip, returncode=255, stdout="", stderr="timeout")
+            return RemoteResult(host=ip, returncode=0, stdout="", stderr="")
+
+        mock_cmd.side_effect = _probe
+        candidates = {
+            "spark1": ["192.168.2.1", "192.168.3.1"],
+            "spark2": ["192.168.3.2", "192.168.2.2"],
+        }
+        result = validate_ib_connectivity(candidates)
+
+        assert result == {"spark1": "192.168.3.1", "spark2": "192.168.2.2"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -316,6 +316,63 @@ class TestSaveJobMetadata:
         assert "port" not in meta
         assert "served_model_name" not in meta
 
+    def test_api_key_persisted_via_runtime(self, tmp_path: Path):
+        """Runtime's resolve_api_key result is persisted to metadata."""
+        from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+        recipe = _make_recipe(defaults={"api_key": "sk-abc"})
+
+        class _Rt:
+            def resolve_api_key(self, recipe, overrides=None):
+                return recipe.defaults.get("api_key")
+
+        save_job_metadata(
+            "sparkrun_authkey",
+            recipe,
+            ["10.0.0.1"],
+            cache_dir=str(tmp_path),
+            runtime=_Rt(),
+        )
+        meta = load_job_metadata("sparkrun_authkey", cache_dir=str(tmp_path))
+        assert meta is not None
+        assert meta["api_key"] == "sk-abc"
+
+    def test_api_key_omitted_when_runtime_returns_none(self, tmp_path: Path):
+        """No api_key field when resolve_api_key returns None."""
+        from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+        recipe = _make_recipe()
+
+        class _Rt:
+            def resolve_api_key(self, recipe, overrides=None):
+                return None
+
+        save_job_metadata(
+            "sparkrun_nokey",
+            recipe,
+            ["10.0.0.1"],
+            cache_dir=str(tmp_path),
+            runtime=_Rt(),
+        )
+        meta = load_job_metadata("sparkrun_nokey", cache_dir=str(tmp_path))
+        assert meta is not None
+        assert "api_key" not in meta
+
+    def test_api_key_skipped_when_no_runtime(self, tmp_path: Path):
+        """Backward compat: no runtime arg means no api_key resolution."""
+        from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+        recipe = _make_recipe(defaults={"api_key": "sk-ignored"})
+        save_job_metadata(
+            "sparkrun_noruntime",
+            recipe,
+            ["10.0.0.1"],
+            cache_dir=str(tmp_path),
+        )
+        meta = load_job_metadata("sparkrun_noruntime", cache_dir=str(tmp_path))
+        assert meta is not None
+        assert "api_key" not in meta
+
 
 # =====================================================================
 # Tests: Discovery
@@ -424,6 +481,95 @@ class TestDiscovery:
         healthy = [ep for ep in endpoints if ep.healthy]
         assert len(healthy) == 2
         assert "Qwen/Qwen3-1.7B" in healthy[0].actual_models
+
+    def test_api_key_threaded_into_endpoint(self, jobs_dir: Path):
+        """api_key from job metadata flows into DiscoveredEndpoint."""
+        from sparkrun.proxy.discovery import discover_endpoints
+
+        meta = {
+            "cluster_id": "sparkrun_apikey",
+            "recipe": "vllm-auth",
+            "model": "Org/Authed",
+            "runtime": "vllm",
+            "hosts": ["10.0.0.5"],
+            "port": 8000,
+            "api_key": "sk-upstream",
+        }
+        with open(jobs_dir / "apikey.yaml", "w") as f:
+            yaml.safe_dump(meta, f)
+
+        endpoints = discover_endpoints(
+            cache_dir=str(jobs_dir.parent),
+            check_health=False,
+        )
+        assert len(endpoints) == 1
+        assert endpoints[0].api_key == "sk-upstream"
+
+    def test_health_check_sends_bearer_header(self, jobs_dir: Path):
+        """Health check uses Bearer auth when api_key is set on the endpoint."""
+        from sparkrun.proxy.discovery import discover_endpoints
+
+        meta = {
+            "cluster_id": "sparkrun_authed",
+            "recipe": "vllm-auth",
+            "model": "Org/Authed",
+            "runtime": "vllm",
+            "hosts": ["10.0.0.7"],
+            "port": 8000,
+            "api_key": "sk-bearer",
+        }
+        with open(jobs_dir / "authed.yaml", "w") as f:
+            yaml.safe_dump(meta, f)
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"data": [{"id": "Org/Authed"}]}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        captured: list = []
+
+        def _spy(req, timeout=None):
+            captured.append(req)
+            return mock_response
+
+        with patch("sparkrun.proxy.discovery.urllib.request.urlopen", side_effect=_spy):
+            endpoints = discover_endpoints(
+                cache_dir=str(jobs_dir.parent),
+                check_health=True,
+            )
+
+        healthy = [ep for ep in endpoints if ep.healthy]
+        assert len(healthy) == 1
+        assert captured, "urlopen was not called"
+        # urllib normalises header keys: Authorization → "Authorization"
+        auth_value = captured[0].get_header("Authorization")
+        assert auth_value == "Bearer sk-bearer"
+
+    def test_health_check_no_auth_when_no_api_key(self, populated_jobs_dir: Path):
+        """No Authorization header is sent when endpoint has no api_key."""
+        from sparkrun.proxy.discovery import discover_endpoints
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"data": []}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        captured: list = []
+
+        def _spy(req, timeout=None):
+            captured.append(req)
+            return mock_response
+
+        with patch("sparkrun.proxy.discovery.urllib.request.urlopen", side_effect=_spy):
+            discover_endpoints(
+                cache_dir=str(populated_jobs_dir),
+                check_health=True,
+            )
+
+        for req in captured:
+            assert req.get_header("Authorization") is None
 
     def test_health_check_failure(self, populated_jobs_dir: Path):
         """Failed health check sets healthy=False."""
@@ -800,6 +946,39 @@ class TestEngineConfig:
         config = build_litellm_config(endpoints)
         assert len(config["model_list"]) == 1
         assert config["model_list"][0]["model_name"] == "model-a"
+
+    def test_build_config_uses_endpoint_api_key(self):
+        """Endpoint api_key flows through to litellm_params; absent → 'not-needed'."""
+        from sparkrun.proxy.discovery import DiscoveredEndpoint
+        from sparkrun.proxy.engine import build_litellm_config
+
+        endpoints = [
+            DiscoveredEndpoint(
+                cluster_id="sparkrun_auth",
+                model="Org/Authed",
+                served_model_name=None,
+                runtime="vllm",
+                host="10.0.0.5",
+                port=8000,
+                healthy=True,
+                actual_models=["Org/Authed"],
+                api_key="sk-upstream",
+            ),
+            DiscoveredEndpoint(
+                cluster_id="sparkrun_open",
+                model="Org/Open",
+                served_model_name=None,
+                runtime="vllm",
+                host="10.0.0.6",
+                port=8000,
+                healthy=True,
+                actual_models=["Org/Open"],
+            ),
+        ]
+
+        config = build_litellm_config(endpoints)
+        keys = {m["model_name"]: m["litellm_params"]["api_key"] for m in config["model_list"]}
+        assert keys == {"Org/Authed": "sk-upstream", "Org/Open": "not-needed"}
 
     def test_build_config_deduplicates(self):
         """Same model on same host:port is deduplicated."""

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -281,6 +281,75 @@ def test_vllm_resolve_api_key_none_when_unset():
     assert VllmRayRuntime().resolve_api_key(recipe) is None
 
 
+def test_vllm_resolve_api_key_parses_inline_command_flag():
+    """Literal --api-key in a fixed command string is extracted."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --api-key sk-inline --port 8000",
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_vllm_resolve_api_key_parses_equals_form():
+    """`--api-key=value` form is also extracted."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --api-key=sk-eq --port 8000",
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-eq"
+
+
+def test_vllm_resolve_api_key_ignores_placeholder_in_command():
+    """`--api-key {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --api-key {api_key} --port 8000",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    # defaults.api_key wins over the (rejected) placeholder
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_vllm_resolve_api_key_defaults_beat_inline_command():
+    """defaults.api_key takes precedence over inline --api-key in command."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --api-key sk-inline",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_vllm_api_key_emitted_as_flag_for_structured_command():
+    """defaults.api_key auto-emits as --api-key on structured (no-template) commands."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"port": 8000, "api_key": "sk-flag"},
+        }
+    )
+    cmd = VllmRayRuntime().generate_command(recipe, {}, is_cluster=False)
+    assert "--api-key sk-flag" in cmd
+
+
 # --- SglangRuntime Tests ---
 
 
@@ -348,6 +417,110 @@ def test_sglang_cluster_env():
     env = runtime.get_cluster_env(head_ip="192.168.1.100", num_nodes=2)
 
     assert env["NCCL_CUMEM_ENABLE"] == "0"
+
+
+# --- SGLang resolve_api_key Tests ---
+
+
+def test_sglang_resolve_api_key_from_defaults():
+    """defaults.api_key is the recommended source for sglang too."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_sglang_resolve_api_key_from_env():
+    """env.SGLANG_API_KEY is honored when defaults.api_key is absent."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "env": {"SGLANG_API_KEY": "sk-env"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-env"
+
+
+def test_sglang_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults and env."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"SGLANG_API_KEY": "sk-env"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_sglang_resolve_api_key_defaults_beat_env():
+    """defaults.api_key takes precedence over env.SGLANG_API_KEY."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"SGLANG_API_KEY": "sk-env"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_sglang_resolve_api_key_none_when_unset():
+    """Returns None when no api_key is configured anywhere."""
+    recipe = Recipe.from_dict({"name": "r", "model": "m", "runtime": "sglang"})
+    assert SglangRuntime().resolve_api_key(recipe) is None
+
+
+def test_sglang_resolve_api_key_parses_inline_command_flag():
+    """Literal --api-key in a fixed command string is extracted."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "command": "python -m sglang.launch_server --model-path m --api-key sk-inline --port 30000",
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_sglang_resolve_api_key_ignores_placeholder_in_command():
+    """`--api-key {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "command": "python -m sglang.launch_server --api-key {api_key} --port 30000",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert SglangRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_sglang_api_key_emitted_as_flag_for_structured_command():
+    """defaults.api_key auto-emits as --api-key on structured (no-template) commands."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "sglang",
+            "defaults": {"port": 30000, "api_key": "sk-flag"},
+        }
+    )
+    cmd = SglangRuntime().generate_command(recipe, {}, is_cluster=False)
+    assert "--api-key sk-flag" in cmd
 
 
 def test_sglang_validate_recipe():

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -1636,6 +1636,110 @@ def test_llama_cpp_cluster_strategy():
     assert runtime.cluster_strategy() == "native"
 
 
+# --- llama.cpp resolve_api_key Tests ---
+
+
+def test_llama_cpp_resolve_api_key_from_defaults():
+    """defaults.api_key is the recommended source for llama.cpp too."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_llama_cpp_resolve_api_key_from_env():
+    """env.LLAMA_API_KEY is honored when defaults.api_key is absent."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "env": {"LLAMA_API_KEY": "sk-env"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-env"
+
+
+def test_llama_cpp_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults and env."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"LLAMA_API_KEY": "sk-env"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_llama_cpp_resolve_api_key_defaults_beat_env():
+    """defaults.api_key takes precedence over env.LLAMA_API_KEY."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"LLAMA_API_KEY": "sk-env"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_llama_cpp_resolve_api_key_none_when_unset():
+    """Returns None when no api_key is configured anywhere."""
+    recipe = Recipe.from_dict({"name": "r", "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M", "runtime": "llama-cpp"})
+    assert LlamaCppRuntime().resolve_api_key(recipe) is None
+
+
+def test_llama_cpp_resolve_api_key_parses_inline_command_flag():
+    """Literal --api-key in a fixed command string is extracted."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "command": "llama-server -hf m --api-key sk-inline --port 8080",
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_llama_cpp_resolve_api_key_ignores_placeholder_in_command():
+    """`--api-key {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "command": "llama-server -hf m --api-key {api_key} --port 8080",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert LlamaCppRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_llama_cpp_api_key_emitted_as_flag_for_structured_command():
+    """defaults.api_key auto-emits as --api-key on structured (no-template) commands."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+            "runtime": "llama-cpp",
+            "defaults": {"port": 8080, "api_key": "sk-flag"},
+        }
+    )
+    cmd = LlamaCppRuntime().generate_command(recipe, {}, is_cluster=False)
+    assert "--api-key sk-flag" in cmd
+
+
 def test_llama_cpp_resolve_container_from_recipe():
     """Recipe with container field."""
     recipe_data = {

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -204,6 +204,83 @@ def test_vllm_cluster_env():
     assert env["RAY_memory_monitor_refresh_ms"] == "0"
 
 
+# --- resolve_api_key Tests ---
+
+
+def test_base_resolve_api_key_returns_none():
+    """Base RuntimePlugin returns None — runtimes opt in by overriding."""
+
+    class _Stub(RuntimePlugin):
+        runtime_name = "stub"
+
+        def generate_command(self, *args, **kwargs):
+            return ""
+
+    recipe = Recipe.from_dict({"name": "r", "model": "m", "runtime": "stub", "defaults": {"api_key": "abc"}})
+    assert _Stub().resolve_api_key(recipe) is None
+
+
+def test_vllm_resolve_api_key_from_defaults():
+    """defaults.api_key is the recommended source."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"api_key": "sk-default"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-default"
+    assert VllmDistributedRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_vllm_resolve_api_key_from_env():
+    """env.VLLM_API_KEY is honored when defaults.api_key is absent."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "env": {"VLLM_API_KEY": "sk-env"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-env"
+
+
+def test_vllm_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults and env."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"VLLM_API_KEY": "sk-env"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_vllm_resolve_api_key_defaults_beat_env():
+    """defaults.api_key takes precedence over env.VLLM_API_KEY."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "r",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"api_key": "sk-default"},
+            "env": {"VLLM_API_KEY": "sk-env"},
+        }
+    )
+    assert VllmRayRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_vllm_resolve_api_key_none_when_unset():
+    """Returns None when no api_key is configured anywhere."""
+    recipe = Recipe.from_dict({"name": "r", "model": "m", "runtime": "vllm"})
+    assert VllmRayRuntime().resolve_api_key(recipe) is None
+
+
 # --- SglangRuntime Tests ---
 
 

--- a/tests/test_transfer_error_classification.py
+++ b/tests/test_transfer_error_classification.py
@@ -22,7 +22,7 @@ def _r(host: str, returncode: int, stderr: str = "") -> RemoteResult:
 
 
 def test_classify_no_space():
-    """Issue #168: rsync's 'No space left on device' is recognized."""
+    """rsync's 'No space left on device' is recognized."""
     result = _r(
         "h1",
         11,

--- a/tests/test_transfer_error_classification.py
+++ b/tests/test_transfer_error_classification.py
@@ -1,0 +1,151 @@
+"""Tests for sparkrun.orchestration.transfer — rsync error classification."""
+
+from __future__ import annotations
+
+from sparkrun.orchestration.ssh import RemoteResult
+from sparkrun.orchestration.transfer import (
+    TransferFailure,
+    classify_rsync_failure,
+    format_transfer_failures,
+    map_transfer_failures,
+    map_transfer_failures_detailed,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_rsync_failure
+# ---------------------------------------------------------------------------
+
+
+def _r(host: str, returncode: int, stderr: str = "") -> RemoteResult:
+    return RemoteResult(host=host, returncode=returncode, stdout="", stderr=stderr)
+
+
+def test_classify_no_space():
+    """Issue #168: rsync's 'No space left on device' is recognized."""
+    result = _r(
+        "h1",
+        11,
+        'rsync: [receiver] write failed on "/path/blob": No space left on device (28)',
+    )
+    assert classify_rsync_failure(result) == "out of disk space"
+
+
+def test_classify_disk_quota():
+    result = _r("h1", 11, "rsync: write failed: Disk quota exceeded (122)")
+    assert classify_rsync_failure(result) == "disk quota exceeded"
+
+
+def test_classify_permission_denied():
+    result = _r("h1", 23, "rsync: change_dir failed: Permission denied (13)")
+    assert classify_rsync_failure(result) == "permission denied"
+
+
+def test_classify_connection_refused():
+    result = _r("h1", 255, "ssh: connect to host h1 port 22: Connection refused")
+    assert classify_rsync_failure(result) == "SSH connection refused"
+
+
+def test_classify_connection_timed_out():
+    result = _r("h1", 255, "ssh: connect to host h1 port 22: Connection timed out")
+    assert classify_rsync_failure(result) == "SSH connection timed out"
+
+
+def test_classify_unknown_returns_generic_with_rc():
+    """Unknown stderr falls back to a generic rc-tagged reason."""
+    result = _r("h1", 99, "something weird happened")
+    assert classify_rsync_failure(result) == "rsync failed (rc=99)"
+
+
+def test_classify_empty_stderr_returns_generic():
+    result = _r("h1", 23, "")
+    assert classify_rsync_failure(result) == "rsync failed (rc=23)"
+
+
+def test_classify_case_insensitive():
+    """Patterns match regardless of stderr casing (rsync varies by version)."""
+    result = _r("h1", 11, "NO SPACE LEFT ON DEVICE")
+    assert classify_rsync_failure(result) == "out of disk space"
+
+
+# ---------------------------------------------------------------------------
+# map_transfer_failures (legacy)
+# ---------------------------------------------------------------------------
+
+
+def test_map_transfer_failures_returns_host_names_only():
+    results = [
+        _r("10.0.0.1", 0),
+        _r("10.0.0.2", 11, "No space left on device"),
+    ]
+    failed = map_transfer_failures(results, ["10.0.0.1", "10.0.0.2"], ["m1", "m2"])
+    assert failed == ["m2"]
+
+
+def test_map_transfer_failures_unmapped_host_returned_as_is():
+    """If a result host isn't in the transfer→mgmt mapping it's returned verbatim."""
+    results = [_r("rogue", 1, "err")]
+    failed = map_transfer_failures(results, ["10.0.0.1"], ["m1"])
+    assert failed == ["rogue"]
+
+
+# ---------------------------------------------------------------------------
+# map_transfer_failures_detailed
+# ---------------------------------------------------------------------------
+
+
+def test_map_transfer_failures_detailed_classifies_per_host():
+    results = [
+        _r("10.0.0.1", 0),
+        _r("10.0.0.2", 11, "rsync: write failed: No space left on device (28)"),
+        _r("10.0.0.3", 23, "rsync: change_dir failed: Permission denied (13)"),
+    ]
+    failures = map_transfer_failures_detailed(
+        results,
+        ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+        ["m1", "m2", "m3"],
+    )
+    by_host = {f.host: f for f in failures}
+    assert set(by_host) == {"m2", "m3"}
+    assert by_host["m2"].reason == "out of disk space"
+    assert by_host["m3"].reason == "permission denied"
+
+
+def test_map_transfer_failures_detailed_truncates_long_stderr():
+    """Detail field is bounded so callers don't dump multi-KB blobs in logs."""
+    big_stderr = "x" * 5000
+    results = [_r("10.0.0.1", 23, big_stderr)]
+    failures = map_transfer_failures_detailed(results, ["10.0.0.1"], ["m1"])
+    assert len(failures) == 1
+    assert len(failures[0].detail) <= 400
+
+
+def test_map_transfer_failures_detailed_empty_on_success():
+    results = [_r("10.0.0.1", 0)]
+    failures = map_transfer_failures_detailed(results, ["10.0.0.1"], ["m1"])
+    assert failures == []
+
+
+# ---------------------------------------------------------------------------
+# format_transfer_failures
+# ---------------------------------------------------------------------------
+
+
+def test_format_transfer_failures_groups_by_reason():
+    failures = [
+        TransferFailure(host="m1", reason="out of disk space on destination"),
+        TransferFailure(host="m2", reason="out of disk space on destination"),
+        TransferFailure(host="m3", reason="permission denied on destination"),
+    ]
+    rendered = format_transfer_failures(failures)
+    assert "out of disk space on destination on m1, m2" in rendered
+    assert "permission denied on destination on m3" in rendered
+
+
+def test_format_transfer_failures_empty_returns_empty_string():
+    assert format_transfer_failures([]) == ""
+
+
+def test_format_transfer_failures_single_host():
+    failures = [TransferFailure(host="m1", reason="out of disk space on destination")]
+    assert format_transfer_failures(failures) == "out of disk space on destination on m1"

--- a/tests/test_vram.py
+++ b/tests/test_vram.py
@@ -787,8 +787,41 @@ class TestFetchSafetensorsSizeOrder:
         assert result == 20_000_000_000  # index total_size
         assert api_called == []  # API not called when index succeeds
 
-    def test_api_used_when_no_index(self):
-        """API should work when index file is unavailable."""
+    def test_list_repo_tree_preferred_over_api_for_single_file(self):
+        """list_repo_tree LFS size preferred over model_info API (more accurate
+        for packed quant formats).
+        """
+        api_called = []
+
+        def _fake_model_info(**kwargs):
+            api_called.append(1)
+            return _FakeModelInfo(safetensors=None)
+
+        class _Entry:
+            def __init__(self, rfilename, size):
+                self.rfilename = rfilename
+                self.size = size
+
+        tree = [
+            _Entry("config.json", 1024),
+            _Entry("model.safetensors", 17_500_000_000),
+            _Entry("tokenizer.json", 2048),
+        ]
+
+        with (
+            mock.patch("huggingface_hub.model_info", side_effect=_fake_model_info),
+            mock.patch("huggingface_hub.list_repo_tree", return_value=iter(tree)),
+            mock.patch("huggingface_hub.hf_hub_download", side_effect=Exception("no index")),
+            mock.patch("huggingface_hub.utils.disable_progress_bars"),
+            mock.patch("huggingface_hub.utils.enable_progress_bars"),
+        ):
+            result = fetch_safetensors_size("org/single-file-model")
+
+        assert result == 17_500_000_000
+        assert api_called == []  # API not called when tree size succeeds
+
+    def test_api_used_when_no_index_and_no_tree(self):
+        """API is the last-resort metadata source when list_repo_tree yields nothing."""
         st_info = _FakeSafeTensorsInfo(
             parameters={"BF16": 7_000_000_000},
             total=7_000_000_000,
@@ -797,6 +830,7 @@ class TestFetchSafetensorsSizeOrder:
 
         with (
             mock.patch("huggingface_hub.model_info", return_value=mi),
+            mock.patch("huggingface_hub.list_repo_tree", return_value=iter([])),
             mock.patch("huggingface_hub.hf_hub_download", side_effect=Exception("not found")),
             mock.patch("huggingface_hub.utils.disable_progress_bars"),
             mock.patch("huggingface_hub.utils.enable_progress_bars"),
@@ -805,3 +839,46 @@ class TestFetchSafetensorsSizeOrder:
 
         # BF16 = 2 bytes per element → 7B * 2 = 14B bytes
         assert result == 14_000_000_000
+
+    def test_no_weight_file_download_when_index_missing(self):
+        """Regression for #186: missing index must not trigger model.safetensors download.
+
+        For quantized single-file models (e.g. NVFP4) without an
+        ``index.json``, falling through to ``hf_hub_download(model.safetensors)``
+        would download many GB of weights just to read a header, hanging the
+        CLI.  Only ``model.safetensors.index.json`` is an acceptable file
+        download from this function.
+        """
+        downloaded: list[str] = []
+
+        def _fake_download(**kwargs):
+            downloaded.append(kwargs.get("filename", ""))
+            raise FileNotFoundError("no index here")
+
+        class _Entry:
+            def __init__(self, rfilename, size):
+                self.rfilename = rfilename
+                self.size = size
+
+        tree = [
+            _Entry("config.json", 1024),
+            _Entry("model.safetensors", 17_500_000_000),
+        ]
+
+        st_info = _FakeSafeTensorsInfo(
+            parameters={"F8_E4M3": 35_000_000_000},
+            total=35_000_000_000,
+        )
+        mi = _FakeModelInfo(safetensors=st_info)
+
+        with (
+            mock.patch("huggingface_hub.model_info", return_value=mi),
+            mock.patch("huggingface_hub.list_repo_tree", return_value=iter(tree)),
+            mock.patch("huggingface_hub.hf_hub_download", side_effect=_fake_download),
+            mock.patch("huggingface_hub.utils.disable_progress_bars"),
+            mock.patch("huggingface_hub.utils.enable_progress_bars"),
+        ):
+            result = fetch_safetensors_size("org/nvfp4-single-file")
+
+        assert result == 17_500_000_000  # LFS size from tree, not API params
+        assert downloaded == ["model.safetensors.index.json"]

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.2.35
+sparkrun: 0.2.36
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
This pull request introduces several improvements and enhancements across the codebase, focusing on secure handling of API keys, improved cluster cache inspection, Docker image management, and consistency checks for Docker storage drivers across hosts. The changes increase security, reliability, and user experience when running benchmarks, inspecting clusters, and managing container images.

* Added a new `--api-key-env` option to the benchmark CLI, allowing users to securely pass API keys via environment variables instead of command-line arguments. Passing API keys via `--bench-option` is now blocked for security reasons, and API key values are redacted from CLI output. [[1]](diffhunk://#diff-642a32603a35eeb78e6fe0f6dfc131c1393c15d11c6cacc89bd56ae6c15c8265R137-R141) [[2]](diffhunk://#diff-642a32603a35eeb78e6fe0f6dfc131c1393c15d11c6cacc89bd56ae6c15c8265L564-R595) [[3]](diffhunk://#diff-642a32603a35eeb78e6fe0f6dfc131c1393c15d11c6cacc89bd56ae6c15c8265L655-R687)
* Recipe-sourced API Keys (e.g. from defaults mapping) are now processed across most runtimes (vllm, sglang, llama.cpp, atlas)
* Recipe-sourced API keys are injected automatically for sparkrun proxy and sparkrun benchmark

**Docker Image and Cluster Consistency:**

* Added a storage-driver consistency check to the Docker setup process, warning users if hosts have heterogeneous storage drivers, which can cause unnecessary container re-syncs. [[1]](diffhunk://#diff-ae66a610839dfe244e0cc159dfea186fe137dc62f6b00c735f2c4356b41a54e2R1276-R1292) [[2]](diffhunk://#diff-8085dabd409b66fce044f36c96ef95d3d70177bbb478b9790e5159dc2d553533R797-R813)
* Enhanced `ensure_image` to support a `force_pull` option and improved handling of images tagged as `latest`, ensuring better control over image updates and pulls.

**Model Parameter Size Estimation:**

* Improved the logic for estimating HuggingFace model parameter sizes by prioritizing metadata-only lookups (using `list_repo_tree`), which are more accurate for packed quant formats, and updated the docstring to clarify the new approach. [[1]](diffhunk://#diff-76d5b6bc93edb88b277c63c720152a265fad1972743cd140213140347ba94836L223-R235) [[2]](diffhunk://#diff-76d5b6bc93edb88b277c63c720152a265fad1972743cd140213140347ba94836R258-R261) [[3]](diffhunk://#diff-76d5b6bc93edb88b277c63c720152a265fad1972743cd140213140347ba94836L336-L390)

**Infiniband Detection Fixes:**

* Added functionality in Infiniband transfer and resource distribution logic to search all `ib_candidates` instead of assuming first IP address. This makes CX7 distribution functional on 3-node mesh configurations. [[1]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573L112-R112) [[2]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573L455-R455) [[3]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573L735-R735)

**Cluster Inspection and Cache Status:**

- Refactored cluster inspection to use new helpers (`probe_cache_status`, `probe_local_cache_status`, `format_cache_status_table`) for collecting and displaying cache directory status both locally and remotely, replacing manual SSH and shell scripting logic. The JSON output and CLI table now use structured status objects. [[1]](diffhunk://#diff-57638b4e3b222fbdb13f046317ec40822e62d4b373e62b2e69762b61c5656707L870-R888) [[2]](diffhunk://#diff-57638b4e3b222fbdb13f046317ec40822e62d4b373e62b2e69762b61c5656707L952-R928) [[3]](diffhunk://#diff-57638b4e3b222fbdb13f046317ec40822e62d4b373e62b2e69762b61c5656707L1015-R976)
- Well-formatted table to provide insight into disk space related issues on model distribution errors

**Miscellaneous Improvements:**

- Minor refactors and dependency updates. [[1]](diffhunk://#diff-164c2c1a74164186bcc8873b8b41061a534c08ef7e4cf00b5b150d763b9ed5cdL18-R18) [[2]](diffhunk://#diff-c52669c725e09ea433cd88d773b412bf68812178deba2cbca1da56f9ab6ef4aaR297) [[3]](diffhunk://#diff-c52669c725e09ea433cd88d773b412bf68812178deba2cbca1da56f9ab6ef4aaR347) [[4]](diffhunk://#diff-c52669c725e09ea433cd88d773b412bf68812178deba2cbca1da56f9ab6ef4aaR564)
- Version bump to `0.2.36`.
