### PR TITLE
v0.2.37 Mesh IP Resolution for Container Distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.36"
+version = "0.2.37"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/orchestration/distribution.py
+++ b/src/sparkrun/orchestration/distribution.py
@@ -498,14 +498,18 @@ def distribute_resources(
         )
 
     if transfer_mode == "local":
-        # Local mode: use validated IB IPs for direct transfers
+        # Local mode: use validated IB IPs for direct transfers.
+        # ib_result.ib_ip_map only carries the *first* detected IB IP per host;
+        # on mesh/ring fabrics that IP is often unreachable from the control
+        # machine. _ib_validated carries the reachability-verified IP from
+        # validate_ib_connectivity(), which is what control→host transfers must use.
         ib_ip_map = _ib_validated or {}
         if ib_ip_map and not _use_mgmt:
-            transfer_hosts = [ib_result.ib_ip_map.get(h, h) for h in host_list]
-            logger.debug("ib_ip_map=%r host_list=%r transfer_hosts=%r", ib_result.ib_ip_map, host_list, transfer_hosts)
+            transfer_hosts = [ib_ip_map.get(h, h) for h in host_list]
+            logger.debug("ib_ip_map=%r host_list=%r transfer_hosts=%r", ib_ip_map, host_list, transfer_hosts)
             logger.info(
                 "Using IB network for transfers (%d/%d hosts)",
-                len(ib_result.ib_ip_map),
+                len(ib_ip_map),
                 len(host_list),
             )
     else:
@@ -757,8 +761,11 @@ def distribute_from_config(
     _cross_user = _is_cross_user(ssh_kwargs)
 
     if transfer_mode == "local":
+        # See distribute_resources(): control→host transfers must use the
+        # reachability-verified _ib_validated map, not the first-candidate
+        # ib_result.ib_ip_map (which is wrong on mesh/ring fabrics).
         ib_ip_map = _ib_validated or {}
-        transfer_hosts = [ib_result.ib_ip_map.get(h, h) for h in host_list] if ib_ip_map and not _use_mgmt else None
+        transfer_hosts = [ib_ip_map.get(h, h) for h in host_list] if ib_ip_map and not _use_mgmt else None
         worker_transfer_hosts = None
     else:
         ib_ip_map = ib_result.ib_ip_map

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -1636,6 +1636,44 @@ class TestDistributeResourcesTransferMode:
         mock_validate.assert_called_once()
         mock_img.assert_called_once()
 
+    @mock.patch("sparkrun.containers.distribute.distribute_image_from_local")
+    @mock.patch("sparkrun.orchestration.infiniband.validate_ib_connectivity")
+    @mock.patch("sparkrun.orchestration.infiniband.detect_ib_for_hosts")
+    @mock.patch("sparkrun.orchestration.primitives.build_ssh_kwargs", return_value={})
+    def test_local_mode_uses_validated_ib_ips_not_first_candidate(self, mock_ssh, mock_ib, mock_validate, mock_img):
+        """Regression: on mesh/ring fabrics the first detected IB IP per host
+        may be unreachable from control; transfer_hosts must come from the
+        reachability-verified map returned by validate_ib_connectivity,
+        not from ib_result.ib_ip_map (first detected per host).
+        """
+        # Mirror the user-reported ring scenario: each host's first candidate
+        # is unreachable from control, but a later candidate is.
+        mock_ib.return_value = mock.MagicMock(
+            comm_env=ClusterCommEnv.empty(),
+            mgmt_ip_map={},
+            ib_ip_map={"h1": "192.168.2.2", "h2": "192.168.0.1", "h3": "192.168.2.1"},
+            ib_candidates={
+                "h1": ["192.168.2.2", "192.168.4.2"],
+                "h2": ["192.168.0.1", "192.168.2.1"],
+                "h3": ["192.168.2.1", "192.168.4.1"],
+            },
+        )
+        mock_validate.return_value = {"h1": "192.168.4.2", "h2": "192.168.0.1", "h3": "192.168.4.1"}
+        mock_img.return_value = []
+        from sparkrun.orchestration.distribution import distribute_resources
+
+        distribute_resources(
+            "img:latest",
+            "",
+            ["h1", "h2", "h3"],
+            "/cache",
+            self._make_config(),
+            dry_run=True,
+            transfer_mode="local",
+        )
+        call_kwargs = mock_img.call_args[1]
+        assert call_kwargs["transfer_hosts"] == ["192.168.4.2", "192.168.0.1", "192.168.4.1"]
+
     @mock.patch("sparkrun.containers.distribute.distribute_image_from_head")
     @mock.patch("sparkrun.orchestration.distribution.is_control_in_cluster", return_value=False)
     @mock.patch("sparkrun.orchestration.infiniband.validate_ib_connectivity")

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.2.36
+sparkrun: 0.2.37
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
This pull request addresses a regression in how InfiniBand (IB) IPs are selected for control-to-host transfers in "local" transfer mode, particularly for mesh/ring network topologies. The update ensures that only reachability-verified IB IPs are used, rather than the first detected candidate, which may be unreachable. It also adds a regression test to prevent this issue from recurring and bumps the project version.

**InfiniBand IP selection and transfer logic fixes:**

* Updated `distribute_resources` and `distribute_from_config` in `src/sparkrun/orchestration/distribution.py` to use the reachability-verified `_ib_validated` IP map for control-to-host transfers in "local" mode, instead of the first detected IB IP per host. This resolves issues on mesh/ring fabrics where the first candidate may be unreachable. [[1]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573L501-R512) [[2]](diffhunk://#diff-1f5344604aff28e969ce34e9655849ddea31fb1281f0bb785608820c6889d573R764-R768)

**Testing improvements:**

* Added a regression test `test_local_mode_uses_validated_ib_ips_not_first_candidate` in `tests/test_distribute.py` to ensure that only reachability-verified IB IPs are used for transfers, mirroring a real-world mesh/ring scenario.

**Version bump:**

* Bumped the project version to `0.2.37` in both `pyproject.toml` and `versions.yaml` to reflect these changes. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)