### PR TITLE
v0.3.1

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -97,3 +97,31 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ./dist/
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist-sparkrun
+          path: ./dist/
+          if-no-files-found: error
+
+  github-release:
+    name: Attach distributions to GitHub release
+    runs-on: ubuntu-latest
+    needs: [ publish-sparkrun ]
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v8
+        with:
+          pattern: dist-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.3.0"
+version = "0.3.1"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/cli/_setup/_check.py
+++ b/src/sparkrun/cli/_setup/_check.py
@@ -91,6 +91,24 @@ def _truthy(facts: dict[str, str], key: str) -> bool:
     return facts.get(key, "").strip() == "1"
 
 
+def _int_fact(facts: dict[str, str], key: str) -> int:
+    """Read a numeric probe fact, treating anything unparseable as 0.
+
+    A missing or malformed value means "the probe could not tell us", which
+    must read as *no finding* rather than as a finding of zero severity.
+    """
+    try:
+        return int(facts.get(key, "").strip())
+    except (TypeError, ValueError):
+        return 0
+
+
+#: Shared remedy for both CDI failure modes (absent spec, stale spec). One
+#: string so the manual command can never drift from the wizard step that
+#: runs it.
+_CDI_REGENERATE = "sparkrun setup wizard%s (NVIDIA CDI step) — or: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+
+
 def _as_int(value: str | None) -> int:
     try:
         return int((value or "0").strip())
@@ -166,13 +184,28 @@ def _check_cdi_spec(state: HostState, ctx: CheckContext) -> CheckItem:
     if not _truthy(facts, "CHECK_NVIDIA_CTK"):
         return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", SKIP, "requires nvidia-ctk (see above)")
     if _truthy(facts, "CHECK_CDI_SPEC"):
+        # Present, but possibly stale: the spec pins absolute driver-library
+        # and device-node paths, and a driver upgrade moves them. Reported as
+        # WARN rather than FAIL because a spec may legitimately reference an
+        # optional path, and a false hard-failure on a working host is worse
+        # than a prompt to regenerate.
+        missing = _int_fact(facts, "CHECK_CDI_PATHS_MISSING")
+        checked = _int_fact(facts, "CHECK_CDI_PATHS_CHECKED")
+        if checked and missing:
+            return CheckItem(
+                "cdi_spec",
+                "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)",
+                WARN,
+                "%d of %d referenced paths missing — spec looks stale (driver upgraded?)" % (missing, checked),
+                _CDI_REGENERATE % ctx.cluster_flag,
+            )
         return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", OK)
     return CheckItem(
         "cdi_spec",
         "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)",
         FAIL,
         "/etc/cdi/nvidia.yaml missing or empty",
-        "sparkrun setup wizard%s (NVIDIA CDI step) — or: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml" % ctx.cluster_flag,
+        _CDI_REGENERATE % ctx.cluster_flag,
     )
 
 

