### PR TITLE
v0.2.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ Ctrl+C detaches from logs — it never kills your inference job. Your model keep
 
 See the [full CLI reference](https://sparkrun.dev/cli/overview/) for all commands and options.
 
+## Updating
+
+```bash
+sparkrun update
+```
+
+Upgrades sparkrun (when installed via `uv tool`) and refreshes recipe registries.
+
+### Update channels (advanced)
+
+Opt into preview builds installed from git instead of PyPI:
+
+```bash
+sparkrun update --stable   # PyPI stable release (default)
+sparkrun update --beta     # develop branch preview
+sparkrun update --alpha    # develop-next branch (bleeding edge)
+sparkrun update --yolo     # alias for --alpha
+```
+
+`sparkrun update` with no flag stays on your current channel; a channel flag switches and is remembered for future updates. The same flags work with `sparkrun setup install` and `sparkrun setup update`. Stable prints a plain version (`0.2.40`); beta/alpha add a channel suffix and commit (`0.3.0-alpha+g1a2b3c4`). Switching from a preview channel back to `--stable` may downgrade.
+
 ## Highlights
 
 - **Multi-runtime** — vLLM, SGLang, llama.cpp out of the box

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -205,6 +205,23 @@ Explicit `runtime` always wins. Command-hint detection only fires when `runtime`
 Any key can appear in `defaults` — there is no fixed schema. Runtime-specific keys (e.g. `tool_call_parser`, `ctx_size`,
 `n_gpu_layers`, `reasoning_parser`) are passed through to command template substitution.
 
+#### Atlas high-speed swap
+
+Atlas's block-level KV streaming (`--high-speed-swap`) is enabled with the boolean `high_speed_swap` key, but it
+also needs tuning keys to be usable — Atlas requires `--high-speed-swap-dir` whenever the toggle is set. These keys
+map to the corresponding `--high-speed-swap-*` flags:
+
+```yaml
+defaults:
+  high_speed_swap: true
+  high_speed_swap_dir: /mnt/nvme/atlas-hss      # required; must differ from the --swap-space-gb mount
+  high_speed_swap_gb: 64                          # total NVMe budget (GiB)
+  high_speed_swap_resident_blocks: 512           # HBM scratch slots
+  high_speed_swap_rank: 32                        # predictor low-rank dim
+  high_speed_swap_qd: 8                           # io_uring submission queue depth
+  high_speed_swap_cache_blocks_per_seq: 64       # per-sequence HBM cache cap
+```
+
 ---
 
 ## Executor Config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.2.39"
+version = "0.2.40"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sparkrun-cc-plugin/skills/setup/SKILL.md
+++ b/sparkrun-cc-plugin/skills/setup/SKILL.md
@@ -46,6 +46,11 @@ sparkrun setup update
 
 # Update sparkrun only (skip registry sync)
 sparkrun setup update --no-update-registries
+
+# Update channels (advanced): stable (PyPI, default), beta (develop), alpha (develop-next)
+sparkrun update --beta      # switch to and update the beta channel
+sparkrun update --alpha     # or --yolo; bleeding-edge develop-next
+sparkrun update --stable    # switch back to the stable PyPI release
 ```
 
 ## Setup Wizard (Recommended for First-Time Setup)
@@ -249,6 +254,7 @@ When running SSH setup, the command is interactive and must be run with inherite
 - `sparkrun setup fix-permissions` and `clear-cache` try non-interactive sudo first, then prompt if needed
 - Use `--save-sudo` to install scoped sudoers entries for passwordless future runs
 - `sparkrun update` is a top-level shortcut that upgrades sparkrun (if uv-installed) and updates registries
+- Update channels: `--stable` (PyPI, default), `--beta` (develop), `--alpha`/`--yolo` (develop-next) on `update`, `setup install`, and `setup update`; no flag keeps the current channel, and switching to stable from a preview build may downgrade
 - Cluster `--transfer-mode` options: `auto` (default), `local` (no transfer), `push` (head pushes to workers), `delegated` (workers pull)
 - Cluster `--transfer-interface` options: `auto` (default), `cx7` (use CX7 IPs), `mgmt` (use management IPs)
 - Use `--add-host` / `--remove-host` for incremental cluster changes instead of replacing the full host list

--- a/sparkrun-openclaw-plugin/skills/setup/SKILL.md
+++ b/sparkrun-openclaw-plugin/skills/setup/SKILL.md
@@ -46,6 +46,11 @@ sparkrun setup update
 
 # Update sparkrun only (skip registry sync)
 sparkrun setup update --no-update-registries
+
+# Update channels (advanced): stable (PyPI, default), beta (develop), alpha (develop-next)
+sparkrun update --beta      # switch to and update the beta channel
+sparkrun update --alpha     # or --yolo; bleeding-edge develop-next
+sparkrun update --stable    # switch back to the stable PyPI release
 ```
 
 ## Setup Wizard (Recommended for First-Time Setup)
@@ -249,6 +254,7 @@ When running SSH setup, the command is interactive and must be run with inherite
 - `sparkrun setup fix-permissions` and `clear-cache` try non-interactive sudo first, then prompt if needed
 - Use `--save-sudo` to install scoped sudoers entries for passwordless future runs
 - `sparkrun update` is a top-level shortcut that upgrades sparkrun (if uv-installed) and updates registries
+- Update channels: `--stable` (PyPI, default), `--beta` (develop), `--alpha`/`--yolo` (develop-next) on `update`, `setup install`, and `setup update`; no flag keeps the current channel, and switching to stable from a preview build may downgrade
 - Cluster `--transfer-mode` options: `auto` (default), `local` (no transfer), `push` (head pushes to workers), `delegated` (workers pull)
 - Cluster `--transfer-interface` options: `auto` (default), `cx7` (use CX7 IPs), `mgmt` (use management IPs)
 - Use `--add-host` / `--remove-host` for incremental cluster changes instead of replacing the full host list

--- a/src/sparkrun/cli/__init__.py
+++ b/src/sparkrun/cli/__init__.py
@@ -28,10 +28,32 @@ from ._stop_logs import logs_cmd, stop
 from ._tune import tune
 
 
+def _print_version(ctx, param, value):
+    """Eager callback for --version: render the channel-aware display string."""
+    if not value or ctx.resilient_parsing:
+        return
+    try:
+        from sparkrun.core.config import SparkrunConfig
+        from sparkrun.core.version import display_version
+
+        rendered = display_version(SparkrunConfig())
+    except Exception:
+        rendered = __version__
+    click.echo("sparkrun, version %s" % rendered)
+    ctx.exit()
+
+
 @click.group()
 @click.option("-v", "--verbose", count=True, help="Increase verbosity (-v detail, -vv timestamps, -vvv debug)")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress all output except errors (for scripting)")
-@click.version_option(__version__, prog_name="sparkrun")
+@click.option(
+    "--version",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_print_version,
+    help="Show the version and exit.",
+)
 @click.pass_context
 def main(ctx, verbose, quiet):
     """sparkrun — Launch inference workloads on NVIDIA DGX Spark systems."""
@@ -106,58 +128,66 @@ def status(ctx, hosts, hosts_file, cluster_name, dry_run):
 
 
 @main.command("update")
+@click.option("--stable", is_flag=True, help="Switch to and update the stable channel (PyPI)")
+@click.option("--beta", is_flag=True, help="Switch to and update the beta channel (develop branch)")
+@click.option("--alpha", is_flag=True, help="Switch to and update the alpha channel (develop-next branch)")
+@click.option("--yolo", is_flag=True, help="Alias for --alpha")
 @click.pass_context
-def update(ctx):
+def update(ctx, stable, beta, alpha, yolo):
     """Update sparkrun and recipe registries.
 
-    Attempts to upgrade sparkrun via ``uv tool upgrade`` if it was
-    installed that way, then always updates recipe registries from git.
+    Attempts to upgrade sparkrun via uv if it was installed that way, then
+    always updates recipe registries from git. With no channel flag, updates
+    the currently configured channel; a channel flag switches channels.
 
     If sparkrun was not installed via uv (e.g. pip, pipx, editable
     install), the self-upgrade step is skipped and only registries
     are updated.
     """
-    import shutil
     import subprocess
 
-    from sparkrun import __version__ as old_version
+    from sparkrun.cli._self_update import (
+        capture_old_identity,
+        channel_from_flags,
+        describe_change,
+        install_argv,
+        is_uv_tool_install,
+        new_binary_identity,
+        resolve_uv,
+        update_argv,
+        warn_if_downgrade,
+    )
+    from sparkrun.core.config import SparkrunConfig
+
+    config = SparkrunConfig()
+    current = config.self_update_channel
+    requested = channel_from_flags(stable, beta, alpha, yolo)
+    channel = requested if requested is not None else current
+    switching = requested is not None and requested != current
 
     # --- Step 1: Try self-upgrade via uv (best-effort) ---
-    uv = shutil.which("uv")
+    uv = resolve_uv()
     upgraded = False
-    if uv:
-        check = subprocess.run(
-            [uv, "tool", "list"],
+    if uv and is_uv_tool_install(uv):
+        if switching:
+            warn_if_downgrade(current, channel)
+            click.echo("Switching to the %s channel..." % channel)
+        old_identity = capture_old_identity()
+        click.echo("Checking for sparkrun updates (current: %s)..." % old_identity[0])
+        result = subprocess.run(
+            install_argv(uv, channel) if switching else update_argv(uv, channel),
             capture_output=True,
             text=True,
         )
-        if check.returncode == 0 and "sparkrun" in check.stdout:
-            click.echo("Checking for sparkrun updates (current: %s)..." % old_version)
-            result = subprocess.run(
-                [uv, "tool", "upgrade", "sparkrun"],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode == 0:
-                ver_result = subprocess.run(
-                    ["sparkrun", "--version"],
-                    capture_output=True,
-                    text=True,
-                )
-                if ver_result.returncode == 0:
-                    new_version = ver_result.stdout.strip().rsplit(None, 1)[-1]
-                    if new_version == old_version:
-                        click.echo("sparkrun %s is already the latest version." % old_version)
-                    else:
-                        click.echo("sparkrun updated: %s -> %s" % (old_version, new_version))
-                else:
-                    click.echo("sparkrun updated (could not determine new version).")
-                upgraded = True
-            else:
-                click.echo("Warning: sparkrun upgrade failed: %s" % result.stderr.strip(), err=True)
-                click.echo("Continuing with registry update...", err=True)
+        if result.returncode == 0:
+            config.set_self_update_channel(channel)
+            click.echo(describe_change(channel, old_identity, new_binary_identity()))
+            upgraded = True
         else:
-            click.echo("sparkrun not installed via uv tool — skipping self-upgrade.")
+            click.echo("Warning: sparkrun upgrade failed: %s" % result.stderr.strip(), err=True)
+            click.echo("Continuing with registry update...", err=True)
+    elif uv:
+        click.echo("sparkrun not installed via uv tool — skipping self-upgrade.")
     else:
         click.echo("uv not found — skipping self-upgrade.")
 

--- a/src/sparkrun/cli/_arena.py
+++ b/src/sparkrun/cli/_arena.py
@@ -179,7 +179,8 @@ def arena_benchmark_run(
 
       sparkrun arena benchmark qwen3-1.7b-sglang --tp 2
     """
-    from sparkrun import __version__
+    from sparkrun.core.config import SparkrunConfig
+    from sparkrun.core.version import display_version
     from sparkrun.arena.auth import load_refresh_token, exchange_token
     from sparkrun.arena.upload import generate_submission_id, upload_benchmark_results
     from ._benchmark import _run_benchmark
@@ -187,7 +188,7 @@ def arena_benchmark_run(
 
     # --- Pre-flight checks ---
     click.echo(ASCII_ART)
-    click.echo("sparkrun v%s — Spark Arena benchmark" % __version__)
+    click.echo("sparkrun v%s — Spark Arena benchmark" % display_version(SparkrunConfig()))
     click.echo()
 
     refresh_token = None

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -244,10 +244,11 @@ def run(
     )
 
     # Display summary before launch
-    from sparkrun import __version__
+    from sparkrun.core.config import SparkrunConfig
+    from sparkrun.core.version import display_version
 
     container_image = runtime.resolve_container(recipe, overrides)
-    click.echo("sparkrun v%s" % __version__)
+    click.echo("sparkrun v%s" % display_version(SparkrunConfig()))
     click.echo()
     click.echo("Runtime:   %s" % runtime.runtime_name)
     click.echo("Image:     %s" % container_image)

--- a/src/sparkrun/cli/_self_update.py
+++ b/src/sparkrun/cli/_self_update.py
@@ -1,0 +1,137 @@
+"""Update-channel self-update orchestration for the sparkrun CLI.
+
+Wraps uv-tool install/upgrade behavior for the stable/beta/alpha channels and
+provides identity-based update detection: PyPI stable compares the package
+version, while git channels compare the resolved commit (their `pyproject`
+version is static, so a version-string compare would never detect a change).
+
+The uv argv here is validated by the Phase 0 spike: `uv tool install
+"<git req>" --force` re-resolves a mutable branch to its newest commit and
+rebuilds even when the version is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+import click
+
+from sparkrun.core.channels import (
+    CHANNEL_STABLE,
+    channel_requirement,
+    is_git_channel,
+    normalize_channel,
+)
+from sparkrun.core.version import installed_identity
+
+
+def resolve_uv() -> str | None:
+    """Return the uv executable path, or None if uv is not installed."""
+    return shutil.which("uv")
+
+
+def is_uv_tool_install(uv: str) -> bool:
+    """Return whether sparkrun is installed as a uv tool."""
+    try:
+        check = subprocess.run([uv, "tool", "list"], capture_output=True, text=True)
+    except OSError:
+        return False
+    return check.returncode == 0 and "sparkrun" in check.stdout
+
+
+def channel_from_flags(stable: bool, beta: bool, alpha: bool, yolo: bool) -> str | None:
+    """Return the requested canonical channel from mutually-exclusive flags.
+
+    Returns None when no flag is set. Raises ``click.ClickException`` if flags
+    select conflicting channels (``--yolo`` and ``--alpha`` do not conflict —
+    both normalize to ``alpha``).
+    """
+    requested = {
+        normalize_channel(chan)
+        for chan, enabled in (
+            (CHANNEL_STABLE, stable),
+            ("beta", beta),
+            ("alpha", alpha),
+            ("yolo", yolo),
+        )
+        if enabled
+    }
+    if not requested:
+        return None
+    if len(requested) > 1:
+        raise click.ClickException("Choose only one of --stable, --beta, --alpha, --yolo.")
+    return requested.pop()
+
+
+def install_argv(uv: str, channel: str) -> list[str]:
+    """Build the uv argv to install or switch to a channel."""
+    return [uv, "tool", "install", channel_requirement(channel), "--force"]
+
+
+def update_argv(uv: str, channel: str) -> list[str]:
+    """Build the uv argv to update within a channel.
+
+    Stable uses ``uv tool upgrade``; git channels reinstall with ``--force`` so
+    the mutable branch re-resolves to its newest commit.
+    """
+    if normalize_channel(channel) == CHANNEL_STABLE:
+        return [uv, "tool", "upgrade", "sparkrun"]
+    return install_argv(uv, channel)
+
+
+def new_binary_identity() -> tuple[str | None, str | None]:
+    """Query the freshly installed binary for ``(version, commit)`` via JSON.
+
+    After a uv reinstall the running process holds stale code, so we shell out
+    to the newly installed on-PATH binary's hidden ``setup version --json``.
+    """
+    try:
+        res = subprocess.run(
+            ["sparkrun", "setup", "version", "--json"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None, None
+    if res.returncode != 0:
+        return None, None
+    try:
+        data = json.loads(res.stdout.strip() or "{}")
+    except ValueError:
+        return None, None
+    return data.get("version"), data.get("commit")
+
+
+def describe_change(channel: str, old: tuple[str | None, str | None], new: tuple[str | None, str | None]) -> str:
+    """Return a human message describing the version/commit change after update."""
+    old_version, old_commit = old
+    new_version, new_commit = new
+    if is_git_channel(channel):
+        if new_commit is None:
+            return "sparkrun %s updated (could not determine new commit)." % channel
+        if old_commit == new_commit:
+            return "sparkrun %s is already on the latest commit (g%s)." % (channel, new_commit[:7])
+        old_disp = ("g%s" % old_commit[:7]) if old_commit else "unknown"
+        return "sparkrun %s updated: %s -> g%s" % (channel, old_disp, new_commit[:7])
+    # stable / PyPI
+    if new_version is None:
+        return "sparkrun updated (could not determine new version)."
+    if old_version == new_version:
+        return "sparkrun %s is already the latest version." % new_version
+    return "sparkrun updated: %s -> %s" % (old_version, new_version)
+
+
+def warn_if_downgrade(current_channel: str, requested_channel: str) -> None:
+    """Warn when switching from a git channel to stable, which may downgrade."""
+    if requested_channel == CHANNEL_STABLE and is_git_channel(current_channel):
+        click.echo(
+            "Note: switching to the stable channel may downgrade from a preview build (stable tracks the latest PyPI release).",
+            err=True,
+        )
+
+
+def capture_old_identity() -> tuple[str, str | None]:
+    """Return the currently-running build's ``(version, commit)`` identity."""
+    return installed_identity()

--- a/src/sparkrun/cli/_setup/_commands.py
+++ b/src/sparkrun/cli/_setup/_commands.py
@@ -82,8 +82,12 @@ def setup_completion(ctx, shell):
 @setup.command("install")
 @click.option("--shell", type=click.Choice(["bash", "zsh", "fish"]), default=None, help="Shell type (auto-detected if not specified)")
 @click.option("--no-update-registries", is_flag=True, help="Skip updating recipe registries after installation")
+@click.option("--stable", is_flag=True, help="Install the stable channel (PyPI, default)")
+@click.option("--beta", is_flag=True, help="Install the beta channel (develop branch)")
+@click.option("--alpha", is_flag=True, help="Install the alpha channel (develop-next branch)")
+@click.option("--yolo", is_flag=True, help="Alias for --alpha")
 @click.pass_context
-def setup_install(ctx, shell, no_update_registries):
+def setup_install(ctx, shell, no_update_registries, stable, beta, alpha, yolo):
     """Install sparkrun and tab-completion.
 
     Requires uv (https://docs.astral.sh/uv/).  Typical usage:
@@ -94,8 +98,19 @@ def setup_install(ctx, shell, no_update_registries):
     This installs sparkrun as a uv tool (real binary on PATH), cleans up
     any old aliases/functions from previous installs, configures
     tab-completion, and updates recipe registries.
+
+    Channel flags (--beta/--alpha/--yolo) install from a git branch instead of
+    PyPI and persist the choice for future updates. No flag installs stable.
     """
     import subprocess
+
+    from sparkrun.cli._self_update import channel_from_flags, install_argv
+    from sparkrun.core.channels import CHANNEL_STABLE
+    from sparkrun.core.config import SparkrunConfig
+
+    config = SparkrunConfig()
+    requested = channel_from_flags(stable, beta, alpha, yolo)
+    channel = requested if requested is not None else config.self_update_channel
 
     if not shell:
         shell, rc_file = _detect_shell()
@@ -105,16 +120,18 @@ def setup_install(ctx, shell, no_update_registries):
     # Step 1: Install sparkrun via uv tool
     uv = _require_uv()
 
-    click.echo("Installing sparkrun via uv tool install...")
+    label = "" if channel == CHANNEL_STABLE else "%s channel " % channel
+    click.echo("Installing sparkrun %svia uv tool install..." % label)
     result = subprocess.run(
-        [uv, "tool", "install", "sparkrun", "--force"],
+        install_argv(uv, channel),
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
         click.echo("Error installing sparkrun: %s" % result.stderr.strip(), err=True)
         sys.exit(1)
-    click.echo("sparkrun installed on PATH")
+    config.set_self_update_channel(channel)
+    click.echo("sparkrun %sinstalled on PATH" % label)
 
     # Step 2: Clean up old aliases/functions from previous installs
     if rc_file.exists():
@@ -148,32 +165,49 @@ def setup_install(ctx, shell, no_update_registries):
 
 @setup.command("update")
 @click.option("--no-update-registries", is_flag=True, help="Skip updating recipe registries")
+@click.option("--stable", is_flag=True, help="Switch to and update the stable channel (PyPI)")
+@click.option("--beta", is_flag=True, help="Switch to and update the beta channel (develop branch)")
+@click.option("--alpha", is_flag=True, help="Switch to and update the alpha channel (develop-next branch)")
+@click.option("--yolo", is_flag=True, help="Alias for --alpha")
 @click.pass_context
-def setup_update(ctx, no_update_registries):
+def setup_update(ctx, no_update_registries, stable, beta, alpha, yolo):
     """Update sparkrun to the latest version.
 
-    Requires sparkrun to have been installed via ``uv tool install``.
-    After upgrading, recipe registries are also updated.
+    Requires sparkrun to have been installed via ``uv tool install``. With no
+    channel flag, updates the currently configured channel; a channel flag
+    switches channels. After upgrading, recipe registries are also updated.
 
     \b
       sparkrun setup update
+      sparkrun setup update --beta
     """
-    import shutil
     import subprocess
 
-    from sparkrun import __version__ as old_version
+    from sparkrun.cli._self_update import (
+        capture_old_identity,
+        channel_from_flags,
+        describe_change,
+        install_argv,
+        is_uv_tool_install,
+        new_binary_identity,
+        resolve_uv,
+        update_argv,
+        warn_if_downgrade,
+    )
+    from sparkrun.core.config import SparkrunConfig
 
-    uv = shutil.which("uv")
+    config = SparkrunConfig()
+    current = config.self_update_channel
+    requested = channel_from_flags(stable, beta, alpha, yolo)
+    channel = requested if requested is not None else current
+    switching = requested is not None and requested != current
+
+    uv = resolve_uv()
     if not uv:
         click.echo("Error: uv not found. Install uv first: https://docs.astral.sh/uv/", err=True)
         sys.exit(1)
 
-    check = subprocess.run(
-        [uv, "tool", "list"],
-        capture_output=True,
-        text=True,
-    )
-    if check.returncode != 0 or "sparkrun" not in check.stdout:
+    if not is_uv_tool_install(uv):
         click.echo(
             "Error: sparkrun was not installed via 'uv tool install'.\n"
             "Cannot safely upgrade — manage updates through your package manager instead.",
@@ -181,9 +215,14 @@ def setup_update(ctx, no_update_registries):
         )
         sys.exit(1)
 
-    click.echo("Checking for updates (current: %s)..." % old_version)
+    if switching:
+        warn_if_downgrade(current, channel)
+        click.echo("Switching to the %s channel..." % channel)
+
+    old_identity = capture_old_identity()
+    click.echo("Checking for updates (current: %s)..." % old_identity[0])
     result = subprocess.run(
-        [uv, "tool", "upgrade", "sparkrun"],
+        install_argv(uv, channel) if switching else update_argv(uv, channel),
         capture_output=True,
         text=True,
     )
@@ -191,22 +230,10 @@ def setup_update(ctx, no_update_registries):
         click.echo("Error updating sparkrun: %s" % result.stderr.strip(), err=True)
         sys.exit(1)
 
-    # The running process still has the old module cached, and reload
-    # won't help because uv tool installs into a separate virtualenv.
-    # Ask the newly installed binary instead.
-    ver_result = subprocess.run(
-        ["sparkrun", "--version"],
-        capture_output=True,
-        text=True,
-    )
-    if ver_result.returncode == 0:
-        new_version = ver_result.stdout.strip().rsplit(None, 1)[-1]
-        if new_version == old_version:
-            click.echo("sparkrun %s is already the latest version." % old_version)
-        else:
-            click.echo("sparkrun updated: %s -> %s" % (old_version, new_version))
-    else:
-        click.echo("sparkrun updated (could not determine new version)")
+    config.set_self_update_channel(channel)
+    # The running process still has the old module cached, so ask the newly
+    # installed binary for its identity (version for stable, commit for git).
+    click.echo(describe_change(channel, old_identity, new_binary_identity()))
 
     # Update recipe registries from the newly installed binary — the
     # running process still has old code, so we must shell out.
@@ -219,6 +246,27 @@ def setup_update(ctx, no_update_registries):
         )
         if reg_result.returncode != 0:
             click.echo("Warning: registry update failed (non-fatal).", err=True)
+
+
+@setup.command("version", hidden=True)
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable version identity (version, channel, commit)")
+def setup_version(as_json):
+    """Print the installed sparkrun version identity.
+
+    Hidden helper used by the self-update flow to compare builds across a uv
+    reinstall without scraping the human ``--version`` string.
+    """
+    import json as _json
+
+    from sparkrun.core.config import SparkrunConfig
+    from sparkrun.core.version import display_version, installed_identity
+
+    config = SparkrunConfig()
+    base, commit = installed_identity()
+    if as_json:
+        click.echo(_json.dumps({"version": base, "channel": config.self_update_channel, "commit": commit}))
+    else:
+        click.echo(display_version(config, base))
 
 
 def _run_ssh_diagnose(host_list, user, local_user):

--- a/src/sparkrun/cli/_setup/_wizard.py
+++ b/src/sparkrun/cli/_setup/_wizard.py
@@ -35,7 +35,7 @@ def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
     import shutil
     import subprocess
 
-    from sparkrun import __version__
+    from sparkrun.core.version import display_version
     from sparkrun.core.cluster_manager import ClusterError
     from sparkrun.core.config import SparkrunConfig
     from sparkrun.orchestration.networking import (
@@ -83,7 +83,7 @@ def setup_wizard(ctx, hosts, cluster_name, user, dry_run, yes):
     try:
         # ── Phase 0: Welcome + Install Check ─────────────────────────
         click.echo()
-        click.echo("Welcome to sparkrun %s setup wizard!" % __version__)
+        click.echo("Welcome to sparkrun %s setup wizard!" % display_version(SparkrunConfig()))
         click.echo("=" * 48)
         click.echo()
 

--- a/src/sparkrun/core/channels.py
+++ b/src/sparkrun/core/channels.py
@@ -1,0 +1,62 @@
+"""Update-channel definitions — the single source of truth shared by config,
+version display, and the CLI self-update flow.
+
+This module is intentionally dependency-free and MUST stay byte-identical across
+release branches (`main`/stable, `develop`/beta, `develop-next`/alpha) so a given
+channel always resolves to the same source regardless of which build is running.
+"""
+
+from __future__ import annotations
+
+CHANNEL_STABLE = "stable"
+CHANNEL_BETA = "beta"
+CHANNEL_ALPHA = "alpha"
+
+CHANNELS = (CHANNEL_STABLE, CHANNEL_BETA, CHANNEL_ALPHA)
+
+# CLI aliases that normalize onto a canonical channel.
+_CHANNEL_ALIASES = {"yolo": CHANNEL_ALPHA}
+
+# Canonical uv requirement per channel. Stable installs from PyPI; beta/alpha
+# install from mutable git branches (re-resolved to the latest commit on update).
+_REPO_URL = "git+https://github.com/spark-arena/sparkrun"
+CHANNEL_REQUIREMENTS = {
+    CHANNEL_STABLE: "sparkrun",
+    CHANNEL_BETA: "sparkrun @ %s@develop" % _REPO_URL,
+    CHANNEL_ALPHA: "sparkrun @ %s@develop-next" % _REPO_URL,
+}
+
+# Human-facing version suffix per channel (stable has none).
+_CHANNEL_SUFFIXES = {
+    CHANNEL_STABLE: "",
+    CHANNEL_BETA: "-beta",
+    CHANNEL_ALPHA: "-alpha",
+}
+
+
+def normalize_channel(value: str | None) -> str:
+    """Return the canonical channel for a raw value.
+
+    Applies aliases (``yolo`` -> ``alpha``) and falls back to ``stable`` for
+    missing or unrecognized values, so callers never act on an unknown channel.
+    """
+    if not value:
+        return CHANNEL_STABLE
+    text = str(value).strip().lower()
+    text = _CHANNEL_ALIASES.get(text, text)
+    return text if text in CHANNELS else CHANNEL_STABLE
+
+
+def channel_requirement(channel: str) -> str:
+    """Return the uv requirement string for a channel."""
+    return CHANNEL_REQUIREMENTS[normalize_channel(channel)]
+
+
+def is_git_channel(channel: str) -> bool:
+    """Return whether a channel installs from a mutable git branch."""
+    return normalize_channel(channel) in (CHANNEL_BETA, CHANNEL_ALPHA)
+
+
+def channel_suffix(channel: str) -> str:
+    """Return the human-facing version suffix for a channel (``""`` for stable)."""
+    return _CHANNEL_SUFFIXES[normalize_channel(channel)]

--- a/src/sparkrun/core/config.py
+++ b/src/sparkrun/core/config.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from typing import Any, TYPE_CHECKING, Optional
 
+import yaml
 from vpd.next.util import read_yaml
 
 if TYPE_CHECKING:
@@ -146,6 +147,41 @@ class SparkrunConfig:
             else:
                 return default
         return current
+
+    def set(self, key: str, value: Any) -> None:
+        """Set a config value by dot-separated key path (in memory; call ``save()`` to persist)."""
+        parts = key.split(".")
+        current = self._data
+        for part in parts[:-1]:
+            nxt = current.get(part)
+            if not isinstance(nxt, dict):
+                nxt = {}
+                current[part] = nxt
+            current = nxt
+        current[parts[-1]] = value
+
+    def save(self) -> None:
+        """Persist the current config to ``config_path`` as YAML."""
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.config_path, "w") as f:
+            yaml.safe_dump(self._data, f, default_flow_style=False, sort_keys=False)
+
+    @property
+    def self_update_channel(self) -> str:
+        """Return the persisted update channel, normalized (default ``stable``)."""
+        from sparkrun.core.channels import normalize_channel
+
+        return normalize_channel(self.get("self_update.channel"))
+
+    def set_self_update_channel(self, channel: str) -> None:
+        """Persist the update channel (normalized) plus its source and requirement."""
+        from sparkrun.core.channels import channel_requirement, is_git_channel, normalize_channel
+
+        canonical = normalize_channel(channel)
+        self.set("self_update.channel", canonical)
+        self.set("self_update.source", "git" if is_git_channel(canonical) else "pypi")
+        self.set("self_update.requirement", channel_requirement(canonical))
+        self.save()
 
     def _get_defaults_section(self, section: str, name: str) -> dict[str, Any]:
         """Return ``defaults.<section>.<name>`` as a dict, or ``{}`` when missing or malformed."""

--- a/src/sparkrun/core/version.py
+++ b/src/sparkrun/core/version.py
@@ -1,0 +1,71 @@
+"""User-facing version rendering and installed-build identity.
+
+Kept separate from ``sparkrun.__version__`` (the raw package metadata version):
+the display string carries a channel suffix and git commit, while the metadata
+version stays clean for machine comparison.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib.metadata import PackageNotFoundError, distribution, version
+
+from sparkrun.core.channels import CHANNEL_STABLE, channel_suffix, normalize_channel
+
+
+def installed_commit() -> str | None:
+    """Return the git commit the installed sparkrun was built from, if any.
+
+    Reads PEP 610 ``direct_url.json`` (written by uv/pip for VCS installs) and
+    returns ``vcs_info.commit_id``. Returns ``None`` for PyPI installs or when
+    the metadata is missing/malformed. Never shells out to git — installed uv
+    tool environments are not guaranteed to contain a checkout.
+    """
+    try:
+        raw = distribution("sparkrun").read_text("direct_url.json")
+    except PackageNotFoundError:
+        return None
+    if not raw:
+        return None
+    try:
+        vcs_info = json.loads(raw).get("vcs_info") or {}
+    except (ValueError, TypeError):
+        return None
+    commit = vcs_info.get("commit_id")
+    return commit if isinstance(commit, str) and commit else None
+
+
+def base_version() -> str:
+    """Return the raw package metadata version (no channel suffix)."""
+    try:
+        return version("sparkrun")
+    except PackageNotFoundError:
+        return "0.0.0-dev"
+
+
+def installed_identity() -> tuple[str, str | None]:
+    """Return ``(base_version, commit_id|None)`` for the installed sparkrun."""
+    return base_version(), installed_commit()
+
+
+def display_version(config=None, base: str | None = None) -> str:
+    """Return the user-facing version string for the configured channel.
+
+    Stable returns the base version unchanged. Beta/alpha append ``-beta`` /
+    ``-alpha`` plus ``+g<short-sha>`` when the installed git commit is known,
+    falling back to the channel-only suffix otherwise.
+    """
+    base = base if base is not None else base_version()
+    channel = CHANNEL_STABLE
+    if config is not None:
+        try:
+            channel = normalize_channel(config.self_update_channel)
+        except Exception:  # pragma: no cover — display must never crash the CLI
+            channel = CHANNEL_STABLE
+    suffix = channel_suffix(channel)
+    if not suffix:
+        return base
+    commit = installed_commit()
+    if commit:
+        return "%s%s+g%s" % (base, suffix, commit[:7])
+    return "%s%s" % (base, suffix)

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -74,6 +74,20 @@ _ATLAS_FLAG_MAP = {
     "model_from_path": "--model-from-path",
     "cache_dir": "--cache-dir",
     "gpu_ordinal": "--gpu-ordinal",
+    # High-speed-swap tuning keys.  These configure the block-level KV
+    # streaming path enabled by the `high_speed_swap` boolean toggle
+    # below; without them the feature is enabled but unconfigurable from
+    # a recipe (`--high-speed-swap-dir` is required by Atlas when the
+    # toggle is set).  `--high-speed-swap-graph` is intentionally omitted:
+    # Atlas parses it as Option<bool> needing a lowercase `true`/`false`
+    # value, which the bare-toggle and Python-bool rendering paths here
+    # cannot emit safely.
+    "high_speed_swap_dir": "--high-speed-swap-dir",
+    "high_speed_swap_gb": "--high-speed-swap-gb",
+    "high_speed_swap_resident_blocks": "--high-speed-swap-resident-blocks",
+    "high_speed_swap_rank": "--high-speed-swap-rank",
+    "high_speed_swap_qd": "--high-speed-swap-qd",
+    "high_speed_swap_cache_blocks_per_seq": "--high-speed-swap-cache-blocks-per-seq",
     # Boolean toggles — present when truthy, omitted otherwise.  Listed
     # in `_ATLAS_BOOL_FLAGS` so build/strip helpers treat them correctly.
     "enable_prefix_caching": "--enable-prefix-caching",

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -78,6 +78,36 @@ def test_atlas_generate_command_bool_flags():
     assert "--high-speed-swap" not in cmd
 
 
+def test_atlas_high_speed_swap_subflags_render():
+    """High-speed-swap tuning keys map to their `--high-speed-swap-*` flags.
+
+    Regression: the `high_speed_swap` toggle was mapped but its required
+    sub-flags were not, so the feature could be turned on but not
+    configured from a recipe (Atlas requires `--high-speed-swap-dir`).
+    """
+    runtime = AtlasRuntime()
+    recipe = _recipe(
+        defaults={
+            "high_speed_swap": True,
+            "high_speed_swap_dir": "/mnt/nvme/atlas-hss",
+            "high_speed_swap_gb": 64,
+            "high_speed_swap_resident_blocks": 512,
+            "high_speed_swap_rank": 32,
+            "high_speed_swap_qd": 8,
+            "high_speed_swap_cache_blocks_per_seq": 64,
+        },
+    )
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--high-speed-swap" in cmd
+    assert "--high-speed-swap-dir /mnt/nvme/atlas-hss" in cmd
+    assert "--high-speed-swap-gb 64" in cmd
+    assert "--high-speed-swap-resident-blocks 512" in cmd
+    assert "--high-speed-swap-rank 32" in cmd
+    assert "--high-speed-swap-qd 8" in cmd
+    assert "--high-speed-swap-cache-blocks-per-seq 64" in cmd
+
+
 def test_atlas_generate_command_from_template():
     """Recipe with explicit command template renders it verbatim."""
     runtime = AtlasRuntime()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4768,8 +4768,12 @@ class TestUpdateCommand:
                 return mock.Mock(returncode=0, stdout="sparkrun v1.0.0\n", stderr="")
             if cmd[1:3] == ["tool", "upgrade"]:
                 return mock.Mock(returncode=0, stdout="", stderr="")
-            if cmd == ["sparkrun", "--version"]:
-                return mock.Mock(returncode=0, stdout="sparkrun, version 1.1.0", stderr="")
+            if cmd == ["sparkrun", "setup", "version", "--json"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout='{"version": "1.1.0", "channel": "stable", "commit": null}',
+                    stderr="",
+                )
             if cmd == ["sparkrun", "registry", "update"]:
                 return mock.Mock(returncode=0, stdout="", stderr="")
             return mock.Mock(returncode=0, stdout="", stderr="")

--- a/tests/test_update_channels.py
+++ b/tests/test_update_channels.py
@@ -1,0 +1,235 @@
+"""Tests for update-channel selection, version display, and self-update wiring."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from sparkrun.cli import main
+from sparkrun.cli._self_update import channel_from_flags, describe_change, update_argv
+from sparkrun.core import channels
+from sparkrun.core.config import SparkrunConfig
+from sparkrun.core.version import display_version
+
+
+# --- channel vocabulary ---
+
+
+def test_normalize_channel_defaults_and_aliases():
+    assert channels.normalize_channel(None) == "stable"
+    assert channels.normalize_channel("") == "stable"
+    assert channels.normalize_channel("bogus") == "stable"
+    assert channels.normalize_channel("BETA") == "beta"
+    assert channels.normalize_channel("yolo") == "alpha"
+    assert channels.normalize_channel("alpha") == "alpha"
+
+
+def test_channel_requirements_map():
+    assert channels.channel_requirement("stable") == "sparkrun"
+    assert channels.channel_requirement("beta").endswith("@develop")
+    assert channels.channel_requirement("alpha").endswith("@develop-next")
+    assert channels.channel_requirement("yolo").endswith("@develop-next")
+
+
+def test_is_git_channel():
+    assert not channels.is_git_channel("stable")
+    assert channels.is_git_channel("beta")
+    assert channels.is_git_channel("alpha")
+
+
+def test_channel_suffix():
+    assert channels.channel_suffix("stable") == ""
+    assert channels.channel_suffix("beta") == "-beta"
+    assert channels.channel_suffix("alpha") == "-alpha"
+
+
+# --- config accessors ---
+
+
+def test_config_channel_defaults_stable(tmp_path):
+    assert SparkrunConfig(tmp_path / "config.yaml").self_update_channel == "stable"
+
+
+def test_config_set_channel_persists(tmp_path):
+    path = tmp_path / "config.yaml"
+    SparkrunConfig(path).set_self_update_channel("beta")
+    reloaded = SparkrunConfig(path)
+    assert reloaded.self_update_channel == "beta"
+    assert reloaded.get("self_update.source") == "git"
+    assert reloaded.get("self_update.requirement").endswith("@develop")
+
+
+def test_config_set_channel_yolo_normalizes_to_alpha(tmp_path):
+    path = tmp_path / "config.yaml"
+    SparkrunConfig(path).set_self_update_channel("yolo")
+    assert SparkrunConfig(path).self_update_channel == "alpha"
+
+
+def test_config_unknown_channel_reads_stable(tmp_path):
+    path = tmp_path / "config.yaml"
+    config = SparkrunConfig(path)
+    config.set("self_update.channel", "wat")
+    config.save()
+    assert SparkrunConfig(path).self_update_channel == "stable"
+
+
+# --- version display ---
+
+
+def test_display_version_stable_no_suffix(tmp_path):
+    assert display_version(SparkrunConfig(tmp_path / "config.yaml"), base="0.2.40") == "0.2.40"
+
+
+def test_display_version_beta_with_commit(tmp_path, monkeypatch):
+    config = SparkrunConfig(tmp_path / "config.yaml")
+    config.set_self_update_channel("beta")
+    monkeypatch.setattr("sparkrun.core.version.installed_commit", lambda: "1a2b3c4d5e6f")
+    assert display_version(config, base="0.2.40") == "0.2.40-beta+g1a2b3c4"
+
+
+def test_display_version_alpha_without_commit(tmp_path, monkeypatch):
+    config = SparkrunConfig(tmp_path / "config.yaml")
+    config.set_self_update_channel("alpha")
+    monkeypatch.setattr("sparkrun.core.version.installed_commit", lambda: None)
+    assert display_version(config, base="0.3.0") == "0.3.0-alpha"
+
+
+# --- flag resolution + change messaging ---
+
+
+def test_channel_from_flags_none():
+    assert channel_from_flags(False, False, False, False) is None
+
+
+def test_channel_from_flags_yolo_is_alpha():
+    assert channel_from_flags(False, False, False, True) == "alpha"
+
+
+def test_channel_from_flags_alpha_and_yolo_agree():
+    assert channel_from_flags(False, False, True, True) == "alpha"
+
+
+def test_channel_from_flags_conflict_raises():
+    with pytest.raises(click.ClickException):
+        channel_from_flags(True, True, False, False)
+
+
+def test_update_argv_stable_uses_upgrade():
+    assert update_argv("uv", "stable") == ["uv", "tool", "upgrade", "sparkrun"]
+
+
+def test_update_argv_git_uses_force_install():
+    argv = update_argv("uv", "beta")
+    assert argv[1:3] == ["tool", "install"] and argv[-1] == "--force" and argv[3].endswith("@develop")
+
+
+def test_describe_change_stable_same():
+    assert "already the latest" in describe_change("stable", ("0.2.40", None), ("0.2.40", None))
+
+
+def test_describe_change_stable_updated():
+    assert describe_change("stable", ("0.2.39", None), ("0.2.40", None)) == "sparkrun updated: 0.2.39 -> 0.2.40"
+
+
+def test_describe_change_git_same_commit():
+    msg = describe_change("beta", ("0.2.40", "abcdef123456"), ("0.2.40", "abcdef123456"))
+    assert "already on the latest commit" in msg and "gabcdef1" in msg
+
+
+def test_describe_change_git_new_commit():
+    msg = describe_change("alpha", ("0.3.0", "aaaaaaa1"), ("0.3.0", "bbbbbbb2"))
+    assert "-> gbbbbbbb" in msg
+
+
+# --- CLI integration ---
+
+
+def _isolate_config(monkeypatch, tmp_path):
+    import sparkrun.core.config as config_module
+
+    monkeypatch.setattr(config_module, "DEFAULT_CONFIG_DIR", tmp_path / "config")
+
+
+def _run(monkeypatch, tmp_path, args, *, stored=None, new_json='{"version": "9.9.9", "channel": "x", "commit": "deadbeefcafe"}'):
+    _isolate_config(monkeypatch, tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    if stored:
+        SparkrunConfig(tmp_path / "config" / "config.yaml").set_self_update_channel(stored)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1:3] == ["tool", "list"]:
+            return mock.Mock(returncode=0, stdout="sparkrun v1\n", stderr="")
+        if cmd == ["sparkrun", "setup", "version", "--json"]:
+            return mock.Mock(returncode=0, stdout=new_json, stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    with mock.patch("subprocess.run", side_effect=fake_run):
+        result = CliRunner().invoke(main, args)
+    return result, calls
+
+
+def _stored_channel(tmp_path):
+    return SparkrunConfig(tmp_path / "config" / "config.yaml").self_update_channel
+
+
+def test_top_update_beta_uses_git_and_persists(monkeypatch, tmp_path):
+    result, calls = _run(monkeypatch, tmp_path, ["update", "--beta"])
+    assert result.exit_code == 0, result.output
+    installs = [c for c in calls if c[1:3] == ["tool", "install"]]
+    assert installs and installs[0][3].endswith("@develop") and "--force" in installs[0]
+    assert _stored_channel(tmp_path) == "beta"
+    assert "Updating recipe registries" in result.output
+
+
+def test_top_update_no_flag_uses_stored_alpha(monkeypatch, tmp_path):
+    result, calls = _run(monkeypatch, tmp_path, ["update"], stored="alpha")
+    assert result.exit_code == 0, result.output
+    installs = [c for c in calls if c[1:3] == ["tool", "install"]]
+    assert installs and installs[0][3].endswith("@develop-next")
+
+
+def test_top_update_stable_uses_uv_upgrade(monkeypatch, tmp_path):
+    result, calls = _run(monkeypatch, tmp_path, ["update"])
+    assert result.exit_code == 0, result.output
+    assert any(c[1:3] == ["tool", "upgrade"] for c in calls)
+
+
+def test_top_update_switch_to_stable_warns_downgrade(monkeypatch, tmp_path):
+    result, calls = _run(monkeypatch, tmp_path, ["update", "--stable"], stored="alpha")
+    assert result.exit_code == 0, result.output
+    assert "may downgrade" in result.output
+    installs = [c for c in calls if c[1:3] == ["tool", "install"]]
+    assert installs and installs[0][3] == "sparkrun"
+    assert _stored_channel(tmp_path) == "stable"
+
+
+def test_setup_update_beta_uses_git(monkeypatch, tmp_path):
+    result, calls = _run(monkeypatch, tmp_path, ["setup", "update", "--beta"])
+    assert result.exit_code == 0, result.output
+    installs = [c for c in calls if c[1:3] == ["tool", "install"]]
+    assert installs and installs[0][3].endswith("@develop")
+    assert _stored_channel(tmp_path) == "beta"
+
+
+def test_setup_install_alpha_uses_git_and_persists(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    with mock.patch("subprocess.run", side_effect=fake_run), mock.patch("sparkrun.cli._setup._commands.setup_completion", mock.MagicMock()):
+        result = CliRunner().invoke(main, ["setup", "install", "--alpha", "--no-update-registries", "--shell", "bash"])
+    assert result.exit_code == 0, result.output
+    installs = [c for c in calls if c[1:3] == ["tool", "install"]]
+    assert installs and installs[0][3].endswith("@develop-next")
+    assert _stored_channel(tmp_path) == "alpha"

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.2.39
+sparkrun: 0.2.40
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
This pull request introduces advanced update channel support for the `sparkrun` CLI, allowing users to easily switch between stable, beta, and alpha (develop-next) release channels for both installation and self-updating. It also improves version reporting to reflect the current channel and commit, and documents new features and options. The most important changes are:

**Update Channel Support and Self-Update Logic:**
* Added support for update channels (`--stable`, `--beta`, `--alpha`, `--yolo`) to the `sparkrun update`, `sparkrun setup install`, and `sparkrun setup update` commands, enabling users to select and persist their preferred release channel. Switching between channels is now explicit and includes downgrade warnings when moving from a preview to the stable channel. [[1]](diffhunk://#diff-39e7f4bba23d2486f8e393791340cff7b85e91d52ea69d359c30867c14f64e56R131-R189) [[2]](diffhunk://#diff-ae66a610839dfe244e0cc159dfea186fe137dc62f6b00c735f2c4356b41a54e2R85-R90) [[3]](diffhunk://#diff-ae66a610839dfe244e0cc159dfea186fe137dc62f6b00c735f2c4356b41a54e2R101-R114) [[4]](diffhunk://#diff-ae66a610839dfe244e0cc159dfea186fe137dc62f6b00c735f2c4356b41a54e2L108-R134) [[5]](diffhunk://#diff-41cd50f1d6653c7ae0bc9f7c516e14a7bfcd1922211f0fa32a2141c5bcca87c6R1-R137)

* Refactored self-update logic into a new module (`src/sparkrun/cli/_self_update.py`), centralizing channel selection, uv tool orchestration, and version/commit identity handling for both PyPI and git-based installs.

**Version Reporting Improvements:**
* Updated the CLI version output and related commands to display the channel and commit information, improving clarity for users on preview builds. [[1]](diffhunk://#diff-39e7f4bba23d2486f8e393791340cff7b85e91d52ea69d359c30867c14f64e56R31-R56) [[2]](diffhunk://#diff-72fc99a67d8746ecd3e5d8474f0fb7d66df5ca7c70a505cdb6bda1f6794d623bL182-R191) [[3]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08L247-R251)

**Documentation Updates:**
* Updated `README.md`, `RECIPES.md`, and plugin skill docs to document the new update channels, usage patterns, and the Atlas high-speed swap recipe keys. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54-R74) [[2]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611R208-R224) [[3]](diffhunk://#diff-db72a706dee394c6314bdbd2fdf92b6d921c137b6a2c9468c35ef6b32da2b761R49-R53) [[4]](diffhunk://#diff-db72a706dee394c6314bdbd2fdf92b6d921c137b6a2c9468c35ef6b32da2b761R257) [[5]](diffhunk://#diff-0c9bde9ae3c445a549147a25ab068ef27008ff94ee96aa36bd3ba9136857e557R49-R53) [[6]](diffhunk://#diff-0c9bde9ae3c445a549147a25ab068ef27008ff94ee96aa36bd3ba9136857e557R257)

**Other:**
* Bumped the package version to `0.2.40`.

These changes improve user experience by making advanced update workflows accessible, ensuring clarity about installed versions, and providing comprehensive documentation.