### PR TITLE
v0.2.39

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -227,6 +227,14 @@ executor_config:
 | `ipc`            | string | `"host"`    | `--ipc`        | IPC namespace                                                                                                       |
 | `shm_size`       | string | `"10.24gb"` | `--shm-size`   | Shared memory size                                                                                                  |
 | `network`        | string | `"host"`    | `--network`    | Network mode                                                                                                        |
+| `entrypoint`     | string | `null`      | `--entrypoint` | Override the image `ENTRYPOINT`. `null` leaves it untouched; `""` clears it so the serve command runs directly       |
+
+**`entrypoint`** is for images that ship their own `ENTRYPOINT`. sparkrun launches the container as `<image> bash -c <command>`, so an image whose `ENTRYPOINT` swallows or wraps that command will fail to serve. Set `entrypoint: ""` to neutralize it — no need to rebuild the image with an emptied entrypoint:
+
+```yaml
+executor_config:
+  entrypoint: ""   # clear the image's ENTRYPOINT
+```
 
 **CLI override:** `sparkrun run --no-rm --restart always my-recipe`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.38"
+version = "0.2.39"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/cli/_arena.py
+++ b/src/sparkrun/cli/_arena.py
@@ -239,6 +239,7 @@ def arena_benchmark_run(
         framework,
         output_file,
         bench_options,
+        None,  # api_key_env
         exit_on_first_fail,
         no_stop,
         skip_run,

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -476,11 +476,13 @@ def launch_inference(
     if not isinstance(recipe_executor_config, dict):
         recipe_executor_config = {}
     cli_exec_opts = executor_config if isinstance(executor_config, dict) else {}
+    runtime_exec_defaults = runtime.get_executor_config_defaults() or {}
     exec_chain = Variables(
         sources=(
             cli_exec_opts,  # CLI flags (highest priority)
             recipe_executor_config,  # recipe YAML
             exec_adjustments,  # executor adjustments
+            runtime_exec_defaults,  # runtime-specific defaults
             EXECUTOR_DEFAULTS,  # hardcoded defaults
         ),
         env_placement=EnvPlacement.IGNORED,

--- a/src/sparkrun/orchestration/executor.py
+++ b/src/sparkrun/orchestration/executor.py
@@ -36,6 +36,7 @@ EXECUTOR_DEFAULTS = {
     "cap_add": None,
     "ulimit": None,
     "devices": None,
+    "entrypoint": None,
 }
 
 
@@ -61,6 +62,7 @@ class ExecutorConfig:
     devices: list[str] | None = None
     memory_limit: str | None = None
     labels: list[str] | None = None
+    entrypoint: str | None = None
 
     @classmethod
     def from_chain(cls, chain) -> ExecutorConfig:
@@ -105,6 +107,10 @@ class ExecutorConfig:
             devices=raw_devices or None,
             memory_limit=chain.get("memory_limit") or None,
             labels=raw_labels or None,
+            # NOTE: do not collapse with ``or None`` -- an empty string is a
+            # meaningful value here ("" clears the image's ENTRYPOINT), distinct
+            # from None ("not set", leave the image's ENTRYPOINT untouched).
+            entrypoint=chain.get("entrypoint"),
         )
 
     def __post_init__(self):

--- a/src/sparkrun/orchestration/executor_docker.py
+++ b/src/sparkrun/orchestration/executor_docker.py
@@ -22,6 +22,11 @@ class DockerExecutor(Executor):
         cfg = self.config
         opts: list[str] = []
 
+        if cfg.entrypoint is not None:
+            # ``--entrypoint ''`` clears an image's own ENTRYPOINT so the
+            # generated ``bash -c <command>`` runs directly. ``is not None``
+            # (not truthiness) is deliberate: "" is the clear-it value.
+            opts.extend(["--entrypoint", quote(cfg.entrypoint)])
         if cfg.privileged:
             opts.append("--privileged")
         if cfg.gpus:

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -391,6 +391,17 @@ class AtlasRuntime(RuntimePlugin):
             "NCCL_MAX_NCHANNELS": "2",
         }
 
+    def get_executor_config_defaults(self) -> dict:
+        """Clear the image's ENTRYPOINT so the generated ``bash -c`` runs.
+
+        The Atlas image ships its own ENTRYPOINT; sparkrun launches the
+        container with ``bash -c <command>``, so the entrypoint must be
+        cleared. Routed through ``executor_config`` (rather than a raw
+        ``--entrypoint`` in ``get_extra_docker_opts``) so a recipe can
+        still override it.
+        """
+        return {"entrypoint": ""}
+
     def get_extra_docker_opts(self) -> list[str]:
         """RDMA device + capabilities required by Atlas's NCCL/io_uring paths.
 
@@ -399,12 +410,13 @@ class AtlasRuntime(RuntimePlugin):
         run the storage path unconfined. ``IPC_LOCK`` + ``memlock=-1``
         unblock ``ibv_reg_mr``; ``SYS_NICE`` is needed by the SQPOLL
         kernel thread.
+
+        The ENTRYPOINT clear lives in ``get_executor_config_defaults`` so
+        recipes can override it; ``cap_add``/``security_opt`` stay here as
+        unconditional appends (they must not be dropped by, e.g., rootless
+        mode zeroing ``cap_add`` in the executor config chain).
         """
-        # TODO: this should transition to be executor_config pass-through [FUTURE; works well enough today]
         return [
-            # Allow bash
-            "--entrypoint",
-            '""',
             "--cap-add=IPC_LOCK",
             "--cap-add=SYS_NICE",
             "--security-opt",

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -351,9 +351,10 @@ class AtlasRuntime(RuntimePlugin):
         else:
             result = tp * ep
 
-        if result > 1:
-            raise ValueError("Atlas runtime currently only supports single node. Support for multiple nodes is coming soon.")
-
+        # result > 1 drives the native NCCL cluster path: generate_node_command()
+        # assigns per-rank --rank/--world-size/--master-addr/--master-port and the
+        # cluster env carries the validated GB10 RoCEv2 NCCL settings. The published
+        # EP=2 recipes (qwen3.5-122b-a10b, minimax-m2.7) require this to launch.
         return result
 
     # --- Cluster env ---

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -306,6 +306,20 @@ class RuntimePlugin(Plugin):
         """
         return []
 
+    def get_executor_config_defaults(self) -> dict:
+        """Runtime-level defaults merged into the executor config chain.
+
+        Override to set executor options (e.g. ``entrypoint``) that should
+        apply by default for this runtime but remain overridable by the
+        recipe's ``executor_config`` and CLI flags. Sits just above the
+        built-in ``EXECUTOR_DEFAULTS`` in priority, so both the recipe and
+        the CLI win over it.
+
+        Returns:
+            Dict of executor config keys -> values (empty by default).
+        """
+        return {}
+
     def validate_recipe(self, recipe: Recipe) -> list[str]:
         """Return list of warnings/errors for runtime-specific fields.
 

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -178,27 +178,25 @@ def test_atlas_compute_required_nodes_solo():
     assert runtime.compute_required_nodes(_recipe()) is None
 
 
-# TODO: re-enable tests with multi-node / distributed support
-#
-# def test_atlas_compute_required_nodes_pure_ep():
-#     """ep_size=2, tp=1 → 2 nodes."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"ep_size": 2})
-#     assert runtime.compute_required_nodes(recipe) == 2
-#
-#
-# def test_atlas_compute_required_nodes_overlapping_tp_ep():
-#     """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
-#     assert runtime.compute_required_nodes(recipe) == 2
-#
-#
-# def test_atlas_compute_required_nodes_orthogonal_tp_ep():
-#     """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
-#     runtime = AtlasRuntime()
-#     recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
-#     assert runtime.compute_required_nodes(recipe) == 8
+def test_atlas_compute_required_nodes_pure_ep():
+    """ep_size=2, tp=1 → 2 nodes."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"ep_size": 2})
+    assert runtime.compute_required_nodes(recipe) == 2
+
+
+def test_atlas_compute_required_nodes_overlapping_tp_ep():
+    """tp=2, ep=2 → 2 nodes (overlapping groups, not 4)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 2})
+    assert runtime.compute_required_nodes(recipe) == 2
+
+
+def test_atlas_compute_required_nodes_orthogonal_tp_ep():
+    """tp=2, ep=4 → 8 nodes (orthogonal mesh)."""
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"tensor_parallel": 2, "ep_size": 4})
+    assert runtime.compute_required_nodes(recipe) == 8
 
 
 # --- Cluster env / docker opts ---

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -229,6 +229,14 @@ def test_atlas_extra_docker_opts_include_required_capabilities():
     assert "seccomp=unconfined" in joined
 
 
