### PR TITLE
fix(cli): add missing api_key_env positional arg in arena_benchmark_run

### DIFF
--- a/src/sparkrun/cli/_arena.py
+++ b/src/sparkrun/cli/_arena.py
@@ -239,6 +239,7 @@ def arena_benchmark_run(
         framework,
         output_file,
         bench_options,
+        None,  # api_key_env
         exit_on_first_fail,
         no_stop,
         skip_run,


### PR DESCRIPTION
When running `sparkrun arena benchmark` it failed with `TypeError: _run_benchmark() missing 1 required positional argument: 'dry_run'`. This happened because `api_key_env` was not passed in the positional args list.