### PR TITLE
feat(executor): add executor_config.entrypoint to override image ENTRYPOINT

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -227,6 +227,14 @@ executor_config:
 | `ipc`            | string | `"host"`    | `--ipc`        | IPC namespace                                                                                                       |
 | `shm_size`       | string | `"10.24gb"` | `--shm-size`   | Shared memory size                                                                                                  |
 | `network`        | string | `"host"`    | `--network`    | Network mode                                                                                                        |
+| `entrypoint`     | string | `null`      | `--entrypoint` | Override the image `ENTRYPOINT`. `null` leaves it untouched; `""` clears it so the serve command runs directly       |
+
+**`entrypoint`** is for images that ship their own `ENTRYPOINT`. sparkrun launches the container as `<image> bash -c <command>`, so an image whose `ENTRYPOINT` swallows or wraps that command will fail to serve. Set `entrypoint: ""` to neutralize it — no need to rebuild the image with an emptied entrypoint:
+
+```yaml
+executor_config:
+  entrypoint: ""   # clear the image's ENTRYPOINT
+```
 
 **CLI override:** `sparkrun run --no-rm --restart always my-recipe`
 

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -476,11 +476,13 @@ def launch_inference(
     if not isinstance(recipe_executor_config, dict):
         recipe_executor_config = {}
     cli_exec_opts = executor_config if isinstance(executor_config, dict) else {}
+    runtime_exec_defaults = runtime.get_executor_config_defaults() or {}
     exec_chain = Variables(
         sources=(
             cli_exec_opts,  # CLI flags (highest priority)
             recipe_executor_config,  # recipe YAML
             exec_adjustments,  # executor adjustments
+            runtime_exec_defaults,  # runtime-specific defaults
             EXECUTOR_DEFAULTS,  # hardcoded defaults
         ),
         env_placement=EnvPlacement.IGNORED,

--- a/src/sparkrun/orchestration/executor.py
+++ b/src/sparkrun/orchestration/executor.py
@@ -36,6 +36,7 @@ EXECUTOR_DEFAULTS = {
     "cap_add": None,
     "ulimit": None,
     "devices": None,
+    "entrypoint": None,
 }
 
 
@@ -61,6 +62,7 @@ class ExecutorConfig:
     devices: list[str] | None = None
     memory_limit: str | None = None
     labels: list[str] | None = None
+    entrypoint: str | None = None
 
     @classmethod
     def from_chain(cls, chain) -> ExecutorConfig:
@@ -105,6 +107,10 @@ class ExecutorConfig:
             devices=raw_devices or None,
             memory_limit=chain.get("memory_limit") or None,
             labels=raw_labels or None,
+            # NOTE: do not collapse with ``or None`` -- an empty string is a
+            # meaningful value here ("" clears the image's ENTRYPOINT), distinct
+            # from None ("not set", leave the image's ENTRYPOINT untouched).
+            entrypoint=chain.get("entrypoint"),
         )
 
     def __post_init__(self):

--- a/src/sparkrun/orchestration/executor_docker.py
+++ b/src/sparkrun/orchestration/executor_docker.py
@@ -22,6 +22,11 @@ class DockerExecutor(Executor):
         cfg = self.config
         opts: list[str] = []
 
+        if cfg.entrypoint is not None:
+            # ``--entrypoint ''`` clears an image's own ENTRYPOINT so the
+            # generated ``bash -c <command>`` runs directly. ``is not None``
+            # (not truthiness) is deliberate: "" is the clear-it value.
+            opts.extend(["--entrypoint", quote(cfg.entrypoint)])
         if cfg.privileged:
             opts.append("--privileged")
         if cfg.gpus:

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -391,6 +391,17 @@ class AtlasRuntime(RuntimePlugin):
             "NCCL_MAX_NCHANNELS": "2",
         }
 