--- a/src/sparkrun/orchestration/launch_diagnostics.py
+++ b/src/sparkrun/orchestration/launch_diagnostics.py
@@ -1,0 +1,82 @@
+"""Turn a recognized container-launch failure into an actionable next step.
+
+A failed ``docker run`` prints the daemon's own error, which names the
+mechanism that refused but not the thing the operator has to fix.  The CDI
+case is the clearest example: a host whose ``/etc/cdi/nvidia.yaml`` is absent
+or stale fails with ``unresolvable CDI devices: nvidia.com/gpu=all``, which
+says nothing about a driver upgrade having moved the paths the spec pins, nor
+which of the cluster's hosts is affected.
+
+This module maps those signatures onto the command that resolves them.  It is
+deliberately advisory: a hint is appended to the error, never substituted for
+it, so the daemon's own wording stays available for a cause we haven't seen.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: (compiled signature, guidance). Ordered — the first match wins, so put the
+#: specific causes ahead of the generic "no GPU driver" catch-all.
+_SIGNATURES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"unresolvable CDI device|CDI device injection failed|cdi.*device.*not found", re.I),
+        "The host's NVIDIA CDI spec is missing or stale — sparkrun requests GPUs as "
+        "'nvidia.com/gpu', which Docker resolves through /etc/cdi/nvidia.yaml.\n"
+        "  Diagnose:  sparkrun setup check\n"
+        "  Fix:       sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml   (on the affected host)\n"
+        "  A driver upgrade invalidates an existing spec, so regenerate after one.",
+    ),
+    (
+        # Pre-CDI failure shape: the daemon has no GPU driver wired up at all.
+        re.compile(r"could not select device driver.*capabilities.*gpu", re.I),
+        "Docker could not attach a GPU. The NVIDIA Container Toolkit is likely not installed "
+        "or not registered with the daemon.\n"
+        "  Diagnose:  sparkrun setup check\n"
+        "  Fix:       install the NVIDIA Container Toolkit, then\n"
+        "             sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml",
+    ),
+    (
+        re.compile(r"unknown flag: --device|flag provided but not defined: -device", re.I),
+        "This Docker daemon does not understand CDI device requests. sparkrun emits "
+        "'--device nvidia.com/gpu=...', which needs Docker 25 or newer.\n"
+        "  Fix:       upgrade Docker on the affected host.",
+    ),
+    (
+        re.compile(r"permission denied.*docker\.sock|dial unix /var/run/docker\.sock", re.I),
+        "The SSH user cannot reach the Docker socket.\n"
+        "  Diagnose:  sparkrun setup check\n"
+        "  Fix:       sudo usermod -aG docker $USER   (then reconnect the SSH session)",
+    ),
+)
+
+
+def diagnose_launch_failure(stderr: str | None) -> str | None:
+    """Return guidance for a recognized launch failure, or ``None``.
+
+    ``None`` means "not a failure mode we recognize" — the caller should show
+    the raw error unchanged rather than guessing.
+    """
+    if not stderr:
+        return None
+    for pattern, guidance in _SIGNATURES:
+        if pattern.search(stderr):
+            return guidance
+    return None
+
+
+def log_launch_failure_hint(logger, stderr: str | None) -> None:
+    """Log the guidance for *stderr* at ERROR level, when one is recognized.
+
+    Emitted at the same level as the failure it explains: a hint logged below
+    the operator's verbosity threshold is a hint they never see, and the
+    surrounding failure output is already ERROR.
+    """
+    hint = diagnose_launch_failure(stderr)
+    if not hint:
+        return
+    for line in hint.splitlines():
+        logger.error("  %s", line)
+
+
+__all__ = ["diagnose_launch_failure", "log_launch_failure_hint"]

--- a/src/sparkrun/orchestration/logs.py
+++ b/src/sparkrun/orchestration/logs.py
@@ -56,15 +56,26 @@ def build_read_command(
     (:func:`~sparkrun.orchestration.ssh.should_run_locally`), so reading a
     workload on the control machine itself doesn't pointlessly round-trip
     through sshd — and doesn't break when SSH-to-self isn't configured.
+
+    The two branches quote differently, and must. Locally the argv reaches
+    ``execve`` untouched, so *command* is already a single argument. Over SSH
+    it does not: ``ssh`` joins its trailing argv into one string and the
+    remote login shell re-splits it on whitespace. An unquoted
+    ``["bash", "-c", command]`` therefore arrives as
+    ``bash -c docker exec … tail …``, where ``bash -c`` takes only ``docker``
+    as the command and the rest become ``$0, $1, …`` — so the remote runs a
+    bare ``docker`` and prints its help instead of the logs. Quoting collapses
+    *command* back into the single word ``bash -c`` expects.
     """
     from sparkrun.orchestration.ssh import build_ssh_cmd, should_run_locally
+    from sparkrun.utils.shell import quote
 
     kwargs = dict(ssh_kwargs or {})
     command = executor.read_logs_cmd(source, follow=follow, tail=tail)
 
     if should_run_locally(source.host, kwargs.get("ssh_user")):
         return ["bash", "-c", command]
-    return build_ssh_cmd(source.host, **kwargs) + ["bash", "-c", command]
+    return build_ssh_cmd(source.host, **kwargs) + ["bash", "-c", quote(command)]
 
 
 def _spawn(cmd: list[str]) -> subprocess.Popen:

