### PR TITLE
fix(benchmark): tie benchmark identity to recipe content; never reuse COMPLETE state silently

### DIFF
--- a/src/sparkrun/api/_benchmark.py
+++ b/src/sparkrun/api/_benchmark.py
@@ -7,7 +7,6 @@ callers get the full flow with no Click / sys.exit coupling.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
@@ -143,6 +142,28 @@ def _write_consolidated(state_dir: Path, consolidated: dict[str, Any]) -> Path:
     p = state_dir / "consolidated.json"
     p.write_text(json.dumps(consolidated, indent=2))
     return p
+
+
+def _should_remeasure_complete_state(
+    resume_mode: "ResumeMode",
+    on_complete_state: "Callable[[Any], bool] | None",
+    existing_state: Any,
+) -> bool:
+    """Whether COMPLETE prior state should be discarded and re-measured.
+
+    "Resuming" COMPLETE state runs zero tasks and re-emits the previous run's
+    results into the new output — indistinguishable from a real measurement, so
+    it must never happen silently (the caller warns on the reuse path).
+
+    ``ResumeMode.AUTO`` delegates the choice to *on_complete_state* (the CLI
+    wires an interactive confirm); with no callback the library default is
+    reuse, matching prior behaviour.  ``IF_EXISTS`` / ``REQUIRED`` asked for a
+    resume explicitly, so they always reuse.  (``FRESH`` never reaches here —
+    it deletes the state before this decision.)
+    """
+    if resume_mode != ResumeMode.AUTO or on_complete_state is None:
+        return False
+    return bool(on_complete_state(existing_state))
 
 
 # ---------------------------------------------------------------------------
