### PR TITLE
fix(atlas): emit --disable-tool-grammar and --fp8-kv-calibration-tokens

### DIFF
--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -58,6 +58,13 @@ _ATLAS_FLAG_MAP = {
     "kv_high_precision_layers": "--kv-high-precision-layers",
     "tool_call_parser": "--tool-call-parser",
     "tool_max_tokens": "--tool-max-tokens",
+    # Takes an explicit bool VALUE (`--disable-tool-grammar true`), not a
+    # bare toggle: it overrides MODEL.toml's `[behavior].disable_tool_grammar`,
+    # so "absent" and "false" are genuinely different. Hence it is NOT in
+    # `_ATLAS_BOOL_FLAGS`; `_normalize_config` lowercases the value because
+    # Rust's bool parser rejects Python's `str(True)` == "True".
+    "disable_tool_grammar": "--disable-tool-grammar",
+    "fp8_kv_calibration_tokens": "--fp8-kv-calibration-tokens",
     "scheduling_policy": "--scheduling-policy",
     "tbt_deadline_ms": "--tbt-deadline-ms",
     "max_prefill_tokens": "--max-prefill-tokens",
@@ -200,11 +207,20 @@ class AtlasRuntime(RuntimePlugin):
         Accepts ``auth_token`` as an alias for the canonical ``api_key``
         key so users can use either in recipe defaults; flag emission
         only looks at the canonical key.
+
+        Also renders ``disable_tool_grammar`` as a lowercase ``true``/
+        ``false`` string.  It is a value-taking flag (not a toggle), and
+        the default ``str(value)`` rendering would emit Python's ``True``,
+        which Atlas' Rust bool parser rejects.
         """
         if not config.get("api_key"):
             alias = config.get("auth_token")
             if alias:
                 config.set("api_key", alias)
+
+        val = config.get("disable_tool_grammar")
+        if val is not None and isinstance(val, bool):
+            config.set("disable_tool_grammar", "true" if val else "false")
 
     def generate_command(
         self,


### PR DESCRIPTION
## Problem

`disable_tool_grammar` is not in `_ATLAS_FLAG_MAP`, so sparkrun **silently drops it** from the generated serve command even when a recipe sets it. The recipe looks right on disk, but the engine sparkrun launches differs from the same config run by hand.

The consequence is not cosmetic: with Atlas' tool grammar left on, **parallel tool calls collapse to zero** (BFCL parallel 0.00). Several GB10 users hit exactly this running the Atlas qwen3.6 recipes — the hand-run "golden" config worked, the sparkrun-launched one didn't, and this missing flag was the difference.

`fp8_kv_calibration_tokens` is dropped the same way. Without it, a checkpoint that ships no k/v scales (e.g. `nvidia/Qwen3.6-35B-A3B-NVFP4`) refuses to serve under fp8 KV at all.

## Fix

Add both to `_ATLAS_FLAG_MAP`, and lowercase the rendered bool in `_normalize_config`.

Two points worth review attention:

- `--disable-tool-grammar` takes an explicit **value** (`--disable-tool-grammar true`); it is not a bare toggle. It *overrides* MODEL.toml's `[behavior].disable_tool_grammar`, so "absent" and "false" are genuinely different states. It therefore must **not** go in `_ATLAS_BOOL_FLAGS`, which emits presence-only flags.
- Atlas' Rust bool parser rejects Python's `str(True)` == `"True"`, hence the lowercasing in `_normalize_config` rather than relying on default rendering.

## Verification

On a DGX Spark GB10, driving the Atlas qwen3.6 NVFP4 recipes end-to-end through `sparkrun run`:

- the generated command now carries `--disable-tool-grammar true` and `--fp8-kv-calibration-tokens 256`
- the served model returns **3/3 parallel tool calls** (`get_weather` for Paris, Tokyo, Cairo) on both `nvidia/Qwen3.6-27B-NVFP4` and `nvidia/Qwen3.6-35B-A3B-NVFP4`, where they were previously grammar-collapsed