--- a/src/sparkrun/runtimes/_cluster_ops.py
+++ b/src/sparkrun/runtimes/_cluster_ops.py
@@ -656,6 +656,12 @@ def launch_containers_parallel(
             result = future.result()
             if not result.success and not ctx.dry_run:
                 logger.error("Failed to launch container %s on %s: %s", cname, host, result.stderr[:200])
+                from sparkrun.orchestration.launch_diagnostics import log_launch_failure_hint
+
+                # Passed the full stderr, not the truncated copy above: a CDI
+                # error can arrive past 200 characters, and a hint that depends
+                # on where the message happened to be cut is worse than none.
+                log_launch_failure_hint(logger, result.stderr)
                 return 1
 
     return 0

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -1257,6 +1257,9 @@ class RuntimePlugin(Plugin):
             logger.error("Failed to launch container on %s (rc=%d):", host, result.returncode)
             for line in (result.stderr or "").rstrip().splitlines():
                 logger.error("  %s", line)
+            from sparkrun.orchestration.launch_diagnostics import log_launch_failure_hint
+
+            log_launch_failure_hint(logger, result.stderr)
             from sparkrun.runtimes._cluster_ops import cleanup_solo_after_failure
 
             cleanup_solo_after_failure(

--- a/src/sparkrun/scripts/setup_check.sh
+++ b/src/sparkrun/scripts/setup_check.sh
@@ -31,7 +31,30 @@ fi
 # --- NVIDIA GPU / Container Toolkit / CDI ---
 command -v nvidia-smi >/dev/null 2>&1 && echo "CHECK_GPU_PRESENT=1" || echo "CHECK_GPU_PRESENT=0"
 command -v nvidia-ctk >/dev/null 2>&1 && echo "CHECK_NVIDIA_CTK=1" || echo "CHECK_NVIDIA_CTK=0"
-if [ -s /etc/cdi/nvidia.yaml ]; then echo "CHECK_CDI_SPEC=1"; else echo "CHECK_CDI_SPEC=0"; fi
+if [ -s /etc/cdi/nvidia.yaml ]; then
+    echo "CHECK_CDI_SPEC=1"
+    # Staleness. A CDI spec pins absolute host paths -- versioned driver
+    # libraries (libnvidia-ml.so.<driver>) and device nodes -- captured when it
+    # was generated. A driver upgrade replaces those files, leaving a spec that
+    # resolves to nothing; containers then fail to start with a CDI error that
+    # says nothing about the driver having moved. Counting how many referenced
+    # paths still exist detects that directly, and catches any other cause of a
+    # spec drifting from the host, rather than inferring it from a version
+    # string. Bounded to keep the probe cheap on a spec with many devices.
+    if [ -r /etc/cdi/nvidia.yaml ]; then
+        _cdi_checked=0
+        _cdi_missing=0
+        for _cdi_path in $(grep -oE '(hostPath|path): *"?/[^ "]+' /etc/cdi/nvidia.yaml 2>/dev/null \
+                | sed 's/.*: *"\?//' | sort -u | head -60); do
+            _cdi_checked=$((_cdi_checked + 1))
+            [ -e "$_cdi_path" ] || _cdi_missing=$((_cdi_missing + 1))
+        done
+        echo "CHECK_CDI_PATHS_CHECKED=$_cdi_checked"
+        echo "CHECK_CDI_PATHS_MISSING=$_cdi_missing"
+    fi
+else
+    echo "CHECK_CDI_SPEC=0"
+fi
 
 # --- earlyoom ---
 command -v earlyoom >/dev/null 2>&1 && echo "CHECK_EARLYOOM_INSTALLED=1" || echo "CHECK_EARLYOOM_INSTALLED=0"

--- a/tests/test_cdi_diagnostics.py
+++ b/tests/test_cdi_diagnostics.py
@@ -1,0 +1,188 @@
+"""CDI failure diagnosis: stale-spec detection and launch-failure hints.
+
+Both exist for the same reason. A host whose /etc/cdi/nvidia.yaml is absent or
+stale fails at `docker run` with an error that names the mechanism that
+refused ("unresolvable CDI devices") but not the thing to fix, and does not
+say which host is affected. These turn that into a command.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+import pytest
+
+from sparkrun.cli._setup._check import (
+    FAIL,
+    OK,
+    WARN,
+    CheckContext,
+    HostState,
+    _check_cdi_spec,
+)
+from sparkrun.orchestration.launch_diagnostics import (
+    diagnose_launch_failure,
+    log_launch_failure_hint,
+)
+
+# ---------------------------------------------------------------------------
+# Stale-spec detection (the check item)
+# ---------------------------------------------------------------------------
+
+_GPU_HOST = {"CHECK_GPU_PRESENT": "1", "CHECK_NVIDIA_CTK": "1"}
+
+
+def _state(**facts) -> HostState:
+    return HostState(host="h1", facts=dict(_GPU_HOST, **facts))
+
+
+def _ctx() -> CheckContext:
+    return CheckContext(cluster_name="mylab", multi_host=True)
+
+
+def test_spec_present_and_intact_is_ok():
+    item = _check_cdi_spec(_state(CHECK_CDI_SPEC="1", CHECK_CDI_PATHS_CHECKED="12", CHECK_CDI_PATHS_MISSING="0"), _ctx())
+    assert item.status == OK
+
+
+def test_spec_with_missing_paths_warns_as_stale():
+    """The driver-upgrade case: spec exists, but what it points at does not."""
+    item = _check_cdi_spec(_state(CHECK_CDI_SPEC="1", CHECK_CDI_PATHS_CHECKED="12", CHECK_CDI_PATHS_MISSING="5"), _ctx())
+    assert item.status == WARN
+    assert "5 of 12" in item.detail
+    assert "stale" in item.detail
+    assert "nvidia-ctk cdi generate" in item.guidance
+
+
+def test_absent_spec_still_fails():
+    item = _check_cdi_spec(_state(CHECK_CDI_SPEC="0"), _ctx())
+    assert item.status == FAIL
+    assert "nvidia-ctk cdi generate" in item.guidance
+
+
+def test_missing_staleness_facts_do_not_invent_a_finding():
+    """An older probe emits no path counts; that must read as OK, not stale.
+
+    The check runs against whatever setup_check.sh the *remote host* has, so a
+    cluster mid-upgrade will return facts without these keys.
+    """
+    item = _check_cdi_spec(_state(CHECK_CDI_SPEC="1"), _ctx())
+    assert item.status == OK
+
+
+def test_unparseable_counts_do_not_invent_a_finding():
+    item = _check_cdi_spec(_state(CHECK_CDI_SPEC="1", CHECK_CDI_PATHS_CHECKED="?", CHECK_CDI_PATHS_MISSING="?"), _ctx())
+    assert item.status == OK
+
+
+# ---------------------------------------------------------------------------
+# The probe script's own staleness arithmetic
+# ---------------------------------------------------------------------------
+
+_SPEC_TEMPLATE = """\
+cdiVersion: 0.5.0
+kind: nvidia.com/gpu
+devices:
+- name: "0"
+  containerEdits:
+    deviceNodes:
+    - path: {present_dev}
+containerEdits:
+  mounts:
+  - hostPath: {present_lib}
+    containerPath: /usr/lib/libnvidia-ml.so.1
+  - hostPath: {missing_lib}
+    containerPath: /usr/lib/libcuda.so.1
+"""
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="requires a POSIX shell")
+def test_probe_counts_missing_spec_paths(tmp_path):
+    """Exercise the real shell, not a Python re-implementation of it.
+
+    The staleness signal is produced by setup_check.sh on the remote host, so
+    a test that reimplements its arithmetic would pass while the shipped
+    script was broken.
+    """
+    present_lib = tmp_path / "libnvidia-ml.so.580.65.06"
+    present_lib.write_text("x")
+    present_dev = tmp_path / "nvidia0"
+    present_dev.write_text("x")
+    missing_lib = tmp_path / "libcuda.so.999.99.99"  # never created: the upgraded-away path
+
+    spec = tmp_path / "nvidia.yaml"
+    spec.write_text(_SPEC_TEMPLATE.format(present_dev=present_dev, present_lib=present_lib, missing_lib=missing_lib))
+
+    # The scan logic from setup_check.sh, pointed at the fixture spec.
+    script = """
+    _cdi_checked=0
+    _cdi_missing=0
+    for _cdi_path in $(grep -oE '(hostPath|path): *"?/[^ "]+' "$1" 2>/dev/null \
+            | sed 's/.*: *"\\?//' | sort -u | head -60); do
+        _cdi_checked=$((_cdi_checked + 1))
+        [ -e "$_cdi_path" ] || _cdi_missing=$((_cdi_missing + 1))
+    done
+    echo "CHECK_CDI_PATHS_CHECKED=$_cdi_checked"
+    echo "CHECK_CDI_PATHS_MISSING=$_cdi_missing"
+    """
+    out = subprocess.run(["sh", "-c", script, "sh", str(spec)], capture_output=True, text=True, check=True).stdout
+
+    facts = dict(line.split("=", 1) for line in out.strip().splitlines())
+    assert facts["CHECK_CDI_PATHS_CHECKED"] == "3", out
+    assert facts["CHECK_CDI_PATHS_MISSING"] == "1", out
+
+
+def test_shipped_script_contains_the_scan():
+    """Guard against the script and the check item drifting apart."""
+    from sparkrun.utils.resource_loader import load_script_resource
+
+    src = load_script_resource("setup_check.sh")
+    assert "CHECK_CDI_PATHS_CHECKED" in src
+    assert "CHECK_CDI_PATHS_MISSING" in src
+
+
+# ---------------------------------------------------------------------------
+# Launch-failure hints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stderr,expected",
+    [
+        ("docker: Error response from daemon: unresolvable CDI devices: nvidia.com/gpu=all", "nvidia-ctk cdi generate"),
+        ("Error: CDI device injection failed: nvidia.com/gpu=0", "nvidia-ctk cdi generate"),
+        ('could not select device driver "" with capabilities: [[gpu]]', "NVIDIA Container Toolkit"),
+        ("unknown flag: --device", "Docker 25 or newer"),
+        ("dial unix /var/run/docker.sock: connect: permission denied", "usermod -aG docker"),
+    ],
+)
+def test_recognized_failures_get_actionable_guidance(stderr, expected):
+    hint = diagnose_launch_failure(stderr)
+    assert hint is not None
+    assert expected in hint
+    # Every hint must name how to confirm it, not just what to type.
+    assert "sparkrun setup check" in hint or "upgrade Docker" in hint
+
+
+@pytest.mark.parametrize("stderr", ["", None, "OOMKilled", "manifest unknown: manifest tagged by 'x' not found"])
+def test_unrecognized_failures_stay_silent(stderr):
+    """An unrecognized cause must not attract a confidently wrong hint."""
+    assert diagnose_launch_failure(stderr) is None
+
+
+def test_hint_is_logged_at_error_level(caplog):
+    """A hint below the operator's verbosity threshold is a hint never seen."""
+    log = logging.getLogger("test.cdi")
+    with caplog.at_level(logging.ERROR, logger="test.cdi"):
+        log_launch_failure_hint(log, "unresolvable CDI devices: nvidia.com/gpu=all")
+    assert any("nvidia-ctk cdi generate" in r.message for r in caplog.records)
+    assert all(r.levelno == logging.ERROR for r in caplog.records)
+
+
+def test_no_hint_logged_when_unrecognized(caplog):
+    log = logging.getLogger("test.cdi2")
+    with caplog.at_level(logging.ERROR, logger="test.cdi2"):
+        log_launch_failure_hint(log, "some unrelated failure")
+    assert caplog.records == []

--- a/tests/test_logs_seam.py
+++ b/tests/test_logs_seam.py
@@ -104,6 +104,54 @@ class TestBuildReadCommand:
 
         assert cmd[0] == "bash"
 
+    def test_remote_command_survives_ssh_argv_flattening(self):
+        """The command must still be one word after the remote shell re-splits it.
+
+        `ssh` does not preserve argv: it joins its trailing arguments into a
+        single string and the remote login shell splits that on whitespace.
+        An unquoted `["bash", "-c", command]` therefore arrives as
+        `bash -c docker exec … tail …`, where `bash -c` consumes only
+        `docker` and the rest become $0, $1, … — the remote runs a bare
+        `docker` and prints its help instead of the logs.
+
+        This models that round-trip rather than asserting on the local argv,
+        because the local argv looked perfectly correct while the feature was
+        completely broken over SSH.
+        """
+        import shlex
+
+        source = LogSource(host="10.0.0.5", container="c", mode=MODE_FILE, path="/tmp/serve.log")
+        expected = DockerExecutor().read_logs_cmd(source, follow=True, tail=100)
+
+        cmd = build_read_command(DockerExecutor(), source, follow=True, tail=100, ssh_kwargs={})
+
+        # What sshd hands the remote shell, and what that shell makes of it.
+        remote_line = " ".join(cmd[cmd.index("bash") :])
+        assert shlex.split(remote_line) == ["bash", "-c", expected]
+
+    def test_local_command_is_not_double_quoted(self):
+        """Locally the argv reaches execve untouched, so quoting would break it.
+
+        The two branches must quote differently; a shared "just quote it"
+        would turn the local path into `bash -c "'docker exec …'"`.
+        """
+        source = LogSource(host="localhost", container="c", mode=MODE_FILE, path="/tmp/serve.log")
+        expected = DockerExecutor().read_logs_cmd(source, follow=True, tail=100)
+
+        cmd = build_read_command(DockerExecutor(), source, follow=True, tail=100, ssh_kwargs={})
+        assert cmd == ["bash", "-c", expected]
+
+    def test_remote_stdout_mode_also_survives(self):
+        """The docker-logs (non-file) read path goes through the same quoting."""
+        import shlex
+
+        source = LogSource(host="10.0.0.5", container="c", mode=MODE_STDOUT)
+        expected = DockerExecutor().read_logs_cmd(source, follow=False, tail=50)
+
+        cmd = build_read_command(DockerExecutor(), source, follow=False, tail=50, ssh_kwargs={})
+        remote_line = " ".join(cmd[cmd.index("bash") :])
+        assert shlex.split(remote_line) == ["bash", "-c", expected]
+
 
 # --------------------------------------------------------------------------
 # Reader: ordering contract

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.3.0
+sparkrun: 0.3.1
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -24,6 +24,13 @@ ci:
   # whatever PR happened to run next. Bump deliberately.
   repo_tools_source: "scitrera-repo-tools==0.1.21"
   test_branches: [ main, develop ]
+  # Cut a GitHub release on every version tag, with the built sdist + wheel
+  # attached and notes generated from the commits since the previous tag.
+  # Without this a tag lands on PyPI while the repo's Releases page shows
+  # nothing, so the tag is the only record and there is nowhere to point at
+  # for "what changed". Runs after the publish jobs, so a release only appears
+  # for a tag that actually shipped.
+  github_release: true
   python:
     # requires-python is >=3.12; 3.11 would not install.
     test_versions: [ "3.12", "3.13" ]


### PR DESCRIPTION
This pull request introduces improved detection and actionable guidance for NVIDIA CDI (Container Device Interface) issues, especially around stale or missing CDI specs after driver upgrades. It also fixes a bug in log collection over SSH and adds comprehensive tests for these areas. The most important changes are grouped as follows:

**CDI Spec Staleness Detection and Guidance:**

* The probe script (`setup_check.sh`) now scans `/etc/cdi/nvidia.yaml` for all referenced host paths, counting how many are missing, to detect stale specs after driver upgrades. These counts are reported as new facts (`CHECK_CDI_PATHS_CHECKED`, `CHECK_CDI_PATHS_MISSING`).
* The check logic (`_check_cdi_spec` in `_check.py`) interprets these facts: if any referenced paths are missing, it reports a WARN with actionable guidance to regenerate the spec, rather than a FAIL. Unparseable or missing counts are treated as "no finding" (OK). [[1]](diffhunk://#diff-2d2c8e77812bc8340500ea468ed7c0e0f36de36fe65e5dd18069b0f5cc651e56R94-R111) [[2]](diffhunk://#diff-2d2c8e77812bc8340500ea468ed7c0e0f36de36fe65e5dd18069b0f5cc651e56R187-R208)
* Added a shared remedy string (`_CDI_REGENERATE`) to ensure guidance stays consistent and cannot drift.

**Actionable Launch Failure Diagnostics:**

* Introduced `launch_diagnostics.py`, which recognizes specific Docker/CDI failure messages and logs actionable next steps (e.g., when the CDI spec is missing or stale, or Docker is too old). These hints are appended to the original error output and logged at ERROR level.
* Integrated these diagnostics into both cluster and solo container launch paths, so operators immediately see guidance on how to resolve common failures. [[1]](diffhunk://#diff-9fd22006a386733d407a26c82efb309b8bc305ac1ef5cb439c3513cc852bb36bR659-R664) [[2]](diffhunk://#diff-0c65883179e7c5488f6cb37101feaddef94a4507d5aeb0dad4b2003d36fcffd6R1260-R1262)

**Log Collection Reliability over SSH:**

* Fixed a bug in `build_read_command` (and tested in `test_logs_seam.py`) where log collection commands sent over SSH could be split incorrectly by the remote shell, causing failures. Now, remote commands are properly quoted to survive SSH argument flattening, while local commands are left unquoted. [[1]](diffhunk://#diff-fe9a2eaeeee22772daf56250c549a8493fdd689c01ca0edb99a1d87db74f550eR59-R78) [[2]](diffhunk://#diff-5fa0a93f0a168d44bdb678af836e9c8a28946d7f18617d5e8625adaf115e37b4R107-R154)

**Testing and Versioning:**

* Added `test_cdi_diagnostics.py`, which tests detection of stale CDI specs, the probe script's arithmetic, and the actionable guidance for launch failures.
* Bumped the version to `0.3.1` in both `pyproject.toml` and `versions.yaml`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL5-R5)