+def test_atlas_clears_entrypoint_via_executor_config():
+    """Atlas clears the image ENTRYPOINT through executor_config, not raw docker opts."""
+    runtime = AtlasRuntime()
+    assert runtime.get_executor_config_defaults() == {"entrypoint": ""}
+    # The entrypoint must NOT be re-injected as a raw flag (would double up / not be overridable).
+    assert "--entrypoint" not in " ".join(runtime.get_extra_docker_opts())
+
+
 # --- validate_recipe ---
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -115,6 +115,41 @@ class TestExecutorConfig:
         cfg = ExecutorConfig.from_chain(chain)
         assert cfg.memory_limit == "16G"
 
+    def test_entrypoint_default_none(self):
+        assert ExecutorConfig().entrypoint is None
+
+    def test_from_chain_entrypoint_value(self):
+        cfg = ExecutorConfig.from_chain({"entrypoint": "bash"})
+        assert cfg.entrypoint == "bash"
+
+    def test_from_chain_entrypoint_empty_preserved(self):
+        """Empty string is a meaningful value ("clear ENTRYPOINT"), not None."""
+        cfg = ExecutorConfig.from_chain({"entrypoint": ""})
+        assert cfg.entrypoint == ""
+
+    def test_from_chain_entrypoint_unset_is_none(self):
+        cfg = ExecutorConfig.from_chain({"gpus": "0"})
+        assert cfg.entrypoint is None
+
+    def test_config_chain_entrypoint_empty_survives_layering(self):
+        """A runtime default of "" survives the Variables chain and beats EXECUTOR_DEFAULTS."""
+        from scitrera_app_framework.api import EnvPlacement, Variables
+
+        runtime_defaults = {"entrypoint": ""}
+        chain = Variables(sources=({}, {}, runtime_defaults, EXECUTOR_DEFAULTS), env_placement=EnvPlacement.IGNORED)
+        cfg = ExecutorConfig.from_chain(chain)
+        assert cfg.entrypoint == ""
+
+    def test_config_chain_recipe_overrides_runtime_entrypoint(self):
+        """Recipe executor_config wins over a runtime-supplied entrypoint default."""
+        from scitrera_app_framework.api import EnvPlacement, Variables
+
+        recipe_opts = {"entrypoint": "bash"}
+        runtime_defaults = {"entrypoint": ""}
+        chain = Variables(sources=({}, recipe_opts, {}, runtime_defaults, EXECUTOR_DEFAULTS), env_placement=EnvPlacement.IGNORED)
+        cfg = ExecutorConfig.from_chain(chain)
+        assert cfg.entrypoint == "bash"
+
     def test_config_chain_layering(self):
         """Verify config chain resolution: CLI > recipe > defaults."""
         from scitrera_app_framework.api import EnvPlacement, Variables
