### PR TITLE
fix(recipe): collapse v1 brace escapes in commands; guard non-string defaults (#213)

### DIFF
--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -325,6 +325,18 @@ def _resolve_runtime_from_command_hint(recipe: Recipe) -> None:
         recipe.runtime = "trtllm"
 
 
+def _collapse_brace_escapes(value: str) -> str:
+    """Collapse vpd-style brace escapes (``{{`` -> ``{``, ``}}`` -> ``}``).
+
+    v1 (eugr) recipes double their braces so a literal ``{`` survives vpd
+    ``{placeholder}`` substitution — e.g. a JSON-valued flag written as
+    ``--diffusion-config '{{"canvas_length": 256}}'``.  Once substitution has
+    run, the doubled braces are collapsed back to single braces, matching
+    eugr's own ``run-recipe.sh``.
+    """
+    return value.replace("{{", "{").replace("}}", "}")
+
+
 def _resolve_v1_migration(recipe: Recipe) -> None:
     """v1 format recipes -> eugr builder (runtime left for vllm variant resolution)."""
     if recipe.recipe_version != "1":
@@ -332,9 +344,13 @@ def _resolve_v1_migration(recipe: Recipe) -> None:
     if recipe.runtime in ("vllm", ""):
         if not recipe.builder:
             recipe.builder = "eugr"
-        # TODO: verify possible failures from this; v1 recipes sometimes use '{{' in defaults values to escape '{'.
-        # replace '{{' in str defaults values with '{'
-        recipe.defaults = {k: v.replace("{{", "{") for k, v in recipe.defaults.items()}
+        # v1 recipes may escape literal braces as '{{'/'}}' in defaults values
+        # (e.g. a JSON-valued flag default).  Collapse them for string values
+        # only; non-string defaults (numeric port, max_num_seqs,
+        # gpu_memory_utilization, ...) are passed through untouched.
+        recipe.defaults = {
+            k: (_collapse_brace_escapes(v) if isinstance(v, str) else v) for k, v in recipe.defaults.items()
+        }
 
 
 def _resolve_eugr_signals(recipe: Recipe) -> None:
@@ -949,6 +965,14 @@ class Recipe:
         while last != rendered:
             last = rendered
             rendered = arg_substitute(rendered, config_chain)
+
+        # v1 (eugr) recipes escape literal braces as '{{'/'}}' so they survive
+        # the {placeholder} substitution above (e.g. JSON-valued flags like
+        # --diffusion-config '{{...}}').  Collapse them back now that
+        # substitution is done, so the runtime receives valid JSON rather than
+        # doubled braces.  Done post-substitution to preserve the escaping.
+        if self.recipe_version == "1":
+            rendered = _collapse_brace_escapes(rendered)
 
         # Fix trailing spaces after backslash line-continuations.
         # ``\<space><newline>`` → ``\<newline>``

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -115,6 +115,45 @@ def test_load_v1_recipe_no_mods_still_eugr(tmp_recipe_dir: Path):
     assert recipe.runtime_config.get("mods", []) == []
 
 
+def test_v1_migration_preserves_non_string_defaults():
+    """v1 migration must not crash on non-string default values.
+
+    The brace-escape collapse only applies to string values; numeric defaults
+    (port, max_num_seqs, gpu_memory_utilization — as used by the eugr
+    DiffusionGemma recipes) are passed through untouched. Regression for the
+    ``'int' object has no attribute 'replace'`` crash (issue #213).
+    """
+    recipe = Recipe.from_dict(
+        {
+            "name": "v1-numeric",
+            "model": "google/diffusiongemma-26B-A4B-it",
+            "recipe_version": "1",
+            "runtime": "vllm",
+            "defaults": {
+                "port": 8000,
+                "max_num_seqs": 10,
+                "gpu_memory_utilization": 0.8,
+                "max_model_len": 262144,
+            },
+        }
+    )
+    # from_dict already calls resolve(); reaching here means no crash.
+    assert recipe.defaults["port"] == 8000
+    assert recipe.defaults["max_num_seqs"] == 10
+    assert recipe.defaults["gpu_memory_utilization"] == 0.8
+    # string defaults still get their brace escapes collapsed
+    r2 = Recipe.from_dict(
+        {
+            "name": "v1-str",
+            "model": "m",
+            "recipe_version": "1",
+            "runtime": "vllm",
+            "defaults": {"diffusion_config": '{{"canvas_length": 256}}'},
+        }
+    )
+    assert r2.defaults["diffusion_config"] == '{"canvas_length": 256}'
+
+
 def test_recipe_from_dict(sample_v2_recipe_data: dict[str, Any]):
     """Create a recipe from a dict and verify all fields are correctly set.
 
@@ -396,6 +435,47 @@ def test_recipe_render_command_no_template():
     rendered = recipe.render_command(config)
 
     assert rendered is None
+
+
+def test_render_command_collapses_v1_brace_escapes():
+    """v1 recipes collapse ``{{``/``}}`` escapes after placeholder substitution.
+
+    eugr recipes write JSON-valued flags with doubled braces so the literal
+    braces survive ``{placeholder}`` substitution; ``render_command`` collapses
+    them back so the runtime receives valid JSON rather than ``{{...}}``.
+    Regression for issue #213.
+    """
+    recipe = Recipe.from_dict(
+        {
+            "name": "v1-json",
+            "model": "google/diffusiongemma-26B-A4B-it",
+            "recipe_version": "1",
+            "runtime": "vllm",
+            "defaults": {"port": 8000},
+            "command": "vllm serve m --port {port} --diffusion-config '{{\"canvas_length\": 256}}'",
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert "--diffusion-config '{\"canvas_length\": 256}'" in rendered
+    assert "{{" not in rendered
+    assert "}}" not in rendered
+    assert "--port 8000" in rendered
+
+
+def test_render_command_does_not_collapse_braces_for_v2():
+    """v2 recipes are unaffected by the v1 brace-escape collapse."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --x '{{literal}}'",
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert "{{literal}}" in rendered
 
 
 def test_render_command_fixes_trailing_space_continuations():


### PR DESCRIPTION
## Summary

Fixes #213 — the eugr DiffusionGemma v1 recipes fail to launch on `develop-03x`.

v1 (eugr) recipes escape literal braces as `{{`/`}}` so they survive vpd `{placeholder}` substitution — e.g. a JSON-valued flag like `--diffusion-config '{{"canvas_length": 256}}'`. Two separate problems made these recipes fail:

1. **Numeric-defaults crash.** The brace collapse ran over `recipe.defaults` and called `str.replace` on every value, crashing with `'int' object has no attribute 'replace'` on the numeric defaults these recipes carry (`port`, `max_num_seqs`, `gpu_memory_utilization`). The collapse is now guarded to string values only.

2. **Braces never collapsed in the command template.** These recipes put the JSON in the `command` template, not in `defaults`, so the escapes were never collapsed and reached vLLM as literal `{{...}}` (visible via `--dry-run`). `render_command` now collapses `{{`/`}}` **after** `{placeholder}` substitution (post-substitution, so the escaping still does its job), gated to v1 recipes so v2 templates are untouched.

## Diagnosis credit

Root-cause analysis of the numeric-defaults crash was reported by @ib0010 in #213. This PR addresses that plus the second (command-template) failure surfaced while reproducing it.

## Testing

Unit tests added in `tests/test_recipe.py`:
- numeric v1 defaults no longer crash on migration
- string v1 defaults still collapse correctly
- command-template `{{...}}` collapses to valid JSON for v1
- v2 command templates are left untouched

Validated end-to-end on a DGX Spark: a v1 recipe with a doubled-brace `--diffusion-config '{{...}}'` now collapses to valid JSON, vLLM parses `{'canvas_length': 256, 'max_denoising_steps': 48}` with zero parse errors, and the model serves a live completion through the OpenAI endpoint.

## Scope / risk

Small and surgical — a string-guarded collapse on defaults plus one post-substitution collapse in `render_command`, both gated so v2 behavior is unchanged.
