### PR TITLE
fix: detect local IP when installed directly on DGX Spark

### DIFF
--- a/src/sparkrun/core/hosts.py
+++ b/src/sparkrun/core/hosts.py
@@ -6,13 +6,32 @@ Resolves hosts from CLI args, files, cluster manager, or config defaults.
 from __future__ import annotations
 
 import logging
+import re
 import socket
+import subprocess
 from pathlib import Path
 
 from sparkrun.core.cluster_manager import ClusterError, ClusterManager
 from sparkrun.utils import is_local_host  # noqa: F401 re-exported for backward compat
 
 logger = logging.getLogger(__name__)
+
+_IP_ADDR_RE = re.compile(r"\binet6?\s+([0-9a-fA-F.:]+)")
+
+
+def _collect_interface_ips() -> set[str]:
+    """Enumerate IPs bound to local interfaces via ``ip -o addr show``.
+
+    Why: socket.getaddrinfo(gethostname()) misses interface IPs that aren't in
+    DNS/hosts (common on DGX Spark, where the LAN IP isn't mapped to the host).
+    """
+    try:
+        result = subprocess.run(["ip", "-o", "addr", "show"], capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if result.returncode != 0:
+        return set()
+    return {m.group(1).split("%")[0] for m in _IP_ADDR_RE.finditer(result.stdout)}
 
 
 def _get_local_identifiers() -> set[str]:
@@ -41,6 +60,8 @@ def _get_local_identifiers() -> set[str]:
                 identifiers.add(info[4][0])
         except (OSError, socket.gaierror):
             pass
+
+    identifiers.update(_collect_interface_ips())
 
     return identifiers
 

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -239,6 +239,12 @@ def test_resolve_hosts_whitespace_only_string_returns_empty():
 class TestIsControlInCluster:
     """Tests for is_control_in_cluster() local membership detection."""
 
+    @pytest.fixture(autouse=True)
+    def _no_interface_ips(self):
+        """Default to no interface IPs so tests can mock socket alone."""
+        with mock.patch("sparkrun.core.hosts._collect_interface_ips", return_value=set()):
+            yield
+
     @mock.patch("sparkrun.core.hosts.socket")
     def test_hostname_match(self, mock_socket):
         """Returns True when hostname matches a host in the list."""
@@ -337,3 +343,15 @@ class TestIsControlInCluster:
         mock_socket.gaierror = OSError
 
         assert is_control_in_cluster([]) is False
+
+    @mock.patch("sparkrun.core.hosts._collect_interface_ips", return_value={"192.168.1.157", "127.0.0.1"})
+    @mock.patch("sparkrun.core.hosts.socket")
+    def test_interface_ip_match_when_hostname_not_in_dns(self, mock_socket, _mock_ips):
+        """Regression: hostname resolves only to 127.0.0.1 but a LAN interface
+        IP matches the cluster — should detect local membership."""
+        mock_socket.gethostname.return_value = "spark-9a09"
+        mock_socket.getfqdn.return_value = "localhost"
+        mock_socket.getaddrinfo.return_value = [(None, None, None, None, ("127.0.0.1",))]
+        mock_socket.gaierror = OSError
+
+        assert is_control_in_cluster(["192.168.1.157"]) is True


### PR DESCRIPTION
When `sparkrun` is installed directly on the DGX spark and the cluster ip is entered as the Spark's local IP in the network, some configurations can't be run. For example atlas recipes for Qwen3.6 work, however eugr vLLM build fail without a clean error. 



```shell
sparkrun run @spark-arena/e8e202f4-c7af-4aaa-87c4-ef2ad9cfba59

...

  File "/home/dogacel/.local/share/uv/tools/sparkrun/lib/python3.12/site-packages/sparkrun/builders/eugr.py", line 400, in prepare_image
    self._build_image_remote(image, effective_build_args, head, ssh_kwargs, dry_run, config=config, save_logs=save_build_logs)
  File "/home/dogacel/.local/share/uv/tools/sparkrun/lib/python3.12/site-packages/sparkrun/builders/eugr.py", line 1182, in _build_image_remote
    raise RuntimeError(
RuntimeError: eugr remote container build failed on 192.168.1.157 (exit 255); phase=unknown
(full log: /home/dogacel/.cache/sparkrun/eugr-builds/vllm-node-20260528-024528-remote-192.168.1.157.log)
```

After applying the fix the image is building properly.

The commit content is AI generated by manually validated by me.