@@ -217,6 +252,23 @@ class TestDockerExecutorConfig:
         executor = DockerExecutor(cfg)
         cmd = executor.run_cmd("img:latest")
         assert "--network=bridge" in cmd
+
+    def test_entrypoint_unset_omits_flag(self):
+        cmd = DockerExecutor(ExecutorConfig()).run_cmd("img:latest")
+        assert "--entrypoint" not in cmd
+
+    def test_entrypoint_empty_clears(self):
+        cmd = DockerExecutor(ExecutorConfig(entrypoint="")).run_cmd("img:latest")
+        assert "--entrypoint ''" in cmd
+
+    def test_entrypoint_value(self):
+        cmd = DockerExecutor(ExecutorConfig(entrypoint="bash")).run_cmd("img:latest")
+        assert "--entrypoint bash" in cmd
+
+    def test_entrypoint_precedes_image(self):
+        """--entrypoint must come before the image, or docker rejects it."""
+        cmd = DockerExecutor(ExecutorConfig(entrypoint="")).run_cmd("img:latest", command="vllm serve")
+        assert cmd.index("--entrypoint") < cmd.index("img:latest")
 
     def test_memory_limit(self):
         cfg = ExecutorConfig(memory_limit="64G")

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -651,6 +651,15 @@ def test_sglang_speculative_skip_key_strips_flag():
     assert "--speculative-draft-model-path" not in cmd
 
 
