### PR TITLE
Enable multi-node node-count for Atlas EP/TP cluster deploys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.38"
+version = "0.2.39"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -351,9 +351,10 @@ class AtlasRuntime(RuntimePlugin):
         else:
             result = tp * ep
 
-        if result > 1:
-            raise ValueError("Atlas runtime currently only supports single node. Support for multiple nodes is coming soon.")
-
+        # result > 1 drives the native NCCL cluster path: generate_node_command()
+        # assigns per-rank --rank/--world-size/--master-addr/--master-port and the
+        # cluster env carries the validated GB10 RoCEv2 NCCL settings. The published
+        # EP=2 recipes (qwen3.5-122b-a10b, minimax-m2.7) require this to launch.
         return result
 
     # --- Cluster env ---

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -178,27 +178,25 @@ def test_atlas_compute_required_nodes_solo():
     assert runtime.compute_required_nodes(_recipe()) is None
 
 
-# TODO: re-enable tests with multi-node / distributed support
-#
-# def test_atlas_compute_required_nodes_pure_ep():
-#     """ep_size=2, tp=1 → 2 nodes."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"ep_size": 2})
-#     assert runtime.compute_required_nodes(recipe) == 2
-#
-#
-# def test_atlas_compute_required_nodes_overlapping_tp_ep():
-#     """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
-#     assert runtime.compute_required_nodes(recipe) == 2
-#
-#
-# def test_atlas_compute_required_nodes_orthogonal_tp_ep():
-#     """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
-#     assert runtime.compute_required_nodes(recipe) == 8
+def test_atlas_compute_required_nodes_pure_ep():
+    """ep_size=2, tp=1 → 2 nodes."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"ep_size": 2})
+    assert runtime.compute_required_nodes(recipe) == 2
+
+
+def test_atlas_compute_required_nodes_overlapping_tp_ep():
+    """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
+    assert runtime.compute_required_nodes(recipe) == 2
+
+
+def test_atlas_compute_required_nodes_orthogonal_tp_ep():
+    """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
+    assert runtime.compute_required_nodes(recipe) == 8
 
 
 # --- Cluster env / docker opts ---

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.2.38
+sparkrun: 0.2.39
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
## Enable multi-node node-count for Atlas EP/TP cluster deploys

### Problem

`AtlasRuntime.compute_required_nodes()` hard-raised the moment a recipe needed more than one node:

```python
if result > 1:
    raise ValueError("Atlas runtime currently only supports single node. "
                     "Support for multiple nodes is coming soon.")
```

That refusal fires at the node-count gate, *before* any orchestration runs. So every published EP=2 recipe is dead on arrival:

- `official-recipes/qwen3.5/atlas/qwen3.5-122b-a10b-nvfp4-ep2-atlas.yaml` (`min_nodes: 2`, `ep_size: 2`)
- `official-recipes/minimax-m2.7/atlas/minimax-m2.7-nvfp4-ep2-atlas.yaml` (`min_nodes: 2`, `ep_size: 2`)

These same models are advertised as available on atlasinference.io (EP2 badges; "EP=2 = Expert Parallelism across two nodes"). A two-node operator who follows the site and runs `sparkrun run @atlas/...-ep2-atlas --hosts ip1,ip2` hits the `ValueError` immediately — there is currently no working path from the published recipes/marketing to an actual EP=2 launch.

The node-count path was previously enabled (`48bb169`) and then reverted (`d1187bf`) with **no recorded reason** (bare "This reverts commit ..."). @dbotwinick — if there was an off-record reason to hold this back, flag it before merge.

### Change

Removes the `result > 1` guard. **Scope is strictly the multi-node branch:**

- `tp <= 1 and ep <= 1` → still returns `None`
- `result == 1` → still returns `1`
- `result > 1` → now returns the node count instead of raising, flowing into the **already-implemented and already-tested** native NCCL cluster path: `generate_node_command()` assigns per-rank `--rank` / `--world-size` / `--master-addr` / `--master-port`, and `get_cluster_env()` carries the validated GB10 RoCEv2 NCCL settings.

Single-node deploys — the only ones that work today — are byte-identical.

Restores the three `compute_required_nodes` multi-node tests (pure-EP → 2, overlapping `tp==ep` → 2, orthogonal `tp*ep` → 8) that were commented out in `038dc36` "pending distributed support implementation."

### Scope / honesty

This lifts the gate so the path **runs**; it does not by itself prove 2-node serves coherently. The intent is to let a two-node operator drive the real orchestration and surface genuine runtime issues (IB/RoCE exposure, NCCL ring formation) instead of being stopped by a Python guard. End-to-end EP=2 validation on two Sparks over IB is the follow-up.

### Verification

- Full suite: **2568 passed** (`pytest tests/`)
- The 3 restored multi-node tests: green
- `ruff check src/sparkrun/runtimes/atlas.py tests/test_atlas_runtime.py`: clean
- Version bumped `0.2.38 → 0.2.39` (authoritative `versions.yaml` → `pyproject.toml`), `update-versions.py --check`: in sync — required so a `uvx sparkrun` operator can actually pull the fix (0.2.38 is current on PyPI).
