### PR TITLE
Recipes search function should rglob non-flat registries

### DIFF
--- a/src/sparkrun/core/registry.py
+++ b/src/sparkrun/core/registry.py
@@ -1562,21 +1562,15 @@ class RegistryManager:
             if recipe_dir is None:
                 continue
             # Flat lookup first (existing behavior)
+            found = False
             for ext in (".yaml", ".yml"):
                 candidate = recipe_dir / (name + ext)
                 if candidate.exists():
                     matches.append((entry.name, candidate))
+                    found = True
 
-        # If flat lookup found nothing, search subdirectories by stem
-        if not matches:
-            for entry in registries:
-                if not entry.enabled:
-                    continue
-                if not include_hidden and not entry.visible:
-                    continue
-                recipe_dir = self._recipe_dir(entry)
-                if recipe_dir is None:
-                    continue
+            # If flat lookup found nothing, search subdirectories by stem
+            if not found:
                 for ext in (".yaml", ".yml"):
                     for candidate in sorted(recipe_dir.rglob(f"{name}{ext}")):
                         matches.append((entry.name, candidate))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -544,6 +544,45 @@ class TestRecipeDiscovery:
         assert path.name == "qwen3-1.7b-vllm.yaml"
         assert "qwen3" in str(path)  # Verify it's in the subdirectory
 
+    def test_find_recipe_flat_match_does_not_hide_nested_in_other_registries(self, reg_dirs):
+        """Test that a flat match in one registry doesn't prevent rglob in another.
+
+        Bug: ``find_recipe_in_registries`` short-circuits on the first flat match
+        across *any* registry, skipping the ``rglob`` phase for all other registries.
+        A recipe that lives only in a subdirectory of registry B becomes invisible
+        when registry A has a flat recipe with the same stem.
+        """
+        config, cache = reg_dirs
+        mgr = RegistryManager(config, cache)
+
+        entries = [
+            RegistryEntry(name="reg-a", url="https://example.com/a", subpath="recipes"),
+            RegistryEntry(name="reg-b", url="https://example.com/b", subpath="recipes"),
+        ]
+        mgr._save_registries(entries)
+
+        # Registry A: flat recipe at recipes/<name>.yaml
+        recipe_dir_a = cache / "reg-a" / "recipes"
+        recipe_dir_a.mkdir(parents=True)
+        (cache / "reg-a" / ".git").mkdir(exist_ok=True)
+        with open(recipe_dir_a / "my-model-vllm.yaml", "w") as f:
+            yaml.dump({"name": "Flat Recipe", "model": "test"}, f)
+
+        # Registry B: same recipe name, but ONLY in a subdirectory (no flat match)
+        recipe_dir_b = cache / "reg-b" / "recipes"
+        nested_dir_b = recipe_dir_b / "my-model"
+        nested_dir_b.mkdir(parents=True)
+        (cache / "reg-b" / ".git").mkdir(exist_ok=True)
+        with open(nested_dir_b / "my-model-vllm.yaml", "w") as f:
+            yaml.dump({"name": "Nested Recipe", "model": "test"}, f)
+
+        matches = mgr.find_recipe_in_registries("my-model-vllm")
+
+        # BOTH registries should appear in the results
+        assert len(matches) == 2, f"Expected 2 matches (flat in reg-a, nested in reg-b), got {len(matches)}: {matches}"
+        registry_names = {m[0] for m in matches}
+        assert registry_names == {"reg-a", "reg-b"}
+
 
 class TestRegistryEntryNewFields:
     """Test new RegistryEntry fields."""


### PR DESCRIPTION
`RegistryManager.find_recipe_in_registries()` in `src/sparkrun/core/registry.py` has two phases: (1) flat lookup (`recipes/<name>.yaml`) across all registries, then (2) recursive `rglob` across all registries if phase 1 found **nothing at all**. Because the guard is `if not matches:` (single flag for all registries), a flat match in **any** registry prevents the recursive search from running **for every other registry**. A recipe that lives in a subdirectory (e.g. `recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4.yaml`) becomes invisible when a different registry has a flat file with the same stem.

## Reproduce

Prerequisite: Add the atlas registry and make it visible:

```
localuser@edgexpert-0d1f:~$ cat ~/.config/sparkrun/registries.yaml | grep atlas -A5
- name: atlas
  url: https://github.com/Avarok-Cybersecurity/atlas-recipes.git
  subpath: recipes
  description: "Official Atlas Spark recipes \u2014 the curated lineup from the avarok/atlas-gb10\
    \ catalogue (Qwen3.5/3-Next/Coder-Next, Gemma-4, Nemotron-3, Mistral-Small-4,\
    \ MiniMax-M2.7, Qwen3-VL). Maintained by the Atlas team."
    
localuser@edgexpert$ sparkrun registry list
Name                      URL                                           Enabled   Visible   Tuning   Bench
---------------------------------------------------------------------------------------------------------
atlas                     https://github.com/Avarok-Cybersecurity/atl.. yes       yes       no       no
eugr                      https://github.com/eugr/spark-vllm-docker     yes       yes       no       no
official                  https://github.com/spark-arena/recipe-regis.. yes       yes       yes      yes
sparkrun-transitional     https://github.com/dbotwinick/sparkrun-reci.. yes       yes       yes      no
community                 https://github.com/spark-arena/community-re.. yes       no        yes      yes
experimental              https://github.com/spark-arena/recipe-regis.. yes       no        no       no
sparkrun-testing          https://github.com/dbotwinick/sparkrun-reci.. yes       no        yes      yes
```

Try to show a recipe that exists in two registries, but  the second is flat (atlas) and target the non-flat:

```
localuser@edgexpert-0d1f:~/.local/share/uv/tools/sparkrun/lib/python3.12/site-packages/sparkrun/core$ sparkrun recipe show @atlas/qwen3.6-35b-a3b-nvfp4
Error: Recipe 'qwen3.6-35b-a3b-nvfp4' not found in registry 'atlas'
```

Do the same with the name-only (no registry targeted) and you get the flat version:

```
localuser@edgexpert-0d1f:~/.local/share/uv/tools/sparkrun/lib/python3.12/site-packages/sparkrun/core$ sparkrun recipe show qwen3.6-35b-a3b-nvfp4
Name:         @eugr/qwen3.6-35b-a3b-nvfp4
```

After the fix the `Error: Recipe 'qwen3.6-35b-a3b-nvfp4' not found in registry 'atlas'` no longer occurs (the recipe is shown). Furthermore the second command prompts to select registry:

```
❯ sparkrun recipe show qwen3.6-35b-a3b-nvfp4
Recipe 'qwen3.6-35b-a3b-nvfp4' found in multiple registries:
  1. @eugr/qwen3.6-35b-a3b-nvfp4
  2. @atlas/qwen3.6-35b-a3b-nvfp4

Select registry [1]: 
```