+    def get_executor_config_defaults(self) -> dict:
+        """Clear the image's ENTRYPOINT so the generated ``bash -c`` runs.
+
+        The Atlas image ships its own ENTRYPOINT; sparkrun launches the
+        container with ``bash -c <command>``, so the entrypoint must be
+        cleared. Routed through ``executor_config`` (rather than a raw
+        ``--entrypoint`` in ``get_extra_docker_opts``) so a recipe can
+        still override it.
+        """
+        return {"entrypoint": ""}
+
     def get_extra_docker_opts(self) -> list[str]:
         """RDMA device + capabilities required by Atlas's NCCL/io_uring paths.
 
@@ -399,12 +410,13 @@ class AtlasRuntime(RuntimePlugin):
         run the storage path unconfined. ``IPC_LOCK`` + ``memlock=-1``
         unblock ``ibv_reg_mr``; ``SYS_NICE`` is needed by the SQPOLL
         kernel thread.
+
+        The ENTRYPOINT clear lives in ``get_executor_config_defaults`` so
+        recipes can override it; ``cap_add``/``security_opt`` stay here as
+        unconditional appends (they must not be dropped by, e.g., rootless
+        mode zeroing ``cap_add`` in the executor config chain).
         """
-        # TODO: this should transition to be executor_config pass-through [FUTURE; works well enough today]
         return [
-            # Allow bash
-            "--entrypoint",
-            '""',
             "--cap-add=IPC_LOCK",
             "--cap-add=SYS_NICE",
             "--security-opt",

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -306,6 +306,20 @@ class RuntimePlugin(Plugin):
         """
         return []
 
+    def get_executor_config_defaults(self) -> dict:
+        """Runtime-level defaults merged into the executor config chain.
+
+        Override to set executor options (e.g. ``entrypoint``) that should
+        apply by default for this runtime but remain overridable by the
+        recipe's ``executor_config`` and CLI flags. Sits just above the
+        built-in ``EXECUTOR_DEFAULTS`` in priority, so both the recipe and
+        the CLI win over it.
+
+        Returns:
+            Dict of executor config keys -> values (empty by default).
+        """
+        return {}
+
     def validate_recipe(self, recipe: Recipe) -> list[str]:
         """Return list of warnings/errors for runtime-specific fields.
 

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -229,6 +229,14 @@ def test_atlas_extra_docker_opts_include_required_capabilities():
     assert "seccomp=unconfined" in joined
 
 
+def test_atlas_clears_entrypoint_via_executor_config():
+    """Atlas clears the image ENTRYPOINT through executor_config, not raw docker opts."""
+    runtime = AtlasRuntime()
+    assert runtime.get_executor_config_defaults() == {"entrypoint": ""}
+    # The entrypoint must NOT be re-injected as a raw flag (would double up / not be overridable).
+    assert "--entrypoint" not in " ".join(runtime.get_extra_docker_opts())
+
+
 # --- validate_recipe ---
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -115,6 +115,41 @@ class TestExecutorConfig:
         cfg = ExecutorConfig.from_chain(chain)
         assert cfg.memory_limit == "16G"
 
+    def test_entrypoint_default_none(self):
+        assert ExecutorConfig().entrypoint is None
+
+    def test_from_chain_entrypoint_value(self):
+        cfg = ExecutorConfig.from_chain({"entrypoint": "bash"})
+        assert cfg.entrypoint == "bash"
+
+    def test_from_chain_entrypoint_empty_preserved(self):
+        """Empty string is a meaningful value ("clear ENTRYPOINT"), not None."""
+        cfg = ExecutorConfig.from_chain({"entrypoint": ""})
+        assert cfg.entrypoint == ""
+
+    def test_from_chain_entrypoint_unset_is_none(self):
+        cfg = ExecutorConfig.from_chain({"gpus": "0"})
+        assert cfg.entrypoint is None
+
+    def test_config_chain_entrypoint_empty_survives_layering(self):
+        """A runtime default of "" survives the Variables chain and beats EXECUTOR_DEFAULTS."""
+        from scitrera_app_framework.api import EnvPlacement, Variables
+
+        runtime_defaults = {"entrypoint": ""}
+        chain = Variables(sources=({}, {}, runtime_defaults, EXECUTOR_DEFAULTS), env_placement=EnvPlacement.IGNORED)
+        cfg = ExecutorConfig.from_chain(chain)
+        assert cfg.entrypoint == ""
+
+    def test_config_chain_recipe_overrides_runtime_entrypoint(self):
+        """Recipe executor_config wins over a runtime-supplied entrypoint default."""
+        from scitrera_app_framework.api import EnvPlacement, Variables
+
+        recipe_opts = {"entrypoint": "bash"}
+        runtime_defaults = {"entrypoint": ""}
+        chain = Variables(sources=({}, recipe_opts, {}, runtime_defaults, EXECUTOR_DEFAULTS), env_placement=EnvPlacement.IGNORED)
+        cfg = ExecutorConfig.from_chain(chain)
+        assert cfg.entrypoint == "bash"
+
     def test_config_chain_layering(self):
         """Verify config chain resolution: CLI > recipe > defaults."""
         from scitrera_app_framework.api import EnvPlacement, Variables
@@ -217,6 +252,23 @@ class TestDockerExecutorConfig:
         executor = DockerExecutor(cfg)
         cmd = executor.run_cmd("img:latest")
         assert "--network=bridge" in cmd
+
+    def test_entrypoint_unset_omits_flag(self):
+        cmd = DockerExecutor(ExecutorConfig()).run_cmd("img:latest")
+        assert "--entrypoint" not in cmd
+
+    def test_entrypoint_empty_clears(self):
+        cmd = DockerExecutor(ExecutorConfig(entrypoint="")).run_cmd("img:latest")
+        assert "--entrypoint ''" in cmd
+
+    def test_entrypoint_value(self):
+        cmd = DockerExecutor(ExecutorConfig(entrypoint="bash")).run_cmd("img:latest")
+        assert "--entrypoint bash" in cmd
+
+    def test_entrypoint_precedes_image(self):
+        """--entrypoint must come before the image, or docker rejects it."""
+        cmd = DockerExecutor(ExecutorConfig(entrypoint="")).run_cmd("img:latest", command="vllm serve")
+        assert cmd.index("--entrypoint") < cmd.index("img:latest")
 
     def test_memory_limit(self):
         cfg = ExecutorConfig(memory_limit="64G")

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -651,6 +651,15 @@ def test_sglang_speculative_skip_key_strips_flag():
     assert "--speculative-draft-model-path" not in cmd
 
 
+# --- Executor config defaults hook ---
+
+
+def test_base_runtime_executor_config_defaults_empty():
+    """Base runtimes contribute no executor config defaults."""
+    assert VllmDistributedRuntime().get_executor_config_defaults() == {}
+    assert SglangRuntime().get_executor_config_defaults() == {}
+
+
 # --- VllmDistributedRuntime Tests ---
 
 


### PR DESCRIPTION
Motivation:

It would be nice to be able to use existing containers and override the entrypoint in the recipe. Presently you can do this via an extra command line argument, for example recipes like  https://forums.developer.nvidia.com/t/whats-the-best-speed-we-can-get-with-qwen-3-6-27b-without-quantizing/367561/47 

Can use:

```
sparkrun run /tmp/aeon-qwen3.6-27b-noentry.yaml --executor-args=--entrypoint=
```

But it is easy to forget this.   This PR allows you to bake this into the recipe via an executor_config block:

```
executor_config:                                                                                                                                                                
  entrypoint: ""                                                                                                                                                                
```

So in summary as for images that ship its own ENTRYPOINT  the only workarounds are rebuilding the image with an emptied ENTRYPOINT or passing `--executor-args=--entrypoint=` on the CLI, neither is expressible in a shareable recipe.

Changes implemented:

Add an `entrypoint` key to `executor_config` that maps to `--entrypoint`. `null` (default) leaves the image untouched; `""` clears it so the serve command runs directly. Empty string is preserved through the config chain (not collapsed to None) since "" is the meaningful "clear it" value.

Also add a `RuntimePlugin.get_executor_config_defaults()` hook so runtimes can supply executor-config defaults (overridable by recipe/CLI), and route Atlas's ENTRYPOINT clear through it — closing the long-standing "transition to executor_config pass-through" TODO. Atlas's cap_add / security_opt stay in get_extra_docker_opts() as unconditional appends so they aren't dropped by rootless mode zeroing cap_add in the config chain.

Verified end-to-end via running: an aeon-vllm-ultimate recipe with `executor_config: {entrypoint: ""} removing the need for a wrapper image.