@@ -510,15 +531,15 @@ def _execute_benchmark(
 
     if tasks is not None:
         from sparkrun.benchmarking.run_state import BenchmarkRunState, derive_benchmark_id
+        from sparkrun.orchestration.job_metadata import derive_recipe_fingerprint
 
-        # Fingerprint the effective recipe configuration (canonical resolved
-        # content + user overrides) so two recipes sharing an intent — same
-        # model, port, parallelism — but differing in serve configuration
-        # (e.g. --speculative-config) derive distinct benchmark IDs.  Declared
-        # configuration only: resolved container digests and placement stay
-        # out, keeping the ID stable across relaunches of the same workload.
-        fp_raw = json.dumps(recipe.to_dict(overrides=overrides), sort_keys=True, default=str)
-        recipe_fingerprint = hashlib.sha256(fp_raw.encode()).hexdigest()[:12]
+        # The cluster_id's intent half — previously all derive_benchmark_id
+        # hashed — covers model, port and parallelism, so two recipes differing
+        # only in a serve argument (e.g. --speculative-config) collided and
+        # resumed into each other's results.  The fingerprint digests the
+        # declared serve configuration to separate them; it excludes resolved
+        # artifacts and placement, so the ID stays stable across relaunches.
+        recipe_fingerprint = derive_recipe_fingerprint(recipe, overrides)
 
         benchmark_id = derive_benchmark_id(
             cluster_id,
@@ -546,27 +567,17 @@ def _execute_benchmark(
                     shutil.rmtree(state_dir)
                     logger.debug("Deleted complete benchmark state at %s (--fresh)", state_dir)
                 existing_state = None
+            elif _should_remeasure_complete_state(resume_mode, on_complete_state, existing_state):
+                if state_dir and state_dir.exists():
+                    shutil.rmtree(state_dir)
+                    logger.debug("Deleted complete benchmark state at %s (user chose re-measure)", state_dir)
+                existing_state = None
             else:
-                # "Resuming" COMPLETE state runs zero tasks and re-emits the
-                # previous run's results into the new output — which looks
-                # exactly like a real measurement.  That must never happen
-                # silently.  AUTO consults the caller's callback (the CLI
-                # wires an interactive prompt); IF_EXISTS/REQUIRED asked for
-                # resume explicitly, so reuse — but say so.
-                remeasure = False
-                if resume_mode == ResumeMode.AUTO and on_complete_state is not None:
-                    remeasure = bool(on_complete_state(existing_state))
-                if remeasure:
-                    if state_dir and state_dir.exists():
-                        shutil.rmtree(state_dir)
-                        logger.debug("Deleted complete benchmark state at %s (user chose re-measure)", state_dir)
-                    existing_state = None
-                else:
-                    emitter.warning(
-                        "Prior benchmark state for %s is COMPLETE — re-emitting its recorded results; no requests will be sent. Use --fresh to re-measure."
-                        % benchmark_id
-                    )
-                    bench_result.resumed = True
+                emitter.warning(
+                    "Prior benchmark state for %s is COMPLETE — re-emitting its recorded results; no requests will be sent. Use --fresh to re-measure."
+                    % benchmark_id
+                )
+                bench_result.resumed = True
         else:
             if resume_mode == ResumeMode.FRESH:
                 if state_dir and state_dir.exists():

--- a/src/sparkrun/api/_benchmark.py
+++ b/src/sparkrun/api/_benchmark.py
@@ -7,6 +7,7 @@ callers get the full flow with no Click / sys.exit coupling.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -233,6 +234,7 @@ def _execute_benchmark(
     export_results_files = options.export_files
     resume_mode = options.resume
     on_prompt_required = options.on_prompt_required
+    on_complete_state = options.on_complete_state
     submission_id_for_extras = options.state_extras.get("submission_id") if options.state_extras else None
     scheduler_name = options.scheduler
     category = options.category
@@ -509,12 +511,22 @@ def _execute_benchmark(
     if tasks is not None:
         from sparkrun.benchmarking.run_state import BenchmarkRunState, derive_benchmark_id
 
+        # Fingerprint the effective recipe configuration (canonical resolved
+        # content + user overrides) so two recipes sharing an intent — same
+        # model, port, parallelism — but differing in serve configuration
+        # (e.g. --speculative-config) derive distinct benchmark IDs.  Declared
+        # configuration only: resolved container digests and placement stay
+        # out, keeping the ID stable across relaunches of the same workload.
+        fp_raw = json.dumps(recipe.to_dict(overrides=overrides), sort_keys=True, default=str)
+        recipe_fingerprint = hashlib.sha256(fp_raw.encode()).hexdigest()[:12]
+
         benchmark_id = derive_benchmark_id(
             cluster_id,
             fw.framework_name,
             profile,
             bench_args,
             [t.schedule_entry for t in tasks],
+            recipe_fingerprint=recipe_fingerprint,
         )
 
         state_dir = (config.cache_dir / "benchmarks" / benchmark_id) if config else None
@@ -534,6 +546,27 @@ def _execute_benchmark(
                     shutil.rmtree(state_dir)
                     logger.debug("Deleted complete benchmark state at %s (--fresh)", state_dir)
                 existing_state = None
+            else:
+                # "Resuming" COMPLETE state runs zero tasks and re-emits the
+                # previous run's results into the new output — which looks
+                # exactly like a real measurement.  That must never happen
+                # silently.  AUTO consults the caller's callback (the CLI
+                # wires an interactive prompt); IF_EXISTS/REQUIRED asked for
+                # resume explicitly, so reuse — but say so.
+                remeasure = False
+                if resume_mode == ResumeMode.AUTO and on_complete_state is not None:
+                    remeasure = bool(on_complete_state(existing_state))
+                if remeasure:
+                    if state_dir and state_dir.exists():
+                        shutil.rmtree(state_dir)
+                        logger.debug("Deleted complete benchmark state at %s (user chose re-measure)", state_dir)
+                    existing_state = None
+                else:
+                    emitter.warning(
+                        "Prior benchmark state for %s is COMPLETE — re-emitting its recorded results; no requests will be sent. Use --fresh to re-measure."
+                        % benchmark_id
+                    )
+                    bench_result.resumed = True
         else:
             if resume_mode == ResumeMode.FRESH:
                 if state_dir and state_dir.exists():

--- a/src/sparkrun/api/_benchmark_models.py
+++ b/src/sparkrun/api/_benchmark_models.py
@@ -154,6 +154,11 @@ class BenchmarkOptions:
     on_prompt_required: "Callable[[Any], bool] | None" = None
     """Callback invoked when the CLI would show a confirmation prompt.
     Return ``True`` to accept, ``False`` to cancel.  Step 4 wires this."""
+    on_complete_state: "Callable[[Any], bool] | None" = None
+    """Callback invoked under ``ResumeMode.AUTO`` when prior benchmark state is
+    already COMPLETE.  Return ``True`` to delete it and re-measure, ``False`` to
+    re-emit the recorded results.  When ``None``, complete state is reused —
+    with a warning, never silently."""
 
 
 # --------------------------------------------------------------------------

--- a/src/sparkrun/benchmarking/run_state.py
+++ b/src/sparkrun/benchmarking/run_state.py
@@ -32,6 +32,7 @@ def derive_benchmark_id(
     profile: str | None,
     base_args: dict[str, Any],
     schedule: list[dict[str, Any]] | None,
+    recipe_fingerprint: str | None = None,
 ) -> str:
     """Stable ID derived from canonical-JSON of inputs. Returns ``'bench_<12hex>'``.
 
@@ -40,6 +41,14 @@ def derive_benchmark_id(
     parsed via :func:`parse_cluster_id` and only its intent half is hashed, so a
     benchmark resumes successfully across relaunches that produce a fresh
     placement token but represent the same logical workload.
+
+    ``recipe_fingerprint`` extends the identity to the recipe's *content*
+    (declared serve configuration + user overrides): two recipes that share an
+    intent — same model, port, parallelism — but differ in a serve argument
+    (e.g. ``--speculative-config``) are different workloads and must never
+    resume into each other's results.  The fingerprint hashes declared
+    configuration only, never resolved artifacts or placement, so it is stable
+    across relaunches of the same logical workload.
 
     Malformed (legacy) cluster_ids that do not parse fall back to hashing the
     full string verbatim — they will not match a relaunch, but they also won't
@@ -64,6 +73,8 @@ def derive_benchmark_id(
         "base_args": base_args,
         "schedule": schedule,
     }
+    if recipe_fingerprint is not None:
+        payload["recipe_fingerprint"] = recipe_fingerprint
     raw = json.dumps(payload, sort_keys=True, default=str)
     digest = hashlib.sha256(raw.encode()).hexdigest()[:12]
     return "bench_%s" % digest

--- a/src/sparkrun/benchmarking/run_state.py
+++ b/src/sparkrun/benchmarking/run_state.py
@@ -46,7 +46,9 @@ def derive_benchmark_id(
     (declared serve configuration + user overrides): two recipes that share an
     intent — same model, port, parallelism — but differ in a serve argument
     (e.g. ``--speculative-config``) are different workloads and must never
-    resume into each other's results.  The fingerprint hashes declared
+    resume into each other's results.  Obtain it from
+    :func:`sparkrun.orchestration.job_metadata.derive_recipe_fingerprint`,
+    which is the single definition of *what* gets hashed: declared
     configuration only, never resolved artifacts or placement, so it is stable
     across relaunches of the same logical workload.
 

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -55,6 +55,30 @@ def _resolve_resume_prompt(
     return True
 
 
+def _resolve_complete_prompt(
+    state,
+    on_complete_state: "Callable[[Any], bool] | None",
+) -> bool:
+    """Decide whether to delete COMPLETE prior state and re-measure (mode AUTO).
+
+    Resolution order mirrors :func:`_resolve_resume_prompt`:
+    1. Explicit ``on_complete_state`` callback — caller drives the answer.
+    2. TTY: ``click.confirm`` with default=True (re-measure).
+    3. Non-TTY: ``False`` — reuse deterministically; the API layer warns that
+       cached results are being re-emitted.
+    """
+    if on_complete_state is not None:
+        return bool(on_complete_state(state))
+    import sys as _sys
+
+    if _sys.stdin.isatty():
+        return click.confirm(
+            "Found COMPLETE benchmark state — reusing it re-emits the previous results without running anything. Delete and re-measure?",
+            default=True,
+        )
+    return False
+
+
 class _BenchmarkGroup(click.Group):
     """Click group for ``sparkrun benchmark`` with:
 
@@ -448,6 +472,7 @@ def _run_benchmark(
     fresh: bool = False,
     resume_mode: "ResumeMode | None" = None,
     on_prompt_required: "Callable[[Any], bool] | None" = None,
+    on_complete_state: "Callable[[Any], bool] | None" = None,
     submission_id_for_extras: str | None = None,
     scheduler_name: str | None = None,
     host_list=None,
@@ -486,6 +511,12 @@ def _run_benchmark(
     # task count for the resumed run.
     if on_prompt_required is None:
         on_prompt_required = lambda state: _resolve_resume_prompt(state, len(state.schedule), None)  # noqa: E731
+
+    # Same wiring for COMPLETE prior state: reusing it re-emits recorded
+    # results without measuring, so AUTO mode asks (TTY) or reuses loudly
+    # (non-TTY) via ``_resolve_complete_prompt``.
+    if on_complete_state is None:
+        on_complete_state = lambda state: _resolve_complete_prompt(state, None)  # noqa: E731
 
     # Parse bench_options key=value strings into a dict for BenchmarkOptions.
     # Validation (insecure api_key, malformed) happens in _execute_benchmark.
@@ -565,6 +596,7 @@ def _run_benchmark(
         progress_callback=None,
         state_extras=state_extras,
         on_prompt_required=on_prompt_required,
+        on_complete_state=on_complete_state,
     )
 
     class _CliEmitter(_ProgressEmitter):

--- a/src/sparkrun/orchestration/job_metadata.py
+++ b/src/sparkrun/orchestration/job_metadata.py
@@ -24,11 +24,18 @@ from CLI inputs alone) can still recover workloads at stop / logs time:
 
 The composite ``cluster_id = "sparkrun_" + intent_id + "_" + placement_token``
 has two ``_`` separators (after ``sparkrun`` and after intent_id).
+
+Separately, :func:`derive_recipe_fingerprint` digests a recipe's full *serve
+configuration*.  It is **not** part of the cluster_id: the intent_id stays
+narrow on purpose so lookup paths keep matching a live workload, while
+consumers that must tell differently-configured workloads apart (benchmark
+identity) hash the fingerprint alongside it.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -205,6 +212,9 @@ def _resolve_override(key: str, overrides: dict | None, defaults: dict | None):
 INTENT_ID_LEN = 16
 PLACEMENT_TOKEN_BYTES = 6  # secrets.token_hex(PLACEMENT_TOKEN_BYTES) → PLACEMENT_TOKEN_LEN hex chars
 PLACEMENT_TOKEN_LEN = PLACEMENT_TOKEN_BYTES * 2
+# Length of the serve-configuration digest from :func:`derive_recipe_fingerprint`.
+# Not part of the cluster_id — it identifies *configuration*, not a workload.
+RECIPE_FINGERPRINT_LEN = 12
 
 _INTENT_ID_RE = re.compile(r"^[0-9a-f]{%d}$" % INTENT_ID_LEN)
 _PLACEMENT_TOKEN_RE = re.compile(r"^[0-9a-f]{%d}$" % PLACEMENT_TOKEN_LEN)
@@ -252,6 +262,84 @@ def generate_intent_id(recipe: "Recipe", overrides: dict | None = None) -> str:
 
     key = "\0".join(parts)
     return hashlib.sha256(key.encode()).hexdigest()[:INTENT_ID_LEN]
+
+
+def derive_recipe_fingerprint(recipe: "Recipe", overrides: dict | None = None) -> str:
+    """Deterministic :data:`RECIPE_FINGERPRINT_LEN`-char hex digest of a recipe's *serve configuration*.
+
+    The provenance peer of :func:`generate_intent_id`.  The intent_id answers
+    "which served endpoint is this?" and is deliberately narrow so ``stop`` /
+    ``status`` / ``logs`` keep finding a live workload across relaunches; this
+    answers "what exactly is being served?", so two recipes that share an
+    intent — same runtime, model, port, parallelism — but differ in a serve
+    argument (e.g. ``--max-num-batched-tokens``, ``--speculative-config``) are
+    distinguishable.  Consumers that must not conflate differently-configured
+    workloads hash this *alongside* the intent_id rather than widening the
+    intent_id itself (see
+    :func:`sparkrun.benchmarking.run_state.derive_benchmark_id`).
+
+    Hashes **declared** configuration only:
+
+    * the intent_id (runtime, model, port, served-model-name, parallelism)
+    * the resolved config chain — recipe ``defaults`` layered with *overrides*,
+      i.e. the serve-argument surface
+    * ``container``, ``command``, ``env``, ``model_revision``,
+      ``runtime_version``, ``layout``, ``min_nodes`` / ``max_nodes``.
+      ``command`` matters on its own: a serve flag hardcoded into the command
+      template (rather than declared under ``defaults``) never reaches the
+      config chain, so hashing the template is what catches it.
+    * ``mods`` and ``runtime_config`` — the latter absorbs unknown top-level
+      keys such as v1 ``build_args``, which change the image that gets built
+    * the recipe's *declared* ``pre_exec`` / ``post_exec`` / ``post_commands``,
+      read from the raw recipe so runtime- and builder-injected hooks don't
+      move the digest (v1 ``mods`` are injected into ``pre_exec`` during
+      resolution, which is why they are hashed from the declared list above)
+
+    Deliberately excluded, so the digest stays stable across relaunches of the
+    same logical workload: hosts and placement, resolved container digests /
+    pinned image SHAs, and ``metadata`` — the latter carries provenance plus
+    *auto-detected* model facts that a HuggingFace probe writes back into
+    ``recipe.metadata`` mid-run, so hashing it would make the digest depend on
+    network reachability.
+    """
+
+    def _val(value: Any) -> str:
+        # Canonical per-value encoding: sorts nested mapping keys (so a dict
+        # value's insertion order can't move the digest) while preserving list
+        # order (hook and arg sequence are semantically significant).
+        return json.dumps(value, sort_keys=True, default=str)
+
+    parts: list[str] = [generate_intent_id(recipe, overrides=overrides)]
+
+    config_chain = recipe.build_config_chain(overrides)
+    for key in sorted(config_chain.keys()):
+        parts.append("%s=%s" % (key, _val(config_chain.get(key))))
+
+    for attr in (
+        "container",
+        "command",
+        "model_revision",
+        "runtime_version",
+        "min_nodes",
+        "max_nodes",
+        "env",
+        "mods",
+        "runtime_config",
+    ):
+        parts.append("%s=%s" % (attr, _val(getattr(recipe, attr, None))))
+
+    layout = recipe.layout.to_dict() if getattr(recipe, "layout", None) is not None else None
+    parts.append("layout=%s" % _val(layout))
+
+    # Declared hooks only — ``recipe.pre_exec`` and friends are extended in
+    # place by v1 mods / builders during resolution (see core/mods.py), and
+    # those additions are resolved artifacts, not declared configuration.
+    raw = getattr(recipe, "_raw", None) or {}
+    for hook in ("pre_exec", "post_exec", "post_commands"):
+        parts.append("%s=%s" % (hook, _val(raw.get(hook) or [])))
+
+    key = "\0".join(parts)
+    return hashlib.sha256(key.encode()).hexdigest()[:RECIPE_FINGERPRINT_LEN]
 
 
 def generate_placement_token() -> str:

--- a/tests/test_benchmark_resume_modes.py
+++ b/tests/test_benchmark_resume_modes.py
@@ -239,3 +239,77 @@ def test_cli_fresh_flag_sets_fresh_mode():
             assert received["resume_mode"] == ResumeMode.FRESH
         else:
             assert result.exit_code != 2 or "mutually exclusive" not in (result.output or "")
+
+
+# ---------------------------------------------------------------------------
+# on_complete_state / _resolve_complete_prompt (complete prior state must
+# never be reused silently)
+# ---------------------------------------------------------------------------
+
+
+def test_api_on_complete_state_threaded_through():
+    received = []
+
+    def cb(state):
+        return True
+
+    with patch("sparkrun.api._benchmark._execute_benchmark", side_effect=_stub_execute_benchmark(received)):
+        from sparkrun.api import benchmark
+        from sparkrun.api._benchmark_models import BenchmarkOptions
+
+        benchmark(BenchmarkOptions(recipe="my-recipe", on_complete_state=cb))
+    assert received[0].on_complete_state is cb
+
+
+def test_resolve_complete_prompt_uses_callback_when_provided():
+    from sparkrun.cli._benchmark import _resolve_complete_prompt
+
+    state = MagicMock()
+    called_with = {}
+
+    def cb(s):
+        called_with["state"] = s
+        return False
+
+    result = _resolve_complete_prompt(state, on_complete_state=cb)
+    assert result is False
+    assert called_with["state"] is state
+
+
+def test_resolve_complete_prompt_callback_true():
+    from sparkrun.cli._benchmark import _resolve_complete_prompt
+
+    state = MagicMock()
+    assert _resolve_complete_prompt(state, on_complete_state=lambda s: True) is True
+
+
+def test_resolve_complete_prompt_non_tty_reuses():
+    """Non-TTY: deterministic reuse (False) — the API layer warns loudly."""
+    from unittest.mock import patch as _patch
+
+    from sparkrun.cli._benchmark import _resolve_complete_prompt
+
+    state = MagicMock()
+    with _patch("sys.stdin.isatty", lambda: False):
+        assert _resolve_complete_prompt(state, on_complete_state=None) is False
+
+
+def test_resolve_complete_prompt_tty_uses_click_confirm():
+    """TTY: click.confirm with default=True (re-measure)."""
+    from unittest.mock import patch as _patch
+
+    from sparkrun.cli._benchmark import _resolve_complete_prompt
+
+    state = MagicMock()
+    called = {}
+
+    def fake_confirm(msg, default):
+        called["msg"] = msg
+        called["default"] = default
+        return True
+
+    with _patch("sys.stdin.isatty", lambda: True), _patch("click.confirm", fake_confirm):
+        result = _resolve_complete_prompt(state, on_complete_state=None)
+    assert result is True
+    assert "re-measure" in called["msg"].lower()
+    assert called["default"] is True

--- a/tests/test_benchmark_resume_modes.py
+++ b/tests/test_benchmark_resume_modes.py
@@ -247,6 +247,45 @@ def test_cli_fresh_flag_sets_fresh_mode():
 # ---------------------------------------------------------------------------
 
 
+def test_should_remeasure_auto_honours_callback():
+    """AUTO delegates the decision to the caller's callback, both ways."""
+    from sparkrun.api._benchmark import _should_remeasure_complete_state
+
+    state = MagicMock()
+    seen = []
+
+    def cb(s):
+        seen.append(s)
+        return True
+
+    assert _should_remeasure_complete_state(ResumeMode.AUTO, cb, state) is True
+    assert seen == [state]
+    assert _should_remeasure_complete_state(ResumeMode.AUTO, lambda s: False, state) is False
+
+
+def test_should_remeasure_auto_without_callback_reuses():
+    """No callback (library default) → reuse; the caller warns about it."""
+    from sparkrun.api._benchmark import _should_remeasure_complete_state
+
+    assert _should_remeasure_complete_state(ResumeMode.AUTO, None, MagicMock()) is False
+
+
+def test_should_remeasure_explicit_resume_modes_never_prompt():
+    """IF_EXISTS / REQUIRED asked for a resume, so they reuse without consulting
+    the callback — even when one is wired (the CLI always wires one)."""
+    from sparkrun.api._benchmark import _should_remeasure_complete_state
+
+    called = []
+
+    def cb(s):
+        called.append(s)
+        return True
+
+    for mode in (ResumeMode.IF_EXISTS, ResumeMode.REQUIRED):
+        assert _should_remeasure_complete_state(mode, cb, MagicMock()) is False
+    assert called == []
+
+
 def test_api_on_complete_state_threaded_through():
     received = []
 

--- a/tests/test_benchmark_run_state.py
+++ b/tests/test_benchmark_run_state.py
@@ -67,6 +67,39 @@ def test_derive_benchmark_id_format(tmp_path: Path):
     assert re.fullmatch(r"bench_[0-9a-f]{12}", bid), f"Bad format: {bid!r}"
 
 
+def test_derive_benchmark_id_different_recipe_fingerprint(tmp_path: Path):
+    """Recipes sharing an intent but differing in content get distinct ids.
+
+    Two recipes with the same model/port/parallelism but a different serve
+    argument (different recipe fingerprint) are different workloads — resuming
+    one into the other's results would silently return wrong numbers.
+    """
+    id1 = derive_benchmark_id("cluster-abc", "llama-benchy", "default", {}, None, recipe_fingerprint="0" * 12)
+    id2 = derive_benchmark_id("cluster-abc", "llama-benchy", "default", {}, None, recipe_fingerprint="f" * 12)
+    assert id1 != id2
+
+
+def test_derive_benchmark_id_same_recipe_fingerprint_stable(tmp_path: Path):
+    """Same fingerprint (same declared workload) keeps the id stable across calls."""
+    id1 = derive_benchmark_id("cluster-abc", "llama-benchy", "default", {}, None, recipe_fingerprint="ab" * 6)
+    id2 = derive_benchmark_id("cluster-abc", "llama-benchy", "default", {}, None, recipe_fingerprint="ab" * 6)
+    assert id1 == id2
+
+
+def test_derive_benchmark_id_no_fingerprint_back_compat(tmp_path: Path):
+    """Omitting the fingerprint is identical to passing None (legacy callers)."""
+    id_omitted = derive_benchmark_id("cluster-abc", "llama-benchy", "default", {}, None)
+    id_none = derive_benchmark_id("cluster-abc", "llama-benchy", "default", {}, None, recipe_fingerprint=None)
+    assert id_omitted == id_none
+
+
+def test_derive_benchmark_id_fingerprint_changes_id(tmp_path: Path):
+    """A fingerprinted id differs from the legacy un-fingerprinted id."""
+    id_legacy = derive_benchmark_id("cluster-abc", "llama-benchy", "default", {}, None)
+    id_fp = derive_benchmark_id("cluster-abc", "llama-benchy", "default", {}, None, recipe_fingerprint="0" * 12)
+    assert id_legacy != id_fp
+
+
 # ---------------------------------------------------------------------------
 # BenchmarkRunState.save / load
 # ---------------------------------------------------------------------------

--- a/tests/test_recipe_fingerprint.py
+++ b/tests/test_recipe_fingerprint.py
@@ -1,0 +1,180 @@
+"""Tests for ``derive_recipe_fingerprint`` — the serve-configuration digest.
+
+The fingerprint is the provenance peer of ``generate_intent_id``: the intent_id
+stays narrow (runtime / model / port / served-model-name / parallelism) so
+lookup paths keep matching a live workload, while the fingerprint separates two
+recipes that share an intent but serve *different* configurations.
+
+Two invariants are load-bearing and each has a failure mode that shipped:
+
+* **Distinguishing** — recipes differing only in a serve argument must not
+  collide, or a benchmark resumes into another recipe's results (issue #232).
+* **Stability** — the digest must not move for reasons unrelated to declared
+  configuration (auto-detected metadata, runtime-injected hooks), or a resume
+  silently misses its own prior state.
+"""
+
+from __future__ import annotations
+
+from sparkrun.benchmarking.run_state import derive_benchmark_id
+from sparkrun.core.recipe import Recipe
+from sparkrun.orchestration.job_metadata import (
+    RECIPE_FINGERPRINT_LEN,
+    derive_recipe_fingerprint,
+    generate_cluster_id,
+    generate_intent_id,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _recipe(**changes) -> Recipe:
+    """A minimal v2 recipe; ``changes`` are merged over the base document."""
+    data = {
+        "recipe_version": "2",
+        "model": "Qwen/Qwen3-1.7B",
+        "runtime": "vllm",
+        "container": "vllm/vllm-openai:latest",
+        "defaults": {"port": 8000, "tensor_parallel": 1, "max_num_batched_tokens": 16384},
+        "metadata": {"description": "demo"},
+    }
+    defaults = dict(data["defaults"])
+    defaults.update(changes.pop("defaults", {}))
+    data.update(changes)
+    data["defaults"] = defaults
+    return Recipe(data)
+
+
+# ---------------------------------------------------------------------------
+# Format
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_format():
+    fp = derive_recipe_fingerprint(_recipe())
+    assert len(fp) == RECIPE_FINGERPRINT_LEN
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_fingerprint_is_deterministic():
+    assert derive_recipe_fingerprint(_recipe()) == derive_recipe_fingerprint(_recipe())
+
+
+# ---------------------------------------------------------------------------
+# Distinguishing: same intent, different serve configuration (issue #232)
+# ---------------------------------------------------------------------------
+
+
+def test_serve_arg_difference_changes_fingerprint():
+    """The #232 repro: two recipes differing ONLY in max_num_batched_tokens.
+
+    They share an intent — same runtime, model, port, parallelism — so the
+    intent_id alone cannot tell them apart.
+    """
+    a = _recipe(defaults={"max_num_batched_tokens": 16384})
+    b = _recipe(defaults={"max_num_batched_tokens": 32768})
+
+    assert generate_intent_id(a) == generate_intent_id(b), "precondition: the intent_id does NOT separate these"
+    assert derive_recipe_fingerprint(a) != derive_recipe_fingerprint(b)
+
+
+def test_serve_arg_difference_changes_benchmark_id():
+    """End-to-end: the #232 recipes must derive distinct benchmark IDs.
+
+    Same cluster_id (they place identically), same framework/profile/schedule —
+    only the fingerprint separates them.  This is the assertion that would have
+    caught the original defect.
+    """
+    a = _recipe(defaults={"max_num_batched_tokens": 16384})
+    b = _recipe(defaults={"max_num_batched_tokens": 32768})
+    cluster_id = generate_cluster_id(generate_intent_id(a), "abcdef012345")
+
+    id_a = derive_benchmark_id(cluster_id, "llama-benchy", "default", {}, None, recipe_fingerprint=derive_recipe_fingerprint(a))
+    id_b = derive_benchmark_id(cluster_id, "llama-benchy", "default", {}, None, recipe_fingerprint=derive_recipe_fingerprint(b))
+    assert id_a != id_b
+
+
+def test_cli_override_changes_fingerprint():
+    """A serve argument supplied as a CLI override counts as configuration."""
+    r = _recipe()
+    assert derive_recipe_fingerprint(r) != derive_recipe_fingerprint(r, {"max_num_batched_tokens": 32768})
+
+
+def test_hardcoded_command_flag_changes_fingerprint():
+    """A serve flag hardcoded into ``command`` — not declared under ``defaults``
+    — never reaches the config chain, so the command template itself must be
+    hashed or the two recipes collide.
+    """
+    a = _recipe(command="vllm serve {model} --max-num-batched-tokens 16384")
+    b = _recipe(command="vllm serve {model} --max-num-batched-tokens 32768")
+
+    assert generate_intent_id(a) == generate_intent_id(b), "precondition: the intent_id does NOT separate these"
+    assert derive_recipe_fingerprint(a) != derive_recipe_fingerprint(b)
+
+
+def test_container_env_and_revision_change_fingerprint():
+    base = derive_recipe_fingerprint(_recipe())
+    assert derive_recipe_fingerprint(_recipe(container="vllm/vllm-openai:v0.11.0")) != base
+    assert derive_recipe_fingerprint(_recipe(env={"VLLM_USE_V1": "1"})) != base
+    assert derive_recipe_fingerprint(_recipe(model_revision="abc123")) != base
+
+
+def test_v1_mods_and_build_args_change_fingerprint():
+    """v1 ``mods`` are injected into ``pre_exec`` during resolution and
+    ``build_args`` lands in ``runtime_config``; both change the image that
+    gets built, so both are hashed from their declared form.
+    """
+    base = derive_recipe_fingerprint(_recipe())
+    assert derive_recipe_fingerprint(_recipe(mods=["some-mod"])) != base
+    assert derive_recipe_fingerprint(_recipe(build_args={"VLLM_COMMIT": "abc123"})) != base
+
+
+def test_declared_hooks_change_fingerprint():
+    """Declared hooks alter what is measured, so they belong in the digest."""
+    assert derive_recipe_fingerprint(_recipe(post_commands=["echo warmup"])) != derive_recipe_fingerprint(_recipe())
+
+
+# ---------------------------------------------------------------------------
+# Stability: things that must NOT move the digest
+# ---------------------------------------------------------------------------
+
+
+def test_auto_detected_metadata_does_not_change_fingerprint():
+    """``Recipe.estimate_vram(auto_detect=True)`` writes HuggingFace-probed
+    facts back into ``recipe.metadata`` mid-run (core/recipe.py), and the
+    benchmark flow triggers that before deriving the ID.  Hashing metadata
+    would make the digest depend on network reachability — the same recipe
+    would resume against itself only when the probe happened to succeed.
+    """
+    r = _recipe()
+    before = derive_recipe_fingerprint(r)
+    r.metadata["model_params"] = 1_720_000_000
+    r.metadata["model_dtype"] = "bfloat16"
+    r.metadata["num_layers"] = 28
+    assert derive_recipe_fingerprint(r) == before
+
+
+def test_runtime_injected_hooks_do_not_change_fingerprint():
+    """v1 mods / builders extend ``recipe.pre_exec`` in place during resolution
+    (core/mods.py).  Those are resolved artifacts, not declared configuration.
+    """
+    r = _recipe()
+    before = derive_recipe_fingerprint(r)
+    r.pre_exec.append("docker build -t generated .")
+    assert derive_recipe_fingerprint(r) == before
+
+
+def test_nested_dict_ordering_does_not_change_fingerprint():
+    """A dict-valued serve argument must hash by content, not insertion order."""
+    a = _recipe(defaults={"speculative_config": {"method": "ngram", "num_speculative_tokens": 5}})
+    b = _recipe(defaults={"speculative_config": {"num_speculative_tokens": 5, "method": "ngram"}})
+    assert derive_recipe_fingerprint(a) == derive_recipe_fingerprint(b)
+
+
+def test_metadata_only_recipes_share_a_fingerprint():
+    """Two recipes differing only in documentation metadata are the same workload."""
+    a = _recipe(metadata={"description": "first"})
+    b = _recipe(metadata={"description": "second", "maintainer": "someone"})
+    assert derive_recipe_fingerprint(a) == derive_recipe_fingerprint(b)


### PR DESCRIPTION
Fixes #232.

1. A fingerprint of the resolved recipe content + CLI overrides (declared config only — resolved digests/placement excluded, so resume still survives relaunches) is folded into `derive_benchmark_id`. Two recipes sharing an intent but differing in a serve argument now derive distinct benchmark ids.
2. COMPLETE state under AUTO consults a new `on_complete_state` callback (the CLI wires an interactive confirm, default re-measure; non-TTY reuses deterministically), and every reuse path warns and marks the result resumed. IF_EXISTS/REQUIRED still reuse (explicitly requested) but warn too. FRESH already deleted complete state on this branch.

Unit tests included (fingerprint id derivation: distinct/stable/back-compat; the complete-state prompt resolution chain). The full suite introduces zero new failures vs pristine develop-next.

Fix validated on the same host/recipes as the #232 repro (DGX Spark, 0.3.0-alpha lineage):

```
A2:  bench_b7dce40fa322 (measured)
B2:  bench_89cb8f6608ac (measured)   <- distinct id, real second run
A2 repeat, no --fresh: same id bench_b7dce40fa322, reused with
"Warning: Prior benchmark state ... is COMPLETE — re-emitting its recorded
results; no requests will be sent. Use --fresh to re-measure."
```
