### PR TITLE
fix(atlas): map high-speed-swap tuning sub-flags

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -205,6 +205,23 @@ Explicit `runtime` always wins. Command-hint detection only fires when `runtime`
 Any key can appear in `defaults` — there is no fixed schema. Runtime-specific keys (e.g. `tool_call_parser`, `ctx_size`,
 `n_gpu_layers`, `reasoning_parser`) are passed through to command template substitution.
 
+#### Atlas high-speed swap
+
+Atlas's block-level KV streaming (`--high-speed-swap`) is enabled with the boolean `high_speed_swap` key, but it
+also needs tuning keys to be usable — Atlas requires `--high-speed-swap-dir` whenever the toggle is set. These keys
+map to the corresponding `--high-speed-swap-*` flags:
+
+```yaml
+defaults:
+  high_speed_swap: true
+  high_speed_swap_dir: /mnt/nvme/atlas-hss      # required; must differ from the --swap-space-gb mount
+  high_speed_swap_gb: 64                          # total NVMe budget (GiB)
+  high_speed_swap_resident_blocks: 512           # HBM scratch slots
+  high_speed_swap_rank: 32                        # predictor low-rank dim
+  high_speed_swap_qd: 8                           # io_uring submission queue depth
+  high_speed_swap_cache_blocks_per_seq: 64       # per-sequence HBM cache cap
+```
+
 ---
 
 ## Executor Config

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -74,6 +74,20 @@ _ATLAS_FLAG_MAP = {
     "model_from_path": "--model-from-path",
     "cache_dir": "--cache-dir",
     "gpu_ordinal": "--gpu-ordinal",
+    # High-speed-swap tuning keys.  These configure the block-level KV
+    # streaming path enabled by the `high_speed_swap` boolean toggle
+    # below; without them the feature is enabled but unconfigurable from
+    # a recipe (`--high-speed-swap-dir` is required by Atlas when the
+    # toggle is set).  `--high-speed-swap-graph` is intentionally omitted:
+    # Atlas parses it as Option<bool> needing a lowercase `true`/`false`
+    # value, which the bare-toggle and Python-bool rendering paths here
+    # cannot emit safely.
+    "high_speed_swap_dir": "--high-speed-swap-dir",
+    "high_speed_swap_gb": "--high-speed-swap-gb",
+    "high_speed_swap_resident_blocks": "--high-speed-swap-resident-blocks",
+    "high_speed_swap_rank": "--high-speed-swap-rank",
+    "high_speed_swap_qd": "--high-speed-swap-qd",
+    "high_speed_swap_cache_blocks_per_seq": "--high-speed-swap-cache-blocks-per-seq",
     # Boolean toggles — present when truthy, omitted otherwise.  Listed
     # in `_ATLAS_BOOL_FLAGS` so build/strip helpers treat them correctly.
     "enable_prefix_caching": "--enable-prefix-caching",

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -78,6 +78,36 @@ def test_atlas_generate_command_bool_flags():
     assert "--high-speed-swap" not in cmd
 
 
+def test_atlas_high_speed_swap_subflags_render():
+    """High-speed-swap tuning keys map to their `--high-speed-swap-*` flags.
+
+    Regression: the `high_speed_swap` toggle was mapped but its required
+    sub-flags were not, so the feature could be turned on but not
+    configured from a recipe (Atlas requires `--high-speed-swap-dir`).
+    """
+    runtime = AtlasRuntime()
+    recipe = _recipe(
+        defaults={
+            "high_speed_swap": True,
+            "high_speed_swap_dir": "/mnt/nvme/atlas-hss",
+            "high_speed_swap_gb": 64,
+            "high_speed_swap_resident_blocks": 512,
+            "high_speed_swap_rank": 32,
+            "high_speed_swap_qd": 8,
+            "high_speed_swap_cache_blocks_per_seq": 64,
+        },
+    )
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--high-speed-swap" in cmd
+    assert "--high-speed-swap-dir /mnt/nvme/atlas-hss" in cmd
+    assert "--high-speed-swap-gb 64" in cmd
+    assert "--high-speed-swap-resident-blocks 512" in cmd
+    assert "--high-speed-swap-rank 32" in cmd
+    assert "--high-speed-swap-qd 8" in cmd
+    assert "--high-speed-swap-cache-blocks-per-seq 64" in cmd
+
+
 def test_atlas_generate_command_from_template():
     """Recipe with explicit command template renders it verbatim."""
     runtime = AtlasRuntime()


### PR DESCRIPTION
## Summary

The `high_speed_swap` boolean toggle is mapped in `_ATLAS_FLAG_MAP`, but none of the flags that configure it are. Atlas requires `--high-speed-swap-dir` whenever `--high-speed-swap` is set, so today the feature can be enabled from a recipe but not configured — which makes it effectively unusable from sparkrun.

This PR maps the six configurable sub-flags:

- `--high-speed-swap-dir`
- `--high-speed-swap-gb`
- `--high-speed-swap-resident-blocks`
- `--high-speed-swap-rank`
- `--high-speed-swap-qd`
- `--high-speed-swap-cache-blocks-per-seq`

`--high-speed-swap-graph` is intentionally left out: Atlas parses it as `Option<bool>` requiring a lowercase `true`/`false` value, which the bare-toggle and Python-bool rendering paths can't emit safely. Happy to add it if there's a preferred convention for tri-state flags.

## Changes

- `src/sparkrun/runtimes/atlas.py` — add the six sub-flags to `_ATLAS_FLAG_MAP`
- `tests/test_atlas_runtime.py` — regression test asserting the keys render to `--high-speed-swap-*`
- `RECIPES.md` — document the keys with an example

## Validation

Verified on a DGX Spark GB10 node with `avarok/atlas-gb10:latest`:

- Flag names cross-checked against `spark serve --help` from the image.
- `sparkrun run` with an Atlas recipe emits the flags and the server starts; Atlas reports the feature engaged with the configured values, e.g.
  `--high-speed-swap enabled: dir=..., budget=32 GiB, scratch=256 blocks, rank=32, qd=8`.
- Served `/v1/chat/completions` successfully with the feature active.
- `ruff check` and `pytest tests/test_atlas_runtime.py` pass.

## Note (possible follow-up)

`high_speed_swap_dir` must point to a path writable inside the container. Since the runtime currently bind-mounts only the Hugging Face cache, a swap dir outside a mounted volume fails with a permission error at startup. A natural follow-up would be to bind-mount the configured swap dir; kept out of scope here so this change stays limited to flag mapping.
