### PR TITLE
fix(stop): make `stop --all` work without self-SSH — dispatch discovery and stops locally, report real results

### DIFF
--- a/src/sparkrun/api/__init__.py
+++ b/src/sparkrun/api/__init__.py
@@ -63,12 +63,14 @@ from sparkrun.api._models import (
     LogLine,
     RunOptions,
     RunResult,
+    StopAllResult,
     StopResult,
 )
 from sparkrun.api._run import run
 from sparkrun.api._schedule import schedule
 from sparkrun.api._status import status, status_report
 from sparkrun.api._stop import stop
+from sparkrun.api._stop_all import stop_all
 from sparkrun.api._telemetry import LiveMonitorSession, live_monitor, open_live_monitor, open_telemetry
 
 __all__ = [
@@ -83,6 +85,7 @@ __all__ = [
     "RunOptions",
     "RunResult",
     "StopResult",
+    "StopAllResult",
     "LogLine",
     "JobInfo",
     # Benchmark data models
@@ -108,6 +111,7 @@ __all__ = [
     # Functions
     "run",
     "stop",
+    "stop_all",
     "logs",
     "schedule",
     "status",

--- a/src/sparkrun/api/_models.py
+++ b/src/sparkrun/api/_models.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from sparkrun.core.cluster_manager import ClusterDefinition
+    from sparkrun.core.cluster_manager import ClusterDefinition, ClusterStatusResult
     from sparkrun.core.recipe import Recipe
     from sparkrun.core.scheduler import RankAssignment
 
@@ -196,9 +196,47 @@ class StopResult:
     hosts_targeted: tuple[str, ...]
     """Hosts the stop command was issued against."""
     containers_removed: int
-    """Total count of containers/processes successfully stopped."""
+    """Count of containers/processes actually removed, as reported by the
+    teardown itself — not an assumption of one per host."""
     errors: tuple[str, ...] = ()
     """Human-readable error messages for any hosts that failed."""
+    hosts_failed: tuple[str, ...] = ()
+    """Hosts whose teardown did not confirm.  Non-empty means containers
+    may still be running (and holding VRAM); job metadata is deliberately
+    retained so the workload can still be found and stopped."""
+
+    @property
+    def success(self) -> bool:
+        """True when every targeted host confirmed teardown."""
+        return not self.hosts_failed and not self.errors
+
+
+@dataclass(frozen=True)
+class StopAllResult:
+    """Outputs of :func:`sparkrun.api.stop_all`."""
+
+    discovered: "ClusterStatusResult"
+    """The discovery snapshot the teardown acted on (also what the CLI
+    renders), so callers don't have to re-query to describe what was
+    found."""
+    jobs_stopped: int
+    """Discovered jobs (cluster groups + solo entries) whose containers
+    all confirmed teardown."""
+    containers_removed: int
+    """Containers actually removed, summed across hosts."""
+    hosts_stopped: tuple[str, ...] = ()
+    """Hosts whose teardown confirmed."""
+    hosts_failed: dict[str, str] = field(default_factory=dict)
+    """Host → error for teardowns that did not confirm."""
+    discovery_errors: dict[str, str] = field(default_factory=dict)
+    """Host → error for hosts that could not be queried at all.  These are
+    *not* "nothing to stop" — an unqueryable host may be running
+    containers we never saw."""
+
+    @property
+    def success(self) -> bool:
+        """True when every host was queried and every teardown confirmed."""
+        return not self.hosts_failed and not self.discovery_errors
 
 
 # --------------------------------------------------------------------------

--- a/src/sparkrun/api/_stop.py
+++ b/src/sparkrun/api/_stop.py
@@ -53,6 +53,7 @@ def stop(
         resolve_cluster,
         resolve_recipe,
     )
+    from sparkrun.orchestration.docker import parse_teardown_removed
     from sparkrun.orchestration.executor import resolve_executor
     from sparkrun.orchestration.job_metadata import (
         generate_intent_id,
@@ -146,10 +147,10 @@ def stop(
 
     container_names = executor.enumerate_containers(cluster_id, len(target_hosts))
 
-    # Use cleanup_containers — the established teardown path used by the
-    # CLI.  Tests mock ``sparkrun.orchestration.primitives.cleanup_containers``;
-    # this keeps the api stop dispatch on the conventional path.
-    from sparkrun.orchestration.primitives import build_ssh_kwargs, cleanup_containers
+    # ``cleanup_containers_by_host`` is the shared teardown primitive: it
+    # dispatches local-vs-SSH per host, verifies the containers are
+    # actually gone, and reports what it removed per host.
+    from sparkrun.orchestration.primitives import build_ssh_kwargs, cleanup_containers_by_host
 
     config = sctx.config if sctx is not None else _maybe_load_config()
     if config is not None and cluster_def.user:
@@ -162,23 +163,42 @@ def stop(
 
     errors: list[str] = []
     try:
-        cleanup_containers(target_hosts, container_names, ssh_kwargs=ssh_kwargs)
-        removed_count = len(target_hosts)
-    except Exception as e:
+        results = cleanup_containers_by_host(
+            {host: list(container_names) for host in target_hosts},
+            ssh_kwargs=ssh_kwargs,
+        )
+    except Exception as e:  # pragma: no cover - defensive; the primitive absorbs per-host failures
         errors.append(str(e))
-        removed_count = 0
+        results = {}
 
-    # Cleanup persistent metadata after best-effort stop (matches CLI behaviour).
-    try:
-        remove_job_metadata(cluster_id, cache_dir=cache_dir)
-    except Exception:
-        logger.debug("Failed to remove job metadata for %s", cluster_id, exc_info=True)
+    hosts_failed = tuple(host for host in target_hosts if not (results.get(host) and results[host].success))
+    removed_count = sum(parse_teardown_removed(r.stdout) for r in results.values())
+    for host in hosts_failed:
+        r = results.get(host)
+        detail = ((r.stderr or r.stdout).strip() if r else "") or "teardown did not confirm"
+        errors.append("%s: %s" % (host, detail))
+
+    # Cleanup persistent metadata only once teardown is confirmed
+    # everywhere: while a container survives, the metadata still describes
+    # a live workload and is what ``stop``/``status`` use to find it again.
+    if hosts_failed:
+        logger.warning(
+            "Keeping job metadata for %s — teardown did not confirm on: %s",
+            cluster_id,
+            ", ".join(hosts_failed),
+        )
+    else:
+        try:
+            remove_job_metadata(cluster_id, cache_dir=cache_dir)
+        except Exception:
+            logger.debug("Failed to remove job metadata for %s", cluster_id, exc_info=True)
 
     return StopResult(
         cluster_id=cluster_id,
         hosts_targeted=tuple(target_hosts),
         containers_removed=removed_count,
         errors=tuple(errors),
+        hosts_failed=hosts_failed,
     )
 
 

--- a/src/sparkrun/api/_stop_all.py
+++ b/src/sparkrun/api/_stop_all.py
@@ -1,0 +1,152 @@
+"""``sparkrun.api.stop_all`` — discover and stop every sparkrun workload.
+
+The discovery-driven counterpart to :func:`sparkrun.api.stop`: instead of
+naming a workload, sweep a set of hosts for whatever sparkrun launched
+and tear all of it down.
+
+This is console-free like the rest of ``sparkrun.api`` — it returns a
+:class:`~sparkrun.api._models.StopAllResult` describing what was found,
+what was removed, and what failed; rendering and exit codes are the
+caller's business.  (It previously lived inside the CLI's ``--all``
+branch, which meant the GUI sidecar and any other library caller had no
+way to do it and no way to inherit its fixes.)
+
+Two failure modes are distinguished, and neither is ever silently
+reported as success:
+
+- **discovery errors** — a host that could not be queried.  It is *not*
+  "nothing to stop"; it may be running containers we never saw.
+- **teardown failures** — a host whose containers did not confirm gone.
+  Job metadata for anything with a container there is deliberately
+  retained, because the workload is still live and the metadata is how
+  it is found again.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from sparkrun.api._models import StopAllResult
+
+if TYPE_CHECKING:
+    from sparkrun.core.cluster_manager import ClusterDefinition, ClusterStatusResult
+    from sparkrun.core.context import SparkrunContext
+
+logger = logging.getLogger(__name__)
+
+
+def stop_all(
+    hosts: list[str] | tuple[str, ...],
+    *,
+    cluster: "str | ClusterDefinition | None" = None,
+    cache_dir: str | None = None,
+    ssh_kwargs: dict | None = None,
+    dry_run: bool = False,
+    discovered: "ClusterStatusResult | None" = None,
+    sctx: "SparkrunContext | None" = None,
+) -> StopAllResult:
+    """Discover and stop every sparkrun workload on *hosts*.
+
+    Args:
+        hosts: Hosts to sweep.
+        cluster: Optional cluster name/definition for executor + transport
+            resolution (forwarded to :func:`sparkrun.api.status_report`).
+        cache_dir: Cache directory holding job metadata.
+        ssh_kwargs: SSH connection parameters.
+        dry_run: Log the teardown without executing it.  Discovery still
+            runs for real — there is nothing to preview otherwise.
+        discovered: A snapshot from :func:`sparkrun.api.status_report` to
+            act on instead of re-querying.  Lets a caller that already
+            displayed the discovery (the CLI) avoid a second sweep.
+        sctx: Optional shared :class:`SparkrunContext`.
+
+    Returns:
+        :class:`~sparkrun.api._models.StopAllResult`.
+    """
+    from sparkrun.api._status import status_report
+    from sparkrun.orchestration.docker import parse_teardown_removed
+    from sparkrun.orchestration.primitives import cleanup_containers_by_host
+
+    host_list = list(hosts)
+    result = discovered
+    if result is None:
+        result = status_report(host_list, cluster=cluster, ssh_kwargs=ssh_kwargs, cache_dir=cache_dir, sctx=sctx)
+
+    discovery_errors = dict(result.errors)
+
+    if result.total_containers == 0:
+        return StopAllResult(
+            discovered=result,
+            jobs_stopped=0,
+            containers_removed=0,
+            discovery_errors=discovery_errors,
+        )
+
+    host_containers = _containers_by_host(result)
+
+    results = cleanup_containers_by_host(host_containers, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
+
+    failed_hosts: dict[str, str] = {}
+    for host in host_containers:
+        r = results.get(host)
+        if r is None:
+            failed_hosts[host] = "teardown did not run"
+        elif not r.success:
+            failed_hosts[host] = (r.stderr or r.stdout).strip() or ("exit code %d" % r.returncode)
+
+    if dry_run:
+        # Nothing was executed, so nothing failed and nothing was removed;
+        # report the discovered shape as what *would* be stopped.
+        return StopAllResult(
+            discovered=result,
+            jobs_stopped=len(result.groups) + len(result.solo_entries),
+            containers_removed=result.total_containers,
+            hosts_stopped=tuple(host_containers),
+        )
+
+    containers_removed = sum(parse_teardown_removed(r.stdout) for r in results.values())
+
+    # Drop job metadata only for jobs with no container left behind.
+    jobs_stopped = 0
+    for cid, group in result.groups.items():
+        if any(member_host in failed_hosts for member_host, _role, _status, _image in group.members):
+            continue
+        _forget_job(cid, cache_dir)
+        jobs_stopped += 1
+    for entry in result.solo_entries:
+        if entry.host in failed_hosts:
+            continue
+        solo_cid = entry.name.removesuffix("_solo") if entry.name.endswith("_solo") else entry.name
+        _forget_job(solo_cid, cache_dir)
+        jobs_stopped += 1
+
+    return StopAllResult(
+        discovered=result,
+        jobs_stopped=jobs_stopped,
+        containers_removed=containers_removed,
+        hosts_stopped=tuple(h for h in host_containers if h not in failed_hosts),
+        hosts_failed=failed_hosts,
+        discovery_errors=discovery_errors,
+    )
+
+
+def _containers_by_host(result: "ClusterStatusResult") -> dict[str, list[str]]:
+    """Map host → container names to tear down, from a discovery snapshot."""
+    host_containers: dict[str, list[str]] = {}
+    for cid, group in result.groups.items():
+        for host, role, _status, _image in group.members:
+            host_containers.setdefault(host, []).append("%s_%s" % (cid, role))
+    for entry in result.solo_entries:
+        host_containers.setdefault(entry.host, []).append(entry.name)
+    return host_containers
+
+
+def _forget_job(cluster_id: str, cache_dir: str | None) -> None:
+    """Remove job metadata, tolerating an already-absent record."""
+    from sparkrun.orchestration.job_metadata import remove_job_metadata
+
+    try:
+        remove_job_metadata(cluster_id, cache_dir=cache_dir)
+    except Exception:
+        logger.debug("Failed to remove job metadata for %s", cluster_id, exc_info=True)

--- a/src/sparkrun/cli/_stop_logs.py
+++ b/src/sparkrun/cli/_stop_logs.py
@@ -6,10 +6,11 @@ results to the TTY.  Business logic (cluster_id derivation, executor
 selection from metadata, parallel host dispatch, log streaming)
 lives in :mod:`sparkrun.api`.
 
-The ``--all`` discovery path remains in this module because it has
-no API equivalent yet — that discovery is presentation-heavy (lists
-running clusters by recipe) and would expand the API surface for
-limited benefit.
+``--all`` is no different: discovery and teardown live in
+:func:`sparkrun.api.stop_all`, and this module only prints the
+discovered workloads between the two and maps the result onto an exit
+code.  (It used to own that logic, which meant library callers — the
+desktop sidecar included — could neither do it nor inherit its fixes.)
 """
 
 from __future__ import annotations
@@ -117,10 +118,13 @@ def stop(ctx, target, hosts, hosts_file, cluster_name, stop_all, tp_override, po
         click.echo("Error: %s" % e, err=True)
         sys.exit(1)
 
-    if result.errors:
-        for line in result.errors:
-            click.echo("Warning: %s" % line, err=True)
+    # A teardown that did not confirm is an error, not a warning: the
+    # containers may still be running.  Same contract as ``--all``.
+    for line in result.errors:
+        click.echo("Error: %s" % line, err=True)
     click.echo("Workload stopped on %d host(s)." % len(result.hosts_targeted))
+    if not result.success:
+        sys.exit(1)
 
 
 def _hosts_for_cluster_id_target(target, hosts, hosts_file, cluster_name, config) -> list[str]:
@@ -145,15 +149,14 @@ def _hosts_for_cluster_id_target(target, hosts, hosts_file, cluster_name, config
 
 
 def _stop_all(hosts, hosts_file, cluster_name, config, dry_run, sctx=None):
-    """Discover and stop all sparkrun containers on the target hosts.
+    """Render ``sparkrun stop --all``.
 
-    Kept inline because the discovery-heavy presentation has no API
-    equivalent — it prints a summary of running clusters before
-    issuing teardown commands.
+    Discovery and teardown live in :func:`sparkrun.api.stop_all`; this
+    prints the discovered workloads between the two (which is why the
+    snapshot is passed back in rather than re-queried) and translates the
+    result into output and an exit code.
     """
-    from sparkrun.orchestration.docker import docker_stop_cmd
-    from sparkrun.orchestration.job_metadata import remove_job_metadata
-    from sparkrun.orchestration.primitives import build_ssh_kwargs, run_command_on_host
+    from sparkrun.orchestration.primitives import build_ssh_kwargs
 
     host_list, _cluster_mgr = _resolve_hosts_or_exit(hosts, hosts_file, cluster_name, config, sctx=sctx)
 
@@ -162,78 +165,47 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run, sctx=None):
     click.echo("Discovering sparkrun containers on %d host(s)..." % len(host_list))
     # Status flows from the single source, ``api.status_report`` (cluster-aware
     # resolution + cross-executor merge + display classification).
-    result = api.status_report(host_list, cluster=cluster_name or None, ssh_kwargs=ssh_kwargs, sctx=sctx)
+    discovered = api.status_report(host_list, cluster=cluster_name or None, ssh_kwargs=ssh_kwargs, sctx=sctx)
 
     # A host that errored during discovery may still be running containers —
     # it must not silently read as "nothing to stop".
-    if result.errors:
-        for err_host, err in sorted(result.errors.items()):
-            click.echo("Error: could not query %s: %s" % (err_host, err), err=True)
+    for err_host, err in sorted(discovered.errors.items()):
+        click.echo("Error: could not query %s: %s" % (err_host, err), err=True)
 
-    if result.total_containers == 0:
-        click.echo("No sparkrun containers running.")
-        if result.errors:
+    if discovered.total_containers == 0:
+        if discovered.errors:
+            click.echo("No sparkrun containers found on the hosts that could be queried.")
             sys.exit(1)
+        click.echo("No sparkrun containers running.")
         return
 
     # Summarise what was found
-    jobs_count = len(result.groups) + len(result.solo_entries)
-    click.echo("Found %d job(s), %d container(s):" % (jobs_count, result.total_containers))
-    for cid, group in result.groups.items():
+    jobs_count = len(discovered.groups) + len(discovered.solo_entries)
+    click.echo("Found %d job(s), %d container(s):" % (jobs_count, discovered.total_containers))
+    for cid, group in discovered.groups.items():
         recipe_label = group.meta.get("recipe", "unknown")
         click.echo("  %s (%s) — %d container(s)" % (cid, recipe_label, len(group.members)))
-    for entry in result.solo_entries:
+    for entry in discovered.solo_entries:
         click.echo("  %s on %s" % (entry.name, entry.host))
 
-    # Build per-host container name mapping
-    host_containers: dict[str, list[str]] = {}
-    for cid, group in result.groups.items():
-        for host, role, status, image in group.members:
-            container_name = "%s_%s" % (cid, role)
-            host_containers.setdefault(host, []).append(container_name)
-    for entry in result.solo_entries:
-        host_containers.setdefault(entry.host, []).append(entry.name)
-
-    # Stop containers per host.  Dispatch local-vs-SSH via run_command_on_host
-    # (a bare run_remote_command would try to SSH to localhost, which fails on
-    # hosts without self-SSH configured) and check the result — a failed stop
-    # must not be reported as success.
     click.echo("Stopping all containers...")
-    container_count = 0
-    failed_hosts: dict[str, str] = {}
-    for host, names in host_containers.items():
-        cmds = "; ".join(docker_stop_cmd(n) for n in names)
-        res = run_command_on_host(host, cmds, ssh_kwargs=ssh_kwargs, timeout=30, dry_run=dry_run)
-        if res.success:
-            container_count += len(names)
-        else:
-            failed_hosts[host] = (res.stderr or res.stdout).strip() or ("exit code %d" % res.returncode)
+    result = api.stop_all(
+        host_list,
+        cluster=cluster_name or None,
+        cache_dir=str(config.cache_dir),
+        ssh_kwargs=ssh_kwargs,
+        dry_run=dry_run,
+        discovered=discovered,
+        sctx=sctx,
+    )
 
-    # Clean up job metadata for discovered clusters (skip in dry-run mode and
-    # for any cluster/solo entry with a member on a host where stopping failed
-    # — the container is still running and the metadata still describes it).
-    stopped_jobs = 0
-    if not dry_run:
-        for cid, group in result.groups.items():
-            if any(member_host in failed_hosts for member_host, _role, _status, _image in group.members):
-                continue
-            remove_job_metadata(cid, cache_dir=str(config.cache_dir))
-            stopped_jobs += 1
-        for entry in result.solo_entries:
-            if entry.host in failed_hosts:
-                continue
-            solo_cid = entry.name.removesuffix("_solo") if entry.name.endswith("_solo") else entry.name
-            remove_job_metadata(solo_cid, cache_dir=str(config.cache_dir))
-            stopped_jobs += 1
-    else:
-        stopped_jobs = jobs_count
-
-    hosts_touched = len(host_containers) - len(failed_hosts)
-    click.echo("Stopped %d job(s), %d container(s) across %d host(s)." % (stopped_jobs, container_count, hosts_touched))
-    if failed_hosts:
-        for failed_host, err in sorted(failed_hosts.items()):
-            click.echo("Error: failed to stop containers on %s: %s" % (failed_host, err), err=True)
-    if failed_hosts or result.errors:
+    click.echo(
+        "Stopped %d job(s), %d container(s) across %d host(s)."
+        % (result.jobs_stopped, result.containers_removed, len(result.hosts_stopped))
+    )
+    for failed_host, err in sorted(result.hosts_failed.items()):
+        click.echo("Error: failed to stop containers on %s: %s" % (failed_host, err), err=True)
+    if not result.success:
         sys.exit(1)
 
 

--- a/src/sparkrun/cli/_stop_logs.py
+++ b/src/sparkrun/cli/_stop_logs.py
@@ -153,8 +153,7 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run, sctx=None):
     """
     from sparkrun.orchestration.docker import docker_stop_cmd
     from sparkrun.orchestration.job_metadata import remove_job_metadata
-    from sparkrun.orchestration.primitives import build_ssh_kwargs
-    from sparkrun.orchestration.ssh import run_remote_command
+    from sparkrun.orchestration.primitives import build_ssh_kwargs, run_command_on_host
 
     host_list, _cluster_mgr = _resolve_hosts_or_exit(hosts, hosts_file, cluster_name, config, sctx=sctx)
 
@@ -187,24 +186,46 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run, sctx=None):
     for entry in result.solo_entries:
         host_containers.setdefault(entry.host, []).append(entry.name)
 
-    # Stop containers per host
+    # Stop containers per host.  Dispatch local-vs-SSH via run_command_on_host
+    # (a bare run_remote_command would try to SSH to localhost, which fails on
+    # hosts without self-SSH configured) and check the result — a failed stop
+    # must not be reported as success.
     click.echo("Stopping all containers...")
     container_count = 0
+    failed_hosts: dict[str, str] = {}
     for host, names in host_containers.items():
         cmds = "; ".join(docker_stop_cmd(n) for n in names)
-        run_remote_command(host, cmds, timeout=30, dry_run=dry_run, **ssh_kwargs)
-        container_count += len(names)
+        res = run_command_on_host(host, cmds, ssh_kwargs=ssh_kwargs, timeout=30, dry_run=dry_run)
+        if res.success:
+            container_count += len(names)
+        else:
+            failed_hosts[host] = (res.stderr or res.stdout).strip() or ("exit code %d" % res.returncode)
 
-    # Clean up job metadata for discovered clusters (skip in dry-run mode)
+    # Clean up job metadata for discovered clusters (skip in dry-run mode and
+    # for any cluster/solo entry with a member on a host where stopping failed
+    # — the container is still running and the metadata still describes it).
+    stopped_jobs = 0
     if not dry_run:
-        for cid in result.groups:
+        for cid, group in result.groups.items():
+            if any(member_host in failed_hosts for member_host, _role, _status, _image in group.members):
+                continue
             remove_job_metadata(cid, cache_dir=str(config.cache_dir))
+            stopped_jobs += 1
         for entry in result.solo_entries:
+            if entry.host in failed_hosts:
+                continue
             solo_cid = entry.name.removesuffix("_solo") if entry.name.endswith("_solo") else entry.name
             remove_job_metadata(solo_cid, cache_dir=str(config.cache_dir))
+            stopped_jobs += 1
+    else:
+        stopped_jobs = jobs_count
 
-    hosts_touched = len(host_containers)
-    click.echo("Stopped %d job(s), %d container(s) across %d host(s)." % (jobs_count, container_count, hosts_touched))
+    hosts_touched = len(host_containers) - len(failed_hosts)
+    click.echo("Stopped %d job(s), %d container(s) across %d host(s)." % (stopped_jobs, container_count, hosts_touched))
+    if failed_hosts:
+        for failed_host, err in sorted(failed_hosts.items()):
+            click.echo("Error: failed to stop containers on %s: %s" % (failed_host, err), err=True)
+        sys.exit(1)
 
 
 @click.command("logs")

--- a/src/sparkrun/cli/_stop_logs.py
+++ b/src/sparkrun/cli/_stop_logs.py
@@ -164,8 +164,16 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run, sctx=None):
     # resolution + cross-executor merge + display classification).
     result = api.status_report(host_list, cluster=cluster_name or None, ssh_kwargs=ssh_kwargs, sctx=sctx)
 
+    # A host that errored during discovery may still be running containers —
+    # it must not silently read as "nothing to stop".
+    if result.errors:
+        for err_host, err in sorted(result.errors.items()):
+            click.echo("Error: could not query %s: %s" % (err_host, err), err=True)
+
     if result.total_containers == 0:
         click.echo("No sparkrun containers running.")
+        if result.errors:
+            sys.exit(1)
         return
 
     # Summarise what was found
@@ -225,6 +233,7 @@ def _stop_all(hosts, hosts_file, cluster_name, config, dry_run, sctx=None):
     if failed_hosts:
         for failed_host, err in sorted(failed_hosts.items()):
             click.echo("Error: failed to stop containers on %s: %s" % (failed_host, err), err=True)
+    if failed_hosts or result.errors:
         sys.exit(1)
 
 

--- a/src/sparkrun/core/hardware_probe.py
+++ b/src/sparkrun/core/hardware_probe.py
@@ -330,10 +330,14 @@ def probe_host(
         logger.info("[dry-run] Would probe host %s", host)
         return HostHardware(notes="dry-run probe")
 
+    # ``allow_local=True``: the probed host may be this machine, and a
+    # single-node cluster without self-SSH would otherwise probe as
+    # "hardware probe failed".
     result = run_remote_script(
         host,
         generate_combined_probe_script(),
         timeout=30,
+        allow_local=True,
         **(ssh_kwargs or {}),
     )
     if not result.success:
@@ -377,6 +381,7 @@ def probe_hosts(
         hosts,
         generate_combined_probe_script(),
         timeout=30,
+        allow_local=True,
         **kw,
     )
 

--- a/src/sparkrun/orchestration/docker.py
+++ b/src/sparkrun/orchestration/docker.py
@@ -58,6 +58,74 @@ def docker_stop_cmd(container_name: str, force: bool = True) -> str:
     return "docker stop %s 2>/dev/null || true" % quoted
 
 
+TEARDOWN_REMOVED_MARKER = "sparkrun_removed="
+
+
+def docker_teardown_script(container_names: list[str] | tuple[str, ...]) -> str:
+    """Generate a teardown script that removes containers *and verifies it*.
+
+    :func:`docker_stop_cmd` ends in ``|| true`` so a candidate name that
+    was never running doesn't fail the chain -- which also means a *real*
+    docker failure (daemon down, permission denied, no docker binary)
+    exits 0 and reads as a successful teardown.  Callers that need a
+    truthful answer use this instead: the same removals, followed by a
+    verification pass that
+
+    - fails if docker itself could not be queried afterwards,
+    - fails, listing them, if any target container survived, and
+    - prints ``sparkrun_removed=<n>`` so the caller can report the
+      containers actually removed instead of assuming one per host.
+
+    Args:
+        container_names: Candidate container names to remove.  Names that
+            aren't present are not failures -- teardown is idempotent.
+
+    Returns:
+        Bash script content; a no-op script when *container_names* is empty.
+    """
+    if not container_names:
+        return 'echo "' + TEARDOWN_REMOVED_MARKER + '0"\n'
+
+    lines = ["_sr_removed=0"]
+    for name in container_names:
+        lines.append("if docker rm -f " + quote(name) + " >/dev/null 2>&1; then _sr_removed=$((_sr_removed + 1)); fi")
+
+    # Verification pass.  ``docker ps -a`` (not ``docker ps``) because
+    # ``rm -f`` must leave nothing behind, stopped or running.
+    patterns = " ".join("-e " + quote(name) for name in container_names)
+    lines.extend(
+        [
+            "if ! _sr_all=$(docker ps -a --format '{{.Names}}' 2>&1); then",
+            '  echo "docker ps failed: $_sr_all" >&2',
+            "  exit 1",
+            "fi",
+            "_sr_left=$(printf '%s\\n' \"$_sr_all\" | grep -Fx " + patterns + " || true)",
+            'if [ -n "$_sr_left" ]; then',
+            "  echo \"containers still present: $(printf '%s' \"$_sr_left\" | tr '\\n' ' ')\" >&2",
+            "  exit 1",
+            "fi",
+            'echo "' + TEARDOWN_REMOVED_MARKER + '$_sr_removed"',
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_teardown_removed(stdout: str) -> int:
+    """Read the ``sparkrun_removed=<n>`` count out of teardown stdout.
+
+    Returns 0 when the marker is absent or unparseable -- an unknown
+    count is reported as "removed nothing", never as an optimistic guess.
+    """
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if line.startswith(TEARDOWN_REMOVED_MARKER):
+            try:
+                return int(line[len(TEARDOWN_REMOVED_MARKER) :])
+            except ValueError:
+                return 0
+    return 0
+
+
 def docker_inspect_exists_cmd(image: str) -> str:
     """Generate a command to check if a docker image exists locally.
 

--- a/src/sparkrun/orchestration/executors/docker.py
+++ b/src/sparkrun/orchestration/executors/docker.py
@@ -431,11 +431,8 @@ class DockerExecutor(Executor):
         Unreachable hosts are omitted from :attr:`ClusterStatus.hosts`;
         callers can detect this via ``status.for_host(h) is None``.
         """
-        from dataclasses import replace as _dc_replace
-
         from sparkrun.core.cluster_status import ClusterStatus, HostOccupancy
         from sparkrun.core.hardware import default_dgx_spark_hardware
-        from sparkrun.orchestration.primitives import run_local_script, should_run_locally
         from sparkrun.orchestration.ssh import run_remote_scripts_parallel
 
         if not hosts:
@@ -443,30 +440,21 @@ class DockerExecutor(Executor):
 
         ssh_kwargs = ssh_kwargs or {}
         script = "docker ps --no-trunc --format '{{json .}}' 2>/dev/null || true\n"
-
-        # Dispatch local-vs-SSH per host (the same partition
-        # run_command_on_host and try_clear_page_cache use): a bare SSH to
-        # localhost fails on hosts without self-SSH configured, which would
-        # make every local workload invisible to status discovery — and
-        # everything downstream of it (stop --all, cluster status,
-        # scheduler occupancy).
-        ssh_user = ssh_kwargs.get("ssh_user")
-        local_hosts = [h for h in hosts if should_run_locally(h, ssh_user)]
-        remote_hosts = [h for h in hosts if not should_run_locally(h, ssh_user)]
-
-        results = [_dc_replace(run_local_script(script), host=h) for h in local_hosts]
-        if remote_hosts:
-            results.extend(
-                run_remote_scripts_parallel(
-                    remote_hosts,
-                    script,
-                    ssh_user=ssh_user,
-                    ssh_key=ssh_kwargs.get("ssh_key"),
-                    ssh_options=ssh_kwargs.get("ssh_options"),
-                    timeout=ssh_kwargs.get("timeout", 15),
-                    quiet=True,
-                )
-            )
+        # ``allow_local=True``: a bare SSH to localhost fails on a host
+        # without self-SSH configured, which would make every local
+        # workload invisible to status discovery — and to everything
+        # downstream of it (stop --all, cluster status, scheduler
+        # occupancy, the monitor TUI).
+        results = run_remote_scripts_parallel(
+            hosts,
+            script,
+            ssh_user=ssh_kwargs.get("ssh_user"),
+            ssh_key=ssh_kwargs.get("ssh_key"),
+            ssh_options=ssh_kwargs.get("ssh_options"),
+            timeout=ssh_kwargs.get("timeout", 15),
+            quiet=True,
+            allow_local=True,
+        )
 
         # Map results back to input host order.
         by_host = {r.host: r for r in results}

--- a/src/sparkrun/orchestration/executors/docker.py
+++ b/src/sparkrun/orchestration/executors/docker.py
@@ -431,8 +431,11 @@ class DockerExecutor(Executor):
         Unreachable hosts are omitted from :attr:`ClusterStatus.hosts`;
         callers can detect this via ``status.for_host(h) is None``.
         """
+        from dataclasses import replace as _dc_replace
+
         from sparkrun.core.cluster_status import ClusterStatus, HostOccupancy
         from sparkrun.core.hardware import default_dgx_spark_hardware
+        from sparkrun.orchestration.primitives import run_local_script, should_run_locally
         from sparkrun.orchestration.ssh import run_remote_scripts_parallel
 
         if not hosts:
@@ -440,15 +443,30 @@ class DockerExecutor(Executor):
 
         ssh_kwargs = ssh_kwargs or {}
         script = "docker ps --no-trunc --format '{{json .}}' 2>/dev/null || true\n"
-        results = run_remote_scripts_parallel(
-            hosts,
-            script,
-            ssh_user=ssh_kwargs.get("ssh_user"),
-            ssh_key=ssh_kwargs.get("ssh_key"),
-            ssh_options=ssh_kwargs.get("ssh_options"),
-            timeout=ssh_kwargs.get("timeout", 15),
-            quiet=True,
-        )
+
+        # Dispatch local-vs-SSH per host (the same partition
+        # run_command_on_host and try_clear_page_cache use): a bare SSH to
+        # localhost fails on hosts without self-SSH configured, which would
+        # make every local workload invisible to status discovery — and
+        # everything downstream of it (stop --all, cluster status,
+        # scheduler occupancy).
+        ssh_user = ssh_kwargs.get("ssh_user")
+        local_hosts = [h for h in hosts if should_run_locally(h, ssh_user)]
+        remote_hosts = [h for h in hosts if not should_run_locally(h, ssh_user)]
+
+        results = [_dc_replace(run_local_script(script), host=h) for h in local_hosts]
+        if remote_hosts:
+            results.extend(
+                run_remote_scripts_parallel(
+                    remote_hosts,
+                    script,
+                    ssh_user=ssh_user,
+                    ssh_key=ssh_kwargs.get("ssh_key"),
+                    ssh_options=ssh_kwargs.get("ssh_options"),
+                    timeout=ssh_kwargs.get("timeout", 15),
+                    quiet=True,
+                )
+            )
 
         # Map results back to input host order.
         by_host = {r.host: r for r in results}

--- a/src/sparkrun/orchestration/executors/local.py
+++ b/src/sparkrun/orchestration/executors/local.py
@@ -478,6 +478,9 @@ class LocalExecutor(Executor):
         ) % pid_dir
 
         ssh_kwargs = ssh_kwargs or {}
+        # ``allow_local=True`` for the same reason as the docker executor:
+        # both share the ``"host"`` status scope and are merged, so a host
+        # without self-SSH must not hide its native workloads either.
         results = run_remote_scripts_parallel(
             hosts,
             script,
@@ -486,6 +489,7 @@ class LocalExecutor(Executor):
             ssh_options=ssh_kwargs.get("ssh_options"),
             timeout=ssh_kwargs.get("timeout", 15),
             quiet=True,
+            allow_local=True,
         )
         by_host = {r.host: r for r in results}
         host_entries: list[HostOccupancy] = []

--- a/src/sparkrun/orchestration/primitives.py
+++ b/src/sparkrun/orchestration/primitives.py
@@ -8,7 +8,6 @@ their particular launch and teardown flows.
 from __future__ import annotations
 
 import logging
-import subprocess
 
 from sparkrun.core.config import SparkrunConfig, resolve_hf_cache_home
 from sparkrun.utils import is_valid_ip
@@ -16,9 +15,11 @@ from sparkrun.orchestration.ssh import (
     DEFAULT_MAX_PARALLEL_SSH,
     RemoteResult,
     resolve_parallel_cap,
+    run_local_script,
     run_remote_command,
     run_remote_script,
     run_remote_scripts_parallel,
+    should_run_locally,
 )
 from sparkrun.orchestration.comm_env import ClusterCommEnv
 from sparkrun.orchestration.infiniband import (
@@ -389,6 +390,76 @@ def check_tcp_reachability(
     return results
 
 
+def cleanup_containers_by_host(
+    host_containers: dict[str, list[str]],
+    ssh_kwargs: dict | None = None,
+    dry_run: bool = False,
+    max_workers: int | None = None,
+) -> dict[str, RemoteResult]:
+    """Tear down a *different* container set per host, in parallel.
+
+    The shared teardown primitive: one dispatching, verifying removal per
+    host.  Unlike a bare ``docker rm -f ... || true`` chain, the script
+    (:func:`~sparkrun.orchestration.docker.docker_teardown_script`)
+    confirms the containers are actually gone and reports how many it
+    removed, so callers can report a truthful count instead of assuming
+    the command that returned 0 did anything.
+
+    Best-effort per host: an exception or a failed teardown on one host
+    is recorded, never raised, so it can't block or mask cleanup of the
+    rest.
+
+    Args:
+        host_containers: Mapping of host → container names on that host.
+        ssh_kwargs: SSH connection parameters.
+        dry_run: Log without executing.
+        max_workers: Cap on concurrent cleanup workers (defaults to the
+            shared SSH fan-out cap).
+
+    Returns:
+        Mapping of host → :class:`RemoteResult`.  ``result.success`` is
+        the per-host verdict; the removed count is recoverable via
+        :func:`~sparkrun.orchestration.docker.parse_teardown_removed`.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from sparkrun.orchestration.docker import docker_teardown_script
+
+    if not host_containers:
+        return {}
+
+    results: dict[str, RemoteResult] = {}
+    with ThreadPoolExecutor(max_workers=resolve_parallel_cap(len(host_containers), max_workers)) as pool:
+        futures = {
+            pool.submit(
+                run_command_on_host,
+                host,
+                docker_teardown_script(names),
+                ssh_kwargs=ssh_kwargs,
+                timeout=30,
+                dry_run=dry_run,
+                quiet=True,
+            ): host
+            for host, names in host_containers.items()
+        }
+        for future in as_completed(futures):
+            host = futures[future]
+            try:
+                results[host] = future.result()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("Cleanup raised on %s: %s", host, e)
+                results[host] = RemoteResult(host=host, returncode=255, stdout="", stderr=str(e))
+
+    failed = [h for h, r in results.items() if not r.success] if not dry_run else []
+    if failed:
+        logger.warning(
+            "Container cleanup did not confirm on %d host(s): %s — these may still hold VRAM; check with 'sparkrun stop' or 'docker ps'.",
+            len(failed),
+            ", ".join(sorted(failed)),
+        )
+    return results
+
+
 def cleanup_containers(
     hosts: list[str],
     container_names: list[str],
@@ -396,12 +467,11 @@ def cleanup_containers(
     dry_run: bool = False,
     max_workers: int | None = None,
 ) -> list[str]:
-    """Stop and remove named containers on every host, in parallel.
+    """Stop and remove the same named containers on every host, in parallel.
 
-    Uses local execution when a host is localhost, SSH otherwise.  Cleanup is
-    best-effort: each host is attempted independently and failures are
-    reported (returned + logged) rather than raised, so one unreachable host
-    can't block or mask cleanup of the rest.
+    Thin wrapper over :func:`cleanup_containers_by_host` for the common
+    "same candidate names everywhere" case (see it for the dispatch and
+    verification semantics).
 
     Args:
         hosts: Target hosts.
@@ -412,39 +482,22 @@ def cleanup_containers(
             shared SSH fan-out cap).
 
     Returns:
-        List of hosts where the stop command failed (empty on full success).
-        Always empty in dry-run mode.
+        List of hosts where the teardown did not confirm (empty on full
+        success).  Always empty in dry-run mode.
     """
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    cmds = "; ".join(docker_stop_cmd(name) for name in container_names)
     if not hosts:
         return []
 
-    failed: list[str] = []
-    with ThreadPoolExecutor(max_workers=resolve_parallel_cap(len(hosts), max_workers)) as pool:
-        futures = {
-            pool.submit(run_command_on_host, host, cmds, ssh_kwargs=ssh_kwargs, timeout=30, dry_run=dry_run, quiet=True): host
-            for host in hosts
-        }
-        for future in as_completed(futures):
-            host = futures[future]
-            try:
-                result = future.result()
-            except Exception as e:  # pragma: no cover - defensive
-                logger.debug("Cleanup raised on %s: %s", host, e)
-                failed.append(host)
-                continue
-            if not result.success and not dry_run:
-                failed.append(host)
-
-    if failed and not dry_run:
-        logger.warning(
-            "Container cleanup did not confirm on %d host(s): %s — these may still hold VRAM; check with 'sparkrun stop' or 'docker ps'.",
-            len(failed),
-            ", ".join(failed),
-        )
-    return failed
+    results = cleanup_containers_by_host(
+        {host: list(container_names) for host in hosts},
+        ssh_kwargs=ssh_kwargs,
+        dry_run=dry_run,
+        max_workers=max_workers,
+    )
+    if dry_run:
+        return []
+    # Preserve the caller's host order in the failure report.
+    return [host for host in hosts if not results[host].success]
 
 
 def cleanup_containers_local(
@@ -549,68 +602,13 @@ def find_available_port(
 
 
 # ---------------------------------------------------------------------------
-# Execution dispatch predicate
-# ---------------------------------------------------------------------------
-
-
-def should_run_locally(host: str, ssh_user: str | None = None) -> bool:
-    """True if *host* is local AND no cross-user SSH is needed.
-
-    Use this instead of :func:`~sparkrun.utils.is_local_host` at
-    execution dispatch points (where the code decides "run locally via
-    subprocess" vs "run via SSH").  Keep ``is_local_host`` for pure
-    address-identity checks (e.g. "is this IP me?").
-
-    Returns ``True`` when the host is local and *ssh_user* is ``None``
-    or matches the current OS user.
-    """
-    import os
-    from sparkrun.utils import is_local_host
-
-    if not is_local_host(host):
-        return False
-    if ssh_user is None:
-        return True
-    return ssh_user == os.environ.get("USER", "root")
-
-
-# ---------------------------------------------------------------------------
-# Local execution
-# ---------------------------------------------------------------------------
-
-
-def run_local_script(script: str, dry_run: bool = False) -> RemoteResult:
-    """Execute a script locally via subprocess.
-
-    Args:
-        script: Bash script content to execute.
-        dry_run: If True, log the script but don't execute.
-
-    Returns:
-        RemoteResult with host set to ``"localhost"``.
-    """
-    if dry_run:
-        script_lines = script.count("\n")
-        logger.info("[dry-run] Would execute locally (%d lines, %d bytes)", script_lines, len(script))
-        return RemoteResult(host="localhost", returncode=0, stdout="[dry-run]", stderr="")
-
-    proc = subprocess.run(
-        ["bash", "-s"],
-        input=script,
-        capture_output=True,
-        text=True,
-    )
-    return RemoteResult(
-        host="localhost",
-        returncode=proc.returncode,
-        stdout=proc.stdout,
-        stderr=proc.stderr,
-    )
-
-
-# ---------------------------------------------------------------------------
 # Execution helpers (local-or-remote dispatch)
 # ---------------------------------------------------------------------------
+#
+# ``should_run_locally`` / ``run_local_script`` are defined in
+# ``orchestration.ssh`` (alongside ``RemoteResult``, and so the fan-out
+# helpers there can honour ``allow_local``); they are re-exported above
+# for the many callers that import them from here.
 
 
 def run_script_on_host(
@@ -627,7 +625,7 @@ def run_script_on_host(
     """
     kw = ssh_kwargs or {}
     if should_run_locally(host, kw.get("ssh_user")):
-        return run_local_script(script, dry_run=dry_run)
+        return run_local_script(script, dry_run=dry_run, timeout=timeout)
     return run_remote_script(host, script, timeout=timeout, dry_run=dry_run, **kw)
 
 
@@ -642,7 +640,7 @@ def run_command_on_host(
     """Run a command on a host — dispatches to local or remote execution."""
     kw = ssh_kwargs or {}
     if should_run_locally(host, kw.get("ssh_user")):
-        return run_local_script("#!/bin/bash\n" + command, dry_run=dry_run)
+        return run_local_script("#!/bin/bash\n" + command, dry_run=dry_run, timeout=timeout)
     return run_remote_command(host, command, timeout=timeout, dry_run=dry_run, quiet=quiet, **kw)
 
 

--- a/src/sparkrun/orchestration/ssh.py
+++ b/src/sparkrun/orchestration/ssh.py
@@ -3,14 +3,22 @@
 All remote operations in sparkrun are executed by generating scripts
 as Python strings and piping them to `ssh <host> bash -s` via stdin.
 No files are ever copied to remote hosts.
+
+A host in the target list may *be* the control machine (the single-node
+DGX Spark case, or a control node that is also a cluster member).  SSH to
+such a host only works when self-SSH has been configured, so the
+local-vs-SSH dispatch primitives (:func:`should_run_locally`,
+:func:`run_local_script`) live here alongside :class:`RemoteResult`, and
+the fan-out helpers can honour them via ``allow_local=True``.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from sparkrun.utils.shell import quote, quote_list, args_list_to_shell_str, stdin_bytes
 
@@ -66,6 +74,74 @@ class RemoteResult:
         """Get the last non-empty line of stdout (useful for extracting IPs etc)."""
         lines = [line for line in self.stdout.strip().splitlines() if line.strip()]
         return lines[-1] if lines else ""
+
+
+# ---------------------------------------------------------------------------
+# Local execution / dispatch
+# ---------------------------------------------------------------------------
+
+
+def should_run_locally(host: str, ssh_user: str | None = None) -> bool:
+    """True if *host* is local AND no cross-user SSH is needed.
+
+    Use this instead of :func:`~sparkrun.utils.is_local_host` at
+    execution dispatch points (where the code decides "run locally via
+    subprocess" vs "run via SSH").  Keep ``is_local_host`` for pure
+    address-identity checks (e.g. "is this IP me?").
+
+    Returns ``True`` when the host is local and *ssh_user* is ``None``
+    or matches the current OS user.
+    """
+    from sparkrun.utils import is_local_host
+
+    if not is_local_host(host):
+        return False
+    if ssh_user is None:
+        return True
+    return ssh_user == os.environ.get("USER", "root")
+
+
+def run_local_script(script: str, dry_run: bool = False, timeout: int | None = None) -> RemoteResult:
+    """Execute a script locally via subprocess.
+
+    Args:
+        script: Bash script content to execute.
+        dry_run: If True, log the script but don't execute.
+        timeout: Wall-clock cap in seconds.  Mirrors the SSH path's
+            ``timeout``: a local dispatch must not be able to hang a
+            caller (status polling, teardown) that bounded the remote
+            path.  A timeout is reported as rc 124, like ``timeout(1)``.
+
+    Returns:
+        RemoteResult with host set to ``"localhost"``.
+    """
+    if dry_run:
+        script_lines = script.count("\n")
+        logger.info("[dry-run] Would execute locally (%d lines, %d bytes)", script_lines, len(script))
+        return RemoteResult(host="localhost", returncode=0, stdout="[dry-run]", stderr="")
+
+    try:
+        proc = subprocess.run(
+            ["bash", "-s"],
+            input=script,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        logger.warning("Local execution timed out after %ss", timeout)
+        return RemoteResult(
+            host="localhost",
+            returncode=124,
+            stdout=_decode(e.stdout),
+            stderr=(_decode(e.stderr) + ("\n" if e.stderr else "")) + "local execution timed out after %ss" % timeout,
+        )
+    return RemoteResult(
+        host="localhost",
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+    )
 
 
 def _decode(raw: bytes | str | None) -> str:
@@ -192,6 +268,7 @@ def run_remote_script(
     timeout: int | None = None,
     dry_run: bool = False,
     quiet: bool = False,
+    allow_local: bool = False,
 ) -> RemoteResult:
     """Execute a script on a remote host via stdin piping.
 
@@ -208,6 +285,9 @@ def run_remote_script(
         timeout: Overall execution timeout in seconds.
         dry_run: If True, log the script but don't execute.
         quiet: If True, downgrade failure logging from WARNING to DEBUG.
+        allow_local: Run the script directly (no SSH) when *host* is this
+            machine — see :func:`run_remote_scripts_parallel` for why this
+            is opt-in.
 
     Returns:
         RemoteResult with returncode, stdout, stderr.
@@ -216,6 +296,10 @@ def run_remote_script(
     if dry_run:
         logger.info("[dry-run] Would execute on %s (%d lines, %d bytes)", host, script_lines, len(script))
         return RemoteResult(host=host, returncode=0, stdout="[dry-run]", stderr="")
+
+    if allow_local and should_run_locally(host, ssh_user):
+        logger.debug("  Dispatching locally (no SSH) for: %s", host)
+        return replace(run_local_script(script, timeout=timeout), host=host)
 
     cmd = build_ssh_cmd(host, ssh_user, ssh_key, ssh_options, connect_timeout)
     cmd.extend(["bash", "-s"])
@@ -575,6 +659,7 @@ def run_remote_scripts_parallel(
     dry_run: bool = False,
     quiet: bool = False,
     max_workers: int | None = None,
+    allow_local: bool = False,
 ) -> list[RemoteResult]:
     """Execute the same script on multiple hosts in parallel using threads.
 
@@ -590,6 +675,14 @@ def run_remote_scripts_parallel(
         max_workers: Cap on concurrent SSH workers.  Defaults to
             :data:`DEFAULT_MAX_PARALLEL_SSH`; the effective pool size is
             ``min(len(hosts), max_workers)``.
+        allow_local: Run the script directly (no SSH) on any host that
+            :func:`should_run_locally` accepts.  **Opt-in**, because for
+            some callers SSH-to-self is the point, not an accident:
+            ``api.setup`` probes and meshes SSH credentials and must
+            really connect.  Callers that just want the script's output
+            (status discovery, hardware probes, teardown) pass ``True``
+            so they work on a host without self-SSH configured.  Results
+            are re-keyed to the caller's host string either way.
 
     Returns:
         List of RemoteResult, one per host (order not guaranteed).
@@ -598,23 +691,28 @@ def run_remote_scripts_parallel(
 
     logger.info("  Running script in parallel on %d hosts: %s", len(hosts), ", ".join(hosts))
 
+    local_hosts = {h for h in hosts if should_run_locally(h, ssh_user)} if allow_local else set()
+    if local_hosts:
+        logger.debug("  Dispatching locally (no SSH) for: %s", ", ".join(sorted(local_hosts)))
+
+    def _dispatch(host: str) -> RemoteResult:
+        if host in local_hosts:
+            return replace(run_local_script(script, dry_run=dry_run, timeout=timeout), host=host)
+        return run_remote_script(
+            host,
+            script,
+            ssh_user=ssh_user,
+            ssh_key=ssh_key,
+            ssh_options=ssh_options,
+            timeout=timeout,
+            dry_run=dry_run,
+            quiet=quiet,
+        )
+
     t0 = time.monotonic()
     results: list[RemoteResult] = []
     with ThreadPoolExecutor(max_workers=resolve_parallel_cap(len(hosts), max_workers)) as executor:
-        futures = {
-            executor.submit(
-                run_remote_script,
-                host,
-                script,
-                ssh_user=ssh_user,
-                ssh_key=ssh_key,
-                ssh_options=ssh_options,
-                timeout=timeout,
-                dry_run=dry_run,
-                quiet=quiet,
-            ): host
-            for host in hosts
-        }
+        futures = {executor.submit(_dispatch, host): host for host in hosts}
         for future in as_completed(futures):
             result = future.result()
             results.append(result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5118,11 +5118,14 @@ class TestClusterUserInCLICommands:
 
         captured_kwargs = {}
 
-        def mock_cleanup(host_list, container_names, ssh_kwargs=None, dry_run=False):
+        def mock_cleanup(host_containers, ssh_kwargs=None, dry_run=False, max_workers=None):
+            from sparkrun.orchestration.ssh import RemoteResult
+
             captured_kwargs.update(ssh_kwargs or {})
+            return {h: RemoteResult(host=h, returncode=0, stdout="sparkrun_removed=1", stderr="") for h in host_containers}
 
         monkeypatch.setattr(
-            "sparkrun.orchestration.primitives.cleanup_containers",
+            "sparkrun.orchestration.primitives.cleanup_containers_by_host",
             mock_cleanup,
         )
         monkeypatch.setattr("sparkrun.orchestration.job_metadata.generate_intent_id", lambda *a, **kw: "aabbccdd1122")
@@ -5538,7 +5541,7 @@ class TestStopLogsClusterIdAndOverrides:
             )
 
         with (
-            mock.patch("sparkrun.orchestration.primitives.cleanup_containers"),
+            mock.patch("sparkrun.orchestration.primitives.cleanup_containers_by_host"),
             mock.patch("sparkrun.orchestration.job_metadata.generate_intent_id", return_value="aabbccdd1122") as mock_gen,
             mock.patch.object(DockerExecutor, "query_status", fake_query_status),
             mock.patch("subprocess.run", return_value=mock.Mock(returncode=1, stderr="mocked")),
@@ -5574,7 +5577,7 @@ class TestStopLogsClusterIdAndOverrides:
             )
 
         with (
-            mock.patch("sparkrun.orchestration.primitives.cleanup_containers"),
+            mock.patch("sparkrun.orchestration.primitives.cleanup_containers_by_host"),
             mock.patch("sparkrun.orchestration.job_metadata.generate_intent_id", return_value="aabbccdd1122") as mock_gen,
             mock.patch.object(DockerExecutor, "query_status", fake_query_status),
             mock.patch("subprocess.run", return_value=mock.Mock(returncode=1, stderr="mocked")),
@@ -5611,7 +5614,7 @@ class TestStopLogsClusterIdAndOverrides:
         }
         (jobs_dir / "aabbccdd1122.yaml").write_text(yaml.safe_dump(meta))
 
-        with mock.patch("sparkrun.orchestration.primitives.cleanup_containers") as mock_cleanup:
+        with mock.patch("sparkrun.orchestration.primitives.cleanup_containers_by_host") as mock_cleanup:
             result = runner.invoke(main, ["stop", "aabbccdd1122"])
             assert result.exit_code == 0
             assert "stopped" in result.output.lower()

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -412,8 +412,14 @@ def test_api_stop_recipe_path_succeeds_on_single_match(tmp_path, intent_recipe, 
     from sparkrun.orchestration.executors.docker import DockerExecutor
 
     monkeypatch.setattr(DockerExecutor, "query_status", fake_query_status)
+
     # Stub cleanup to short-circuit the actual SSH dispatch.
-    monkeypatch.setattr("sparkrun.orchestration.primitives.cleanup_containers", lambda *a, **kw: None)
+    def fake_cleanup(host_containers, ssh_kwargs=None, dry_run=False, max_workers=None):
+        from sparkrun.orchestration.ssh import RemoteResult
+
+        return {h: RemoteResult(host=h, returncode=0, stdout="sparkrun_removed=1", stderr="") for h in host_containers}
+
+    monkeypatch.setattr("sparkrun.orchestration.primitives.cleanup_containers_by_host", fake_cleanup)
 
     result = api.stop(recipe=intent_recipe, hosts=("h1",), cache_dir=str(tmp_path))
     assert result.cluster_id == cid

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -657,7 +657,7 @@ def test_stop_by_cluster_id_cross_user_uses_ssh():
     with (
         patch("sparkrun.orchestration.job_metadata.load_job_metadata", return_value={"hosts": ["127.0.0.1"]}),
         patch("sparkrun.orchestration.job_metadata.remove_job_metadata"),
-        patch("sparkrun.orchestration.primitives.cleanup_containers") as mock_remote,
+        patch("sparkrun.orchestration.primitives.cleanup_containers_by_host") as mock_remote,
         patch("sparkrun.orchestration.primitives.cleanup_containers_local") as mock_local,
     ):
         api.stop(cluster_id="sparkrun_abc12345", hosts=("127.0.0.1",), cache_dir="/tmp/cache")

--- a/tests/test_stop_all_dispatch.py
+++ b/tests/test_stop_all_dispatch.py
@@ -1,0 +1,86 @@
+"""Tests for ``stop --all`` teardown dispatch and result handling.
+
+The stop leg must route through ``run_command_on_host`` (local-vs-SSH
+dispatch — a bare ``run_remote_command`` tries to SSH to localhost, which
+fails on hosts without self-SSH configured), and a failed stop must never be
+reported as success: metadata stays, the count is truthful, and the exit
+code is non-zero.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from sparkrun.cli import main
+from sparkrun.core.cluster_manager import ClusterSoloEntry, ClusterStatusResult
+from sparkrun.orchestration.ssh import RemoteResult
+
+
+def _one_solo_report(hosts, *, executor=None, cluster=None, ssh_kwargs=None, sctx=None):
+    """Discovery result with one running solo container on localhost."""
+    entry = ClusterSoloEntry(
+        cluster_id="sparkrun_aaaabbbbccccdddd_eeeeffff0000",
+        host="localhost",
+        name="sparkrun_aaaabbbbccccdddd_eeeeffff0000_solo",
+        status="Up 5 minutes",
+        image="img",
+        meta={},
+    )
+    return ClusterStatusResult(
+        groups={},
+        solo_entries=[entry],
+        errors={},
+        idle_hosts=[],
+        pending_ops=[],
+        total_containers=1,
+        host_count=1,
+    )
+
+
+def test_stop_all_failure_exits_nonzero_and_preserves_metadata(monkeypatch):
+    """A failed stop: exit 1, per-host error, metadata NOT removed, truthful count."""
+    removed = []
+    dispatched = []
+
+    def mock_run_command_on_host(host, command, ssh_kwargs=None, timeout=None, dry_run=False, quiet=False):
+        dispatched.append(host)
+        return RemoteResult(host=host, returncode=255, stdout="", stderr="Host key verification failed.")
+
+    monkeypatch.setattr("sparkrun.api.status_report", _one_solo_report)
+    monkeypatch.setattr("sparkrun.orchestration.primitives.run_command_on_host", mock_run_command_on_host)
+    monkeypatch.setattr(
+        "sparkrun.orchestration.job_metadata.remove_job_metadata",
+        lambda cid, cache_dir=None: removed.append(cid),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    assert dispatched == ["localhost"]
+    assert removed == []
+    assert "Stopped 0 job(s), 0 container(s) across 0 host(s)." in result.output
+    assert "failed to stop containers on localhost" in result.output
+    assert "Host key verification failed." in result.output
+
+
+def test_stop_all_success_cleans_metadata_and_reports(monkeypatch):
+    """A successful stop: exit 0, metadata removed, truthful count."""
+    removed = []
+
+    def mock_run_command_on_host(host, command, ssh_kwargs=None, timeout=None, dry_run=False, quiet=False):
+        return RemoteResult(host=host, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("sparkrun.api.status_report", _one_solo_report)
+    monkeypatch.setattr("sparkrun.orchestration.primitives.run_command_on_host", mock_run_command_on_host)
+    monkeypatch.setattr(
+        "sparkrun.orchestration.job_metadata.remove_job_metadata",
+        lambda cid, cache_dir=None: removed.append(cid),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert removed == ["sparkrun_aaaabbbbccccdddd_eeeeffff0000"]
+    assert "Stopped 1 job(s), 1 container(s) across 1 host(s)." in result.output

--- a/tests/test_stop_all_dispatch.py
+++ b/tests/test_stop_all_dispatch.py
@@ -84,3 +84,48 @@ def test_stop_all_success_cleans_metadata_and_reports(monkeypatch):
     assert result.exit_code == 0
     assert removed == ["sparkrun_aaaabbbbccccdddd_eeeeffff0000"]
     assert "Stopped 1 job(s), 1 container(s) across 1 host(s)." in result.output
+
+
+def test_query_status_dispatches_locally_for_local_host(monkeypatch):
+    """Status discovery must not SSH to a local host (no self-SSH required)."""
+    from sparkrun.orchestration.executors.docker import DockerExecutor
+
+    def mock_local_script(script, dry_run=False):
+        assert "docker ps" in script
+        return RemoteResult(host="localhost", returncode=0, stdout="", stderr="")
+
+    def fail_if_sshed(*args, **kwargs):
+        raise AssertionError("query_status attempted SSH for a local host")
+
+    monkeypatch.setattr("sparkrun.orchestration.primitives.should_run_locally", lambda host, ssh_user=None: True)
+    monkeypatch.setattr("sparkrun.orchestration.primitives.run_local_script", mock_local_script)
+    monkeypatch.setattr("sparkrun.orchestration.ssh.run_remote_scripts_parallel", fail_if_sshed)
+
+    status = DockerExecutor().query_status(["localhost"])
+    occ = status.for_host("localhost")
+    assert occ is not None, "local host missing from status (dispatch failed)"
+    assert occ.workloads == ()
+
+
+def test_stop_all_discovery_error_exits_nonzero(monkeypatch):
+    """A host that errors during discovery must not read as 'nothing to stop'."""
+
+    def erroring_report(hosts, *, executor=None, cluster=None, ssh_kwargs=None, sctx=None):
+        return ClusterStatusResult(
+            groups={},
+            solo_entries=[],
+            errors={"localhost": "Host key verification failed."},
+            idle_hosts=[],
+            pending_ops=[],
+            total_containers=0,
+            host_count=1,
+        )
+
+    monkeypatch.setattr("sparkrun.api.status_report", erroring_report)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    assert "could not query localhost" in result.output
+    assert "Host key verification failed." in result.output

--- a/tests/test_stop_all_dispatch.py
+++ b/tests/test_stop_all_dispatch.py
@@ -1,27 +1,35 @@
-"""Tests for ``stop --all`` teardown dispatch and result handling.
+"""Tests for teardown dispatch and result handling ("stop must not lie").
 
-The stop leg must route through ``run_command_on_host`` (local-vs-SSH
-dispatch — a bare ``run_remote_command`` tries to SSH to localhost, which
-fails on hosts without self-SSH configured), and a failed stop must never be
-reported as success: metadata stays, the count is truthful, and the exit
-code is non-zero.
+Three related contracts, all broken by the same root cause — localhost
+work wrapped in SSH, with the result discarded:
+
+1. **Discovery** must not SSH to a host that *is* this machine (on a host
+   without self-SSH configured that hides every local workload).
+2. **Teardown** must dispatch the same way, verify the containers are
+   actually gone, and report a truthful count.
+3. **A failed teardown is never success**: job metadata stays, the count
+   excludes it, and the CLI exits non-zero.
 """
 
 from __future__ import annotations
 
+import pytest
 from click.testing import CliRunner
 
 from sparkrun.cli import main
-from sparkrun.core.cluster_manager import ClusterSoloEntry, ClusterStatusResult
+from sparkrun.core.cluster_manager import ClusterGroup, ClusterSoloEntry, ClusterStatusResult
 from sparkrun.orchestration.ssh import RemoteResult
 
+SOLO_CID = "sparkrun_aaaabbbbccccdddd_eeeeffff0000"
+GROUP_CID = "sparkrun_1111222233334444_55556666"
 
-def _one_solo_report(hosts, *, executor=None, cluster=None, ssh_kwargs=None, sctx=None):
+
+def _solo_report(hosts=None, **kwargs):
     """Discovery result with one running solo container on localhost."""
     entry = ClusterSoloEntry(
-        cluster_id="sparkrun_aaaabbbbccccdddd_eeeeffff0000",
+        cluster_id=SOLO_CID,
         host="localhost",
-        name="sparkrun_aaaabbbbccccdddd_eeeeffff0000_solo",
+        name=SOLO_CID + "_solo",
         status="Up 5 minutes",
         image="img",
         meta={},
@@ -37,80 +45,110 @@ def _one_solo_report(hosts, *, executor=None, cluster=None, ssh_kwargs=None, sct
     )
 
 
-def test_stop_all_failure_exits_nonzero_and_preserves_metadata(monkeypatch):
-    """A failed stop: exit 1, per-host error, metadata NOT removed, truthful count."""
-    removed = []
-    dispatched = []
+def _two_host_group_report(hosts=None, **kwargs):
+    """A two-host cluster: head on localhost, worker on a remote host."""
+    group = ClusterGroup(
+        cluster_id=GROUP_CID,
+        members=[("localhost", "head", "Up 5 minutes", "img"), ("10.0.0.2", "worker0", "Up 5 minutes", "img")],
+        meta={"recipe": "test-recipe"},
+    )
+    return ClusterStatusResult(
+        groups={GROUP_CID: group},
+        solo_entries=[],
+        errors={},
+        idle_hosts=[],
+        pending_ops=[],
+        total_containers=2,
+        host_count=2,
+    )
+
+
+@pytest.fixture
+def track_metadata(monkeypatch):
+    """Record every remove_job_metadata call."""
+    removed: list[str] = []
+    monkeypatch.setattr(
+        "sparkrun.orchestration.job_metadata.remove_job_metadata",
+        lambda cid, cache_dir=None, **kw: removed.append(cid),
+    )
+    return removed
+
+
+def _mock_teardown(monkeypatch, outcome):
+    """Patch the teardown dispatch; *outcome* maps host → RemoteResult."""
+    dispatched: list[str] = []
 
     def mock_run_command_on_host(host, command, ssh_kwargs=None, timeout=None, dry_run=False, quiet=False):
         dispatched.append(host)
-        return RemoteResult(host=host, returncode=255, stdout="", stderr="Host key verification failed.")
+        return outcome(host)
 
-    monkeypatch.setattr("sparkrun.api.status_report", _one_solo_report)
     monkeypatch.setattr("sparkrun.orchestration.primitives.run_command_on_host", mock_run_command_on_host)
-    monkeypatch.setattr(
-        "sparkrun.orchestration.job_metadata.remove_job_metadata",
-        lambda cid, cache_dir=None: removed.append(cid),
+    return dispatched
+
+
+# ---------------------------------------------------------------------------
+# stop --all: result handling
+# ---------------------------------------------------------------------------
+
+
+def test_stop_all_failure_exits_nonzero_and_preserves_metadata(monkeypatch, track_metadata):
+    """A failed stop: exit 1, per-host error, metadata NOT removed, truthful count."""
+    monkeypatch.setattr("sparkrun.api.status_report", _solo_report)
+    dispatched = _mock_teardown(
+        monkeypatch,
+        lambda host: RemoteResult(host=host, returncode=255, stdout="", stderr="Host key verification failed."),
     )
 
-    runner = CliRunner()
-    result = runner.invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
+    result = CliRunner().invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
 
     assert result.exit_code == 1
     assert dispatched == ["localhost"]
-    assert removed == []
+    assert track_metadata == []
     assert "Stopped 0 job(s), 0 container(s) across 0 host(s)." in result.output
     assert "failed to stop containers on localhost" in result.output
     assert "Host key verification failed." in result.output
 
 
-def test_stop_all_success_cleans_metadata_and_reports(monkeypatch):
-    """A successful stop: exit 0, metadata removed, truthful count."""
-    removed = []
-
-    def mock_run_command_on_host(host, command, ssh_kwargs=None, timeout=None, dry_run=False, quiet=False):
-        return RemoteResult(host=host, returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr("sparkrun.api.status_report", _one_solo_report)
-    monkeypatch.setattr("sparkrun.orchestration.primitives.run_command_on_host", mock_run_command_on_host)
-    monkeypatch.setattr(
-        "sparkrun.orchestration.job_metadata.remove_job_metadata",
-        lambda cid, cache_dir=None: removed.append(cid),
+def test_stop_all_success_cleans_metadata_and_reports(monkeypatch, track_metadata):
+    """A successful stop: exit 0, metadata removed, count read from the teardown."""
+    monkeypatch.setattr("sparkrun.api.status_report", _solo_report)
+    _mock_teardown(
+        monkeypatch,
+        lambda host: RemoteResult(host=host, returncode=0, stdout="sparkrun_removed=1\n", stderr=""),
     )
 
-    runner = CliRunner()
-    result = runner.invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
+    result = CliRunner().invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
 
     assert result.exit_code == 0
-    assert removed == ["sparkrun_aaaabbbbccccdddd_eeeeffff0000"]
+    assert track_metadata == [SOLO_CID]
     assert "Stopped 1 job(s), 1 container(s) across 1 host(s)." in result.output
 
 
-def test_query_status_dispatches_locally_for_local_host(monkeypatch):
-    """Status discovery must not SSH to a local host (no self-SSH required)."""
-    from sparkrun.orchestration.executors.docker import DockerExecutor
+def test_stop_all_partial_failure_keeps_metadata_for_the_whole_job(monkeypatch, track_metadata):
+    """One member host fails → the job's metadata stays: it's still running."""
+    monkeypatch.setattr("sparkrun.api.status_report", _two_host_group_report)
+    _mock_teardown(
+        monkeypatch,
+        lambda host: (
+            RemoteResult(host=host, returncode=0, stdout="sparkrun_removed=1\n", stderr="")
+            if host == "localhost"
+            else RemoteResult(host=host, returncode=255, stdout="", stderr="unreachable")
+        ),
+    )
 
-    def mock_local_script(script, dry_run=False):
-        assert "docker ps" in script
-        return RemoteResult(host="localhost", returncode=0, stdout="", stderr="")
+    result = CliRunner().invoke(main, ["stop", "--all", "--hosts", "localhost,10.0.0.2"], catch_exceptions=False)
 
-    def fail_if_sshed(*args, **kwargs):
-        raise AssertionError("query_status attempted SSH for a local host")
-
-    monkeypatch.setattr("sparkrun.orchestration.primitives.should_run_locally", lambda host, ssh_user=None: True)
-    monkeypatch.setattr("sparkrun.orchestration.primitives.run_local_script", mock_local_script)
-    monkeypatch.setattr("sparkrun.orchestration.ssh.run_remote_scripts_parallel", fail_if_sshed)
-
-    status = DockerExecutor().query_status(["localhost"])
-    occ = status.for_host("localhost")
-    assert occ is not None, "local host missing from status (dispatch failed)"
-    assert occ.workloads == ()
+    assert result.exit_code == 1
+    # The head's container was removed, but the job is not "stopped".
+    assert track_metadata == []
+    assert "Stopped 0 job(s), 1 container(s) across 1 host(s)." in result.output
+    assert "failed to stop containers on 10.0.0.2" in result.output
 
 
 def test_stop_all_discovery_error_exits_nonzero(monkeypatch):
     """A host that errors during discovery must not read as 'nothing to stop'."""
 
-    def erroring_report(hosts, *, executor=None, cluster=None, ssh_kwargs=None, sctx=None):
+    def erroring_report(hosts=None, **kwargs):
         return ClusterStatusResult(
             groups={},
             solo_entries=[],
@@ -123,9 +161,230 @@ def test_stop_all_discovery_error_exits_nonzero(monkeypatch):
 
     monkeypatch.setattr("sparkrun.api.status_report", erroring_report)
 
-    runner = CliRunner()
-    result = runner.invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
+    result = CliRunner().invoke(main, ["stop", "--all", "--hosts", "localhost"], catch_exceptions=False)
 
     assert result.exit_code == 1
     assert "could not query localhost" in result.output
     assert "Host key verification failed." in result.output
+    assert "No sparkrun containers running." not in result.output
+
+
+def test_stop_all_dry_run_stops_nothing_and_succeeds(monkeypatch, track_metadata):
+    """--dry-run reports the discovered shape and touches no metadata."""
+    monkeypatch.setattr("sparkrun.api.status_report", _solo_report)
+    _mock_teardown(monkeypatch, lambda host: RemoteResult(host=host, returncode=0, stdout="[dry-run]", stderr=""))
+
+    result = CliRunner().invoke(main, ["stop", "--all", "--hosts", "localhost", "--dry-run"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert track_metadata == []
+    assert "Stopped 1 job(s), 1 container(s) across 1 host(s)." in result.output
+
+
+# ---------------------------------------------------------------------------
+# api.stop_all: the console-free contract library/GUI callers get
+# ---------------------------------------------------------------------------
+
+
+def test_api_stop_all_reports_failures_without_printing(monkeypatch, track_metadata):
+    """api.stop_all returns structured results; no console, no sys.exit."""
+    import sparkrun.api as api
+
+    _mock_teardown(
+        monkeypatch,
+        lambda host: RemoteResult(host=host, returncode=1, stdout="", stderr="containers still present: x"),
+    )
+
+    result = api.stop_all(["localhost"], discovered=_solo_report())
+
+    assert result.success is False
+    assert result.hosts_failed == {"localhost": "containers still present: x"}
+    assert result.jobs_stopped == 0
+    assert result.containers_removed == 0
+    assert track_metadata == []
+
+
+def test_api_stop_all_nothing_running_is_success(monkeypatch):
+    """No containers and no discovery errors → success, no teardown attempted."""
+    import sparkrun.api as api
+
+    dispatched = _mock_teardown(monkeypatch, lambda host: RemoteResult(host=host, returncode=0, stdout="", stderr=""))
+    empty = ClusterStatusResult(
+        groups={},
+        solo_entries=[],
+        errors={},
+        idle_hosts=["localhost"],
+        pending_ops=[],
+        total_containers=0,
+        host_count=1,
+    )
+
+    result = api.stop_all(["localhost"], discovered=empty)
+
+    assert result.success is True
+    assert result.jobs_stopped == 0
+    assert dispatched == []
+
+
+# ---------------------------------------------------------------------------
+# Discovery dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_query_status_dispatches_locally_for_local_host(monkeypatch):
+    """Status discovery must not SSH to a local host (no self-SSH required)."""
+    from sparkrun.orchestration.executors.docker import DockerExecutor
+
+    def mock_local_script(script, dry_run=False, timeout=None):
+        assert "docker ps" in script
+        return RemoteResult(host="localhost", returncode=0, stdout="", stderr="")
+
+    def fail_if_sshed(*args, **kwargs):
+        raise AssertionError("query_status attempted SSH for a local host")
+
+    monkeypatch.setattr("sparkrun.orchestration.ssh.run_local_script", mock_local_script)
+    monkeypatch.setattr("sparkrun.orchestration.ssh.run_remote_script", fail_if_sshed)
+
+    status = DockerExecutor().query_status(["localhost"])
+    occ = status.for_host("localhost")
+    assert occ is not None, "local host missing from status (dispatch failed)"
+    assert occ.workloads == ()
+
+
+def test_query_status_mixed_local_and_remote_hosts(monkeypatch):
+    """A local head + remote worker: each dispatched its own way, both re-keyed."""
+    from sparkrun.orchestration.executors.docker import DockerExecutor
+
+    sshed: list[str] = []
+
+    def mock_local_script(script, dry_run=False, timeout=None):
+        return RemoteResult(host="localhost", returncode=0, stdout="", stderr="")
+
+    def mock_remote_script(host, script, **kwargs):
+        sshed.append(host)
+        return RemoteResult(host=host, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("sparkrun.orchestration.ssh.run_local_script", mock_local_script)
+    monkeypatch.setattr("sparkrun.orchestration.ssh.run_remote_script", mock_remote_script)
+
+    status = DockerExecutor().query_status(["localhost", "10.0.0.2"])
+
+    assert sshed == ["10.0.0.2"], "only the remote host should be SSHed"
+    assert {h.host for h in status.hosts} == {"localhost", "10.0.0.2"}
+    assert status.errors == {}
+
+
+def test_query_status_local_failure_is_recorded_as_an_error(monkeypatch):
+    """A failed *local* dispatch lands in status.errors like a failed SSH."""
+    from sparkrun.orchestration.executors.docker import DockerExecutor
+
+    monkeypatch.setattr(
+        "sparkrun.orchestration.ssh.run_local_script",
+        lambda script, dry_run=False, timeout=None: RemoteResult(host="localhost", returncode=127, stdout="", stderr="bash: not found"),
+    )
+
+    status = DockerExecutor().query_status(["localhost"])
+
+    assert status.for_host("localhost") is None
+    assert status.errors == {"localhost": "bash: not found"}
+
+
+def test_parallel_local_dispatch_is_opt_in(monkeypatch):
+    """Without allow_local, a local host still goes over SSH.
+
+    ``api.setup`` probes and meshes SSH credentials — for it SSH-to-self
+    is the point, so the local partition must never be implicit.
+    """
+    from sparkrun.orchestration.ssh import run_remote_scripts_parallel
+
+    sshed: list[str] = []
+
+    def mock_remote_script(host, script, **kwargs):
+        sshed.append(host)
+        return RemoteResult(host=host, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("sparkrun.orchestration.ssh.run_remote_script", mock_remote_script)
+    monkeypatch.setattr(
+        "sparkrun.orchestration.ssh.run_local_script",
+        lambda *a, **kw: pytest.fail("local dispatch must be opt-in"),
+    )
+
+    run_remote_scripts_parallel(["localhost"], "echo hi\n")
+    assert sshed == ["localhost"]
+
+
+def test_run_local_script_honours_timeout():
+    """The local branch must not be able to hang a caller that set a timeout."""
+    from sparkrun.orchestration.ssh import run_local_script
+
+    result = run_local_script("sleep 5\n", timeout=1)
+
+    assert result.returncode == 124
+    assert "timed out" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Teardown verification
+# ---------------------------------------------------------------------------
+
+
+def _run_script(script: str, docker_stub: str = "") -> "tuple[int, str, str]":
+    import subprocess
+
+    proc = subprocess.run(["bash", "-c", docker_stub + script], capture_output=True, text=True)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def test_teardown_script_fails_when_a_container_survives():
+    """``docker rm -f ... || true`` always exits 0 — the teardown must not."""
+    from sparkrun.orchestration.docker import docker_teardown_script
+
+    # A stub 'docker' that accepts the rm and then still lists the container.
+    stub = "docker() { if [ \"$1\" = 'ps' ]; then echo sparkrun_zzz_solo; else return 0; fi; }\n"
+    rc, _out, err = _run_script(docker_teardown_script(["sparkrun_zzz_solo"]), stub)
+
+    assert rc == 1
+    assert "still present" in err
+
+
+def test_teardown_script_fails_when_docker_is_unusable():
+    """A dead/absent docker must fail the teardown, not read as success."""
+    from sparkrun.orchestration.docker import docker_teardown_script
+
+    script = docker_teardown_script(["sparkrun_zzz_solo"]).replace("docker ", "docker-does-not-exist ")
+    rc, _out, _err = _run_script(script)
+
+    assert rc == 1
+
+
+def test_teardown_script_reports_removed_count():
+    """The removed count comes from the teardown, not from len(hosts)."""
+    from sparkrun.orchestration.docker import docker_teardown_script, parse_teardown_removed
+
+    # 'a' exists (rm succeeds), 'b' does not (rm fails); neither survives.
+    stub = "docker() { if [ \"$1\" = 'ps' ]; then return 0; elif [ \"$3\" = 'a' ]; then return 0; else return 1; fi; }\n"
+    rc, out, _err = _run_script(docker_teardown_script(["a", "b"]), stub)
+
+    assert rc == 0
+    assert parse_teardown_removed(out) == 1
+
+
+def test_teardown_script_tolerates_containers_that_are_already_gone():
+    """Teardown is idempotent: nothing to remove is success, not failure."""
+    from sparkrun.orchestration.docker import docker_teardown_script, parse_teardown_removed
+
+    stub = "docker() { if [ \"$1\" = 'ps' ]; then return 0; else return 1; fi; }\n"
+    rc, out, _err = _run_script(docker_teardown_script(["gone"]), stub)
+
+    assert rc == 0
+    assert parse_teardown_removed(out) == 0
+
+
+def test_parse_teardown_removed_defaults_to_zero():
+    """An absent/garbled marker reports nothing removed, never a guess."""
+    from sparkrun.orchestration.docker import parse_teardown_removed
+
+    assert parse_teardown_removed("") == 0
+    assert parse_teardown_removed("unrelated output\n") == 0
+    assert parse_teardown_removed("sparkrun_removed=notanumber\n") == 0
+    assert parse_teardown_removed("noise\nsparkrun_removed=3\n") == 3


### PR DESCRIPTION
Fixes #229. Supersedes #231, retargeted to `develop-next` as requested there.

Two legs, same disease — localhost work wrapped in SSH with the result ignored:

1. **Stop leg** (`cli/_stop_logs.py`): `_stop_all` wrapped its stop command in SSH even for localhost, discarded the result, and removed job metadata for containers it never stopped. It now routes through the same `run_command_on_host` dispatcher discovery-era code uses, counts only successfully stopped jobs/containers, keeps metadata for failed ones, prints per-host errors to stderr, and exits non-zero on any failure.
2. **Discovery leg** (new on `develop-next`; `orchestration/executors/docker.py`): the refactored `query_status` wraps its `docker ps` sweep in SSH for every host — on hosts without self-SSH, every local workload is invisible to status discovery and everything downstream of it (`stop --all` reports "No sparkrun containers running" while containers run; `cluster status` errors). Discovery now partitions hosts through the same `should_run_locally` dispatch (local via `run_local_script`, remote via the parallel SSH sweep). `stop --all` additionally surfaces per-host discovery errors and exits non-zero when a host could not be queried.

Tested: CliRunner tests for both directions of the stop leg (failure → exit 1 + error + metadata preserved; success → exit 0 + metadata removed), local-dispatch discovery, and the discovery-error guard. Full suite introduces zero new failures vs pristine develop-next. Verified on a DGX Spark host with no SSH-to-self (the #225-class wizard-free case): before, discovery found nothing while the container ran; after, the #229 repro discovers, stops, and removes the container with a truthful count.
