### PR TITLE
fix(atlas): harden disable_tool_grammar string values + regression tests

### DIFF
--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -211,7 +211,11 @@ class AtlasRuntime(RuntimePlugin):
         Also renders ``disable_tool_grammar`` as a lowercase ``true``/
         ``false`` string.  It is a value-taking flag (not a toggle), and
         the default ``str(value)`` rendering would emit Python's ``True``,
-        which Atlas' Rust bool parser rejects.
+        which Atlas' Rust bool parser rejects.  A YAML bool (``True``) and
+        a quoted string (``"True"``/``"TRUE"``) reach us differently, so
+        both cases are folded to lowercase here; any non-bool-ish string is
+        left untouched so Atlas surfaces its own parse error rather than us
+        guessing.
         """
         if not config.get("api_key"):
             alias = config.get("auth_token")
@@ -219,8 +223,10 @@ class AtlasRuntime(RuntimePlugin):
                 config.set("api_key", alias)
 
         val = config.get("disable_tool_grammar")
-        if val is not None and isinstance(val, bool):
+        if isinstance(val, bool):
             config.set("disable_tool_grammar", "true" if val else "false")
+        elif isinstance(val, str) and val.strip().lower() in ("true", "false"):
+            config.set("disable_tool_grammar", val.strip().lower())
 
     def generate_command(
         self,

--- a/tests/test_atlas_runtime.py
+++ b/tests/test_atlas_runtime.py
@@ -108,6 +108,56 @@ def test_atlas_high_speed_swap_subflags_render():
     assert "--high-speed-swap-cache-blocks-per-seq 64" in cmd
 
 
+def test_atlas_disable_tool_grammar_and_fp8_kv_calibration_render():
+    """`disable_tool_grammar` and `fp8_kv_calibration_tokens` are emitted.
+
+    Regression: neither key was in `_ATLAS_FLAG_MAP`, so sparkrun silently
+    dropped both from the serve command even when a recipe set them. The
+    bool is rendered as a lowercase VALUE (not a bare toggle) because it
+    overrides MODEL.toml's `[behavior].disable_tool_grammar`.
+    """
+    runtime = AtlasRuntime()
+    recipe = _recipe(
+        defaults={
+            "disable_tool_grammar": True,
+            "fp8_kv_calibration_tokens": 256,
+        },
+    )
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--disable-tool-grammar true" in cmd
+    assert "--fp8-kv-calibration-tokens 256" in cmd
+
+
+def test_atlas_disable_tool_grammar_false_renders_lowercase():
+    """A falsy `disable_tool_grammar` still emits an explicit `false` value.
+
+    "absent" and "false" are genuinely different states for Atlas, so unlike
+    a bool toggle the flag must be present with a value even when disabled.
+    """
+    runtime = AtlasRuntime()
+    recipe = _recipe(defaults={"disable_tool_grammar": False})
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "--disable-tool-grammar false" in cmd
+    # Never Python's `str(False)` == "False", which Atlas' Rust parser rejects.
+    assert "--disable-tool-grammar False" not in cmd
+
+
+def test_atlas_disable_tool_grammar_string_value_lowercased():
+    """A quoted string bool (`"True"`/`"FALSE"`) is folded to lowercase.
+
+    YAML `disable_tool_grammar: "True"` reaches the config as a str, not a
+    bool, so the `isinstance(val, bool)` path would miss it and emit the
+    Atlas-rejected `True` verbatim. Bool-ish strings are normalized too.
+    """
+    runtime = AtlasRuntime()
+    for raw, expected in (("True", "true"), ("FALSE", "false"), ("  true  ", "true")):
+        recipe = _recipe(defaults={"disable_tool_grammar": raw})
+        cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+        assert f"--disable-tool-grammar {expected}" in cmd
+
+
 def test_atlas_generate_command_from_template():
     """Recipe with explicit command template renders it verbatim."""
     runtime = AtlasRuntime()


### PR DESCRIPTION
## Context

Follow-up to #221, which added `--disable-tool-grammar` / `--fp8-kv-calibration-tokens` to `_ATLAS_FLAG_MAP` and lowercased the bool value in `_normalize_config`. That fix shipped without tests and only normalized YAML **bools**. This PR closes both gaps.

## Changes

**1. Harden `disable_tool_grammar` normalization**

`_normalize_config` only folded the value when `isinstance(val, bool)`. A quoted recipe value — `disable_tool_grammar: "True"` — reaches the config as a `str`, slipped through unchanged, and emitted `--disable-tool-grammar True` — the exact casing Atlas' Rust bool parser rejects (the same class of surprise #221 set out to eliminate). Bool-ish strings (`"true"`/`"false"`, any case, surrounding whitespace) are now lowercased too; any other string is left untouched so Atlas surfaces its own parse error rather than us guessing.

**2. Regression tests** (absent in #221)

- `--disable-tool-grammar` renders a lowercase `true`/`false` **value** (not a bare toggle, never Python's `"True"`/`"False"`)
- quoted-string bools are lowercased
- `--fp8-kv-calibration-tokens` is emitted

## Verification

`pytest tests/test_atlas_runtime.py` — 45 passed; `ruff check` clean.