### PR TITLE
fix(networking): pin control traffic to explicit fabric hosts

### DIFF
--- a/src/sparkrun/orchestration/infiniband.py
+++ b/src/sparkrun/orchestration/infiniband.py
@@ -210,6 +210,40 @@ def extract_ib_ips(ib_info: dict[str, str]) -> list[str]:
     return [ip.strip() for ip in raw.split(",") if ip.strip()]
 
 
+def _pin_comm_env_to_fabric_host(
+    host: str,
+    ib_info: dict[str, str],
+    env: dict[str, str],
+) -> dict[str, str]:
+    """Bind communication libraries to an explicitly selected fabric IP.
+
+    When a cluster is defined using one of the detected IB/CX interface
+    addresses, that address is the operator's requested inter-node network.
+    Keep management/default-route behavior for hostname and management-IP
+    clusters, but prevent control sockets from silently using another network.
+    """
+    ib_ips = extract_ib_ips(ib_info)
+    net_ifaces = [name.strip() for name in ib_info.get("DETECTED_NET_LIST", "").split(",") if name.strip()]
+    try:
+        fabric_index = ib_ips.index(host)
+        fabric_ifname = net_ifaces[fabric_index]
+    except (ValueError, IndexError):
+        return env
+
+    for name in (
+        "MN_IF_NAME",
+        "OMPI_MCA_btl_tcp_if_include",
+        "GLOO_SOCKET_IFNAME",
+        "TP_SOCKET_IFNAME",
+    ):
+        env[name] = fabric_ifname
+
+    env["NCCL_SOCKET_IFNAME"] = fabric_ifname
+    env["NODE_IP"] = host
+    env["VLLM_HOST_IP"] = host
+    return env
+
+
 def validate_ib_connectivity(
     ib_candidates: dict[str, str] | dict[str, list[str]],
     ssh_kwargs: dict | None = None,
@@ -379,6 +413,7 @@ def detect_ib_for_hosts(
 
         # Per-host comm env (so heterogeneous socket interfaces work)
         host_env = generate_nccl_env(ib_info, topology=topology)
+        host_env = _pin_comm_env_to_fabric_host(result.host, ib_info, host_env)
         if host_env:
             per_host_env[result.host] = host_env
             if result.host == head_host:

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -1227,6 +1227,47 @@ class TestDetectIbForHosts:
         assert result.ib_ip_map == {"h1": "10.0.0.1", "h2": "10.0.0.2"}
 
     @mock.patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel")
+    def test_explicit_fabric_hosts_pin_per_host_control_env(self, mock_parallel):
+        """Fabric-addressed clusters do not retain default-route control interfaces."""
+        mock_parallel.return_value = [
+            RemoteResult(
+                host="192.168.0.155",
+                returncode=0,
+                stdout=(
+                    "IB_DETECTED=1\n"
+                    "DETECTED_SOCKET_IFNAME=wlP9s9\n"
+                    "DETECTED_MGMT_IP=192.168.1.155\n"
+                    "DETECTED_NET_LIST=enp1s0f1np1,enP2p1s0f1np1\n"
+                    "DETECTED_IB_IPS=192.168.0.155,192.168.200.155\n"
+                ),
+                stderr="",
+            ),
+            RemoteResult(
+                host="192.168.0.126",
+                returncode=0,
+                stdout=(
+                    "IB_DETECTED=1\n"
+                    "DETECTED_SOCKET_IFNAME=wlP9s9\n"
+                    "DETECTED_MGMT_IP=192.168.1.126\n"
+                    "DETECTED_NET_LIST=enp1s0f1np1,enP2p1s0f1np1\n"
+                    "DETECTED_IB_IPS=192.168.0.126,192.168.200.126\n"
+                ),
+                stderr="",
+            ),
+        ]
+        from sparkrun.orchestration.infiniband import detect_ib_for_hosts
+
+        result = detect_ib_for_hosts(["192.168.0.155", "192.168.0.126"])
+
+        for host in ("192.168.0.155", "192.168.0.126"):
+            host_env = result.comm_env.get_env(host)
+            assert host_env["GLOO_SOCKET_IFNAME"] == "enp1s0f1np1"
+            assert host_env["TP_SOCKET_IFNAME"] == "enp1s0f1np1"
+            assert host_env["NCCL_SOCKET_IFNAME"] == "enp1s0f1np1"
+            assert host_env["NODE_IP"] == host
+            assert host_env["VLLM_HOST_IP"] == host
+
+    @mock.patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel")
     def test_no_ib_detected(self, mock_parallel):
         """When no IB is found, returns empty results."""
         mock_parallel.return_value = [

--- a/tests/test_infiniband.py
+++ b/tests/test_infiniband.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from sparkrun.orchestration.infiniband import (
+    _pin_comm_env_to_fabric_host,
     generate_ib_detect_script,
     parse_ib_detect_output,
     generate_nccl_env,
@@ -198,6 +199,62 @@ def test_generate_nccl_env_missing_ib_detected():
     env = generate_nccl_env(ib_info)
 
     assert env == {}
+
+
+def test_pin_comm_env_to_explicit_fabric_host():
+    """An explicit fabric host selects its matching interface for control traffic."""
+    ib_info = {
+        "DETECTED_IB_IPS": "192.168.0.155,192.168.200.155",
+        "DETECTED_NET_LIST": "enp1s0f1np1,enP2p1s0f1np1",
+    }
+    env = {
+        "GLOO_SOCKET_IFNAME": "wlP9s9",
+        "NCCL_SOCKET_IFNAME": "wlP9s9,enp1s0f1np1,enP2p1s0f1np1",
+        "NODE_IP": "192.168.1.155",
+    }
+
+    result = _pin_comm_env_to_fabric_host("192.168.200.155", ib_info, env)
+
+    assert result["MN_IF_NAME"] == "enP2p1s0f1np1"
+    assert result["OMPI_MCA_btl_tcp_if_include"] == "enP2p1s0f1np1"
+    assert result["GLOO_SOCKET_IFNAME"] == "enP2p1s0f1np1"
+    assert result["TP_SOCKET_IFNAME"] == "enP2p1s0f1np1"
+    assert result["NCCL_SOCKET_IFNAME"] == "enP2p1s0f1np1"
+    assert result["NODE_IP"] == "192.168.200.155"
+    assert result["VLLM_HOST_IP"] == "192.168.200.155"
+
+
+def test_pin_comm_env_preserves_management_host_behavior():
+    """A hostname or management address keeps the detected default-route env."""
+    ib_info = {
+        "DETECTED_IB_IPS": "192.168.0.155",
+        "DETECTED_NET_LIST": "enp1s0f1np1",
+    }
+    env = {
+        "GLOO_SOCKET_IFNAME": "wlP9s9",
+        "NCCL_SOCKET_IFNAME": "wlP9s9,enp1s0f1np1",
+        "NODE_IP": "192.168.1.155",
+    }
+    original = env.copy()
+
+    result = _pin_comm_env_to_fabric_host("spark", ib_info, env)
+
+    assert result == original
+    assert "VLLM_HOST_IP" not in result
+
+
+def test_pin_comm_env_ignores_unpaired_fabric_ip():
+    """Missing interface data cannot produce a mismatched binding."""
+    ib_info = {
+        "DETECTED_IB_IPS": "192.168.0.155,192.168.200.155",
+        "DETECTED_NET_LIST": "enp1s0f1np1",
+    }
+    env = {"GLOO_SOCKET_IFNAME": "wlP9s9"}
+    original = env.copy()
+
+    result = _pin_comm_env_to_fabric_host("192.168.200.155", ib_info, env)
+
+    assert result == original
 
 
 def test_parse_ib_detect_output_with_whitespace():


### PR DESCRIPTION
## Summary

- detect when cluster hosts are explicitly addressed by a detected IB/CX IP
- bind Gloo, TP, NCCL bootstrap, MPI, and multi-node interface settings to the matching fabric interface
- set `NODE_IP` and `VLLM_HOST_IP` to the explicit fabric address so vLLM message queues do not fall back to the default-route interface
- preserve existing management-interface behavior for hostname and management-IP clusters

## Problem

A two-node cluster configured with CX-7 addresses still selected the default-route WiFi interface for `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, `NCCL_SOCKET_IFNAME`, and `NODE_IP`. vLLM also inferred its message-queue address from the default route. Losing WiFi therefore terminated model serving even though CX-7 remained healthy.

## Validation

- `ruff format --check` and `ruff check` passed
- focused InfiniBand/distribution suites: 165 passed
- full suite: 2612 passed
- live two-node TP=2 validation used CX-7 addresses with zero inter-node WiFi sockets
- model generation remained healthy while the worker's WiFi interface was disconnected for 45 seconds