+# --- Executor config defaults hook ---
+
+
+def test_base_runtime_executor_config_defaults_empty():
+    """Base runtimes contribute no executor config defaults."""
+    assert VllmDistributedRuntime().get_executor_config_defaults() == {}
+    assert SglangRuntime().get_executor_config_defaults() == {}
+
+
 # --- VllmDistributedRuntime Tests ---
 
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.2.38
+sparkrun: 0.2.39
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
This pull request introduces support for overriding or clearing the Docker image `ENTRYPOINT` via the `executor_config` in recipes and adds runtime-level executor config defaults. The main motivation is to ensure that containers launched by `sparkrun` can bypass or neutralize image-supplied entrypoints (especially for the Atlas runtime), improving flexibility and correctness without requiring image rebuilds. The changes also enable multi-node support for the Atlas runtime and expand test coverage accordingly.

**Executor ENTRYPOINT handling:**

- Added an `entrypoint` field to `executor_config`, allowing recipes and runtimes to override or clear the Docker image's `ENTRYPOINT` (set to `""` to clear, `null` to leave untouched) (`src/sparkrun/orchestration/executor.py`, `RECIPES.md`) [[1]](diffhunk://#diff-ced2aa65905401b0f3cc9777093b9be2d1c27d0093a83355a5a1a2a63b9bcbb1R39) [[2]](diffhunk://#diff-ced2aa65905401b0f3cc9777093b9be2d1c27d0093a83355a5a1a2a63b9bcbb1R65) [[3]](diffhunk://#diff-ced2aa65905401b0f3cc9777093b9be2d1c27d0093a83355a5a1a2a63b9bcbb1R110-R113) [[4]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611R230-R237).
- Updated Docker executor logic to correctly handle and position the `--entrypoint` flag, ensuring `""` clears the entrypoint and that the flag is omitted if unset (`src/sparkrun/orchestration/executor_docker.py`).

**Runtime-level executor config defaults:**

- Introduced a `get_executor_config_defaults` hook in the runtime base class, allowing runtimes to provide default executor config values (e.g., Atlas clears `ENTRYPOINT` by default) (`src/sparkrun/runtimes/base.py`, `src/sparkrun/runtimes/atlas.py`, `src/sparkrun/core/launcher.py`) [[1]](diffhunk://#diff-0c65883179e7c5488f6cb37101feaddef94a4507d5aeb0dad4b2003d36fcffd6R309-R322) [[2]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0R395-R405) [[3]](diffhunk://#diff-c52669c725e09ea433cd88d773b412bf68812178deba2cbca1da56f9ab6ef4aaR479-R485).
- Ensured that runtime defaults are properly layered and can be overridden by recipes or CLI flags.

**Atlas runtime improvements:**

- Enabled multi-node support in the Atlas runtime by removing the restriction to single-node launches and updating logic and tests accordingly (`src/sparkrun/runtimes/atlas.py`, `tests/test_atlas_runtime.py`) [[1]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0L354-R357) [[2]](diffhunk://#diff-78294529be27c0e059ddc6f8d17bfb7a69fc3fa23403edca50e62ba6af0d1e09L181-R199).
- Moved the entrypoint clearing logic from raw Docker options to executor config defaults, ensuring it remains overridable and not duplicated (`src/sparkrun/runtimes/atlas.py`, [[1]](diffhunk://#diff-78294529be27c0e059ddc6f8d17bfb7a69fc3fa23403edca50e62ba6af0d1e09R230-R237) [[2]](diffhunk://#diff-a12a3a7b98e777b7a87f9092a67f42f4beceb47c740877c3881dfcde67d529b0R414-L407).

**Testing and documentation:**

- Added and expanded tests for executor config layering, entrypoint handling, and runtime default behavior (`tests/test_executor.py`, `tests/test_runtimes.py`, `tests/test_atlas_runtime.py`) [[1]](diffhunk://#diff-e8b376bb67834a23d818191fe7a2accaf5a9e36fb4f9ee8d925012406d207465R118-R152) [[2]](diffhunk://#diff-e8b376bb67834a23d818191fe7a2accaf5a9e36fb4f9ee8d925012406d207465R256-R272) [[3]](diffhunk://#diff-80c11d57bbd61023f7c13d756732330933fcc3b99dee8e7f776fd448a231aa89R654-R662).
- Updated documentation to describe the new `entrypoint` option and its usage (`RECIPES.md`).

**Version bump:**

- Bumped the `sparkrun` version to `0.2.39` (`pyproject.toml`, `versions.yaml`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5).