### PR TITLE
fix(recipe): mask literal braces for v2 and hook templates too

### DIFF
--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -13,10 +13,10 @@ from typing import Any, TYPE_CHECKING, Optional
 import yaml
 
 from vpd.next.util import read_yaml
-from vpd.legacy.arguments import arg_substitute
 from scitrera_app_framework.api import Variables, EnvPlacement
 
 from sparkrun.core.layout import RecipeLayout
+from sparkrun.utils.text import mask_non_placeholder_braces, render_template, unmask_braces
 
 if TYPE_CHECKING:
     from sparkrun.core.registry import RegistryManager
@@ -29,14 +29,6 @@ logger = logging.getLogger(__name__)
 # an escaped space — a common YAML editing mistake that silently breaks
 # multi-line commands.
 _TRAILING_SPACE_CONTINUATION_RE = re.compile(r"\\ +\n")
-
-# v1 brace-escape masking (see _mask_brace_escapes).  The sentinels are control
-# characters YAML 1.2 forbids in scalar content, so they cannot collide with
-# anything a recipe or an override value can legitimately carry.
-_LBRACE_SENTINEL = "\x00"
-_RBRACE_SENTINEL = "\x01"
-_LBRACE_RUN_RE = re.compile(r"\{+")
-_RBRACE_RUN_RE = re.compile(r"\}+")
 
 _RAY_BACKEND_RE = re.compile(r"--distributed-executor-backend\s+ray\b")
 _CMD_VLLM_RE = re.compile(r"^vllm\s+serve\b")
@@ -204,11 +196,11 @@ class DistributionConfig:
 
         for entry in self.models.entries:
             if isinstance(entry, DistributionModelEntry):
-                entry.name = arg_substitute(entry.name, config_chain)
+                entry.name = render_template(entry.name, config_chain)
 
         for entry in self.containers.entries:
             if isinstance(entry, DistributionContainerEntry):
-                entry.name = arg_substitute(entry.name, config_chain)
+                entry.name = render_template(entry.name, config_chain)
 
         return self
 
@@ -361,39 +353,18 @@ def _collapse_brace_escapes(value: str) -> str:
 
 
 def _mask_brace_escapes(value: str) -> str:
-    """Replace v1 ``{{``/``}}`` escapes with sentinels so substitution can't see them.
+    """Hide v1 ``{{``/``}}`` escapes (and other literal braces) from substitution.
 
-    Collapsing escapes *after* substitution is not enough: vpd's placeholder
-    regex is ``\\{(.*?)\\}``, so the leading brace of a ``{{`` escape opens a
-    match that runs to the first ``}`` — swallowing any placeholder nested
-    inside the escaped span.  ``'{{"n":{tokens}}}'`` therefore matches as one
-    bogus key and ``{tokens}`` is never substituted.  Masking first leaves the
-    escaped braces invisible to the regex, so only real placeholders match.
-
-    Brace runs are paired from the side away from the placeholder name, which
-    is what disambiguates an odd-length run:
-
-    - ``{`` runs pair left-to-right, so ``{{{k}`` is a literal ``{`` followed
-      by the placeholder ``{k}``.
-    - ``}`` runs pair right-to-left, so ``{k}}}`` is the placeholder ``{k}``
-      followed by a literal ``}`` (the DeepSeek ``--speculative-config`` shape,
-      where a placeholder ends a JSON object).
+    Thin wrapper over :func:`sparkrun.utils.text.mask_non_placeholder_braces`,
+    which is shared with lifecycle-hook rendering so both paths treat braces
+    identically.  See that function for the scan rules.
     """
-
-    def _mask_open(m: re.Match) -> str:
-        pairs, odd = divmod(len(m.group()), 2)
-        return _LBRACE_SENTINEL * pairs + "{" * odd
-
-    def _mask_close(m: re.Match) -> str:
-        pairs, odd = divmod(len(m.group()), 2)
-        return "}" * odd + _RBRACE_SENTINEL * pairs
-
-    return _RBRACE_RUN_RE.sub(_mask_close, _LBRACE_RUN_RE.sub(_mask_open, value))
+    return mask_non_placeholder_braces(value, escapes=True)
 
 
 def _unmask_brace_escapes(value: str) -> str:
-    """Restore :func:`_mask_brace_escapes` sentinels as single literal braces."""
-    return value.replace(_LBRACE_SENTINEL, "{").replace(_RBRACE_SENTINEL, "}")
+    """Restore :func:`_mask_brace_escapes` sentinels as literal braces."""
+    return unmask_braces(value)
 
 
 def _resolve_v1_migration(recipe: Recipe) -> None:
@@ -1057,26 +1028,14 @@ class Recipe:
 
         rendered = self.command.strip()
 
-        # v1 (eugr) recipes escape literal braces as '{{'/'}}' so they survive
-        # the {placeholder} substitution below (e.g. JSON-valued flags like
-        # --diffusion-config '{{...}}').  Mask them to sentinels *first* so the
-        # escaped braces are invisible to vpd's placeholder regex — otherwise
-        # an escaped span swallows any placeholder nested inside it — then
-        # restore them as single literal braces once substitution is done, so
-        # the runtime receives valid JSON rather than doubled braces.
-        escaped = self.recipe_version == "1"
-        if escaped:
-            rendered = _mask_brace_escapes(rendered)
-
-        # Use vpd arg_substitute for {placeholder} replacement
-        # Iterate to handle nested substitutions
-        last = None
-        while last != rendered:
-            last = rendered
-            rendered = arg_substitute(rendered, config_chain)
-
-        if escaped:
-            rendered = _unmask_brace_escapes(rendered)
+        # Literal braces are masked to sentinels *first* so they are invisible
+        # to vpd's placeholder regex — otherwise a JSON-valued flag swallows any
+        # placeholder nested inside it — then restored once substitution is
+        # done, so the runtime receives valid JSON.  v1 (eugr) recipes write
+        # their literal braces doubled ('{{'/'}}') and those collapse to one
+        # brace on restore; v2 recipes write JSON with plain braces and get them
+        # back unchanged.  Substitution iterates to resolve nested references.
+        rendered = render_template(rendered, config_chain, escapes=self.recipe_version == "1")
 
         # Fix trailing spaces after backslash line-continuations.
         # ``\<space><newline>`` → ``\<newline>``

--- a/src/sparkrun/orchestration/hooks.py
+++ b/src/sparkrun/orchestration/hooks.py
@@ -12,7 +12,7 @@ import logging
 import subprocess
 from pathlib import Path
 
-from vpd.legacy.arguments import arg_substitute
+from sparkrun.utils.text import render_template
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,15 @@ def build_hook_context(
 def render_hook_command(cmd: str, context: dict[str, str]) -> str:
     """Render ``{key}`` placeholders in a hook command string.
 
-    Uses the same ``arg_substitute`` used for recipe command rendering.
+    Uses the same brace-masking renderer as recipe command rendering, so a
+    placeholder inside a JSON payload resolves here too — a hook like
+    ``curl -d '{"model":"{model}"}'`` otherwise reached the shell with a
+    literal ``{model}``, because vpd's regex matched from the opening brace
+    of the JSON object through the placeholder's closing brace and restored
+    the whole span verbatim.
+
+    Hook commands are not v1 recipe templates, so ``{{`` is left as two
+    literal braces rather than collapsed.
 
     Args:
         cmd: Command string with ``{key}`` placeholders.
@@ -89,12 +97,7 @@ def render_hook_command(cmd: str, context: dict[str, str]) -> str:
     Returns:
         Rendered command string.
     """
-    rendered = cmd
-    last = None
-    while last != rendered:
-        last = rendered
-        rendered = arg_substitute(rendered, context)
-    return rendered
+    return render_template(cmd, context)
 
 
 def render_hook_commands(

--- a/src/sparkrun/utils/text.py
+++ b/src/sparkrun/utils/text.py
@@ -2,6 +2,125 @@
 
 from __future__ import annotations
 
+import logging
+import re
+from typing import Any
+
+from vpd.legacy.arguments import arg_substitute
+
+logger = logging.getLogger(__name__)
+
+# Brace masking sentinels.  Control characters YAML 1.2 forbids in scalar
+# content, so they cannot collide with anything a recipe or an override value
+# can legitimately carry.
+_LBRACE_SENTINEL = "\x00"
+_RBRACE_SENTINEL = "\x01"
+
+# A ``{key}`` span.  ``[^{}]*`` is what makes this safe to run over JSON: a
+# brace whose span contains another brace (``{"a":{...``) cannot match, so it
+# is treated as a literal rather than as the start of a placeholder.
+_PLACEHOLDER_SPAN_RE = re.compile(r"\{[^{}]*\}")
+
+# Upper bound on substitution passes.  Legitimate nesting is a short chain
+# (``base_url`` -> ``port``); anything deeper than this is a cycle.
+_MAX_SUBSTITUTION_PASSES = 10
+
+
+def mask_non_placeholder_braces(value: str, *, escapes: bool) -> str:
+    """Hide every brace that is not part of a ``{key}`` placeholder.
+
+    vpd's placeholder regex is ``\\{(.*?)\\}``, which cannot tell a placeholder
+    from a brace that merely happens to sit in the text.  Any ``{`` opens a
+    non-greedy match that runs to the first ``}``, so a JSON-valued flag
+    swallows the placeholder nested inside it and the whole span is restored
+    verbatim.  Masking first leaves only real placeholders visible to vpd.
+
+    Scanning left to right, each position is one of:
+
+    - ``{{`` / ``}}`` — a brace escape.  With *escapes* (v1 recipes) it masks
+      to a **single** sentinel, so it restores as one literal brace; without,
+      it masks to **two**, so the doubled braces survive untouched.  Either way
+      the braces are invisible to vpd, so an escaped span can no longer eat the
+      placeholder inside it.
+    - ``{key}`` — a placeholder, passed through for vpd to resolve.
+    - a lone ``{`` or ``}`` — literal, masked so it cannot open a bogus span.
+
+    Args:
+        value: Template string.
+        escapes: Treat ``{{``/``}}`` as v1 escapes that collapse to one brace.
+
+    Returns:
+        The masked string; pair with :func:`unmask_braces`.
+    """
+    out: list[str] = []
+    i = 0
+    end = len(value)
+    while i < end:
+        ch = value[i]
+        if ch == "{":
+            if value.startswith("{{", i):
+                out.append(_LBRACE_SENTINEL if escapes else _LBRACE_SENTINEL * 2)
+                i += 2
+                continue
+            match = _PLACEHOLDER_SPAN_RE.match(value, i)
+            if match:
+                out.append(match.group())
+                i = match.end()
+                continue
+            out.append(_LBRACE_SENTINEL)
+        elif ch == "}":
+            if value.startswith("}}", i):
+                out.append(_RBRACE_SENTINEL if escapes else _RBRACE_SENTINEL * 2)
+                i += 2
+                continue
+            out.append(_RBRACE_SENTINEL)
+        else:
+            out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def unmask_braces(value: str) -> str:
+    """Restore :func:`mask_non_placeholder_braces` sentinels as literal braces."""
+    return value.replace(_LBRACE_SENTINEL, "{").replace(_RBRACE_SENTINEL, "}")
+
+
+def render_template(value: str, values: Any, *, escapes: bool = False, max_passes: int = _MAX_SUBSTITUTION_PASSES) -> str:
+    """Render ``{key}`` placeholders, iterating until the text stops changing.
+
+    Iterating is what makes nested references work — a default of
+    ``http://localhost:{port}`` needs a second pass to resolve ``{port}`` once
+    ``{base_url}`` has been pulled in.
+
+    The iteration is bounded.  An unbounded fixpoint loop never terminates for
+    a self-growing value (``a: "x{a}"`` renders ``x{a}`` -> ``xx{a}`` -> ...),
+    turning a malformed recipe into a hang with no output.  On hitting the
+    bound we log and return the last result, so the failure surfaces as a bad
+    command rather than a wedged process.  A value that resolves to itself
+    (``a: "{a}"``) is a fixpoint on the first pass and never reaches this.
+
+    Args:
+        value: Template string.
+        values: Anything with a one-argument ``.get(key)`` — a ``dict`` or a
+            SAF ``Variables`` config chain.
+        escapes: Treat ``{{``/``}}`` as v1 escapes collapsing to one brace.
+        max_passes: Substitution passes before giving up.
+
+    Returns:
+        The rendered string.
+    """
+    rendered = mask_non_placeholder_braces(value, escapes=escapes)
+    for _ in range(max_passes):
+        nxt = arg_substitute(rendered, values)
+        if nxt == rendered:
+            return unmask_braces(rendered)
+        rendered = nxt
+    logger.warning(
+        "Template did not stabilize after %d substitution passes — check for a placeholder whose value contains itself; using the last result",
+        max_passes,
+    )
+    return unmask_braces(rendered)
+
 
 def coerce_value(value: str):
     """Coerce a string value to int, float, or bool where possible."""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -135,6 +135,38 @@ class TestRenderHookCommand:
         result = render_hook_command("curl {base_url}/models", ctx)
         assert result == "curl http://10.0.0.1:8000/v1/models"
 
+    def test_render_placeholder_inside_json_payload(self):
+        """A placeholder inside a JSON body resolves.
+
+        The common post_exec shape — a warm-up ``curl`` that POSTs JSON.  vpd's
+        regex matched from the payload's opening brace through the
+        placeholder's closing brace and restored the span verbatim, so the hook
+        sent a literal ``{model}`` to the server.
+        """
+        ctx = {"base_url": "http://10.0.0.1:8000/v1", "model": "llama-7b"}
+        result = render_hook_command(
+            'curl {base_url}/chat/completions -d \'{"model":"{model}","stream":false}\'',
+            ctx,
+        )
+
+        assert result == 'curl http://10.0.0.1:8000/v1/chat/completions -d \'{"model":"llama-7b","stream":false}\''
+
+    def test_render_json_without_placeholders_untouched(self):
+        """A JSON payload with nothing to substitute passes through unchanged."""
+        cmd = "curl -d '{\"stream\": false}' http://h/x"
+
+        assert render_hook_command(cmd, {"model": "llama-7b"}) == cmd
+
+    def test_render_doubled_braces_preserved(self):
+        """Hook commands are not v1 templates — ``{{`` stays two braces."""
+        assert render_hook_command("echo '{{keep}}'", {"keep": "X"}) == "echo '{{keep}}'"
+
+    def test_render_terminates_on_self_growing_value(self):
+        """A self-referential context value must not hang the render."""
+        result = render_hook_command("echo {a}", {"a": "x{a}"})
+
+        assert result.endswith("{a}")
+
 
 # ---------------------------------------------------------------------------
 # render_hook_commands

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -593,6 +593,86 @@ def test_render_command_v1_unknown_placeholder_is_left_verbatim():
     assert "--x '{\"n\":{nope}}'" in rendered
 
 
+def test_render_command_v2_substitutes_placeholder_inside_bare_json():
+    """A v2 recipe may write JSON with plain braces and a placeholder inside.
+
+    v2 has no ``{{`` escaping convention — ``RECIPES.md`` documents only
+    ``{key}`` — so a JSON-valued flag is written with single braces.  vpd's
+    regex matches from the JSON's opening brace through the placeholder's
+    closing brace, so the placeholder was left unsubstituted and the runtime
+    received a literal ``{num_speculative_tokens}``.
+    """
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-json",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"port": 8000, "num_speculative_tokens": 2},
+            "command": 'vllm serve m --port {port} --speculative-config \'{"method":"mtp","n":{num_speculative_tokens}}\'',
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert '--speculative-config \'{"method":"mtp","n":2}\'' in rendered
+    assert "{num_speculative_tokens}" not in rendered
+
+
+def test_render_command_v2_nested_bare_json_placeholder():
+    """Nesting depth doesn't matter — only the placeholder is touched."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-nested",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"n": 1},
+            "command": 'vllm serve m --c \'{"a":{"b":{n}}}\'',
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert '--c \'{"a":{"b":1}}\'' in rendered
+
+
+def test_render_command_v2_json_without_placeholders_untouched():
+    """A v2 JSON blob that resolves to nothing passes through unchanged."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-plain-json",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"port": 8000},
+            "command": "vllm serve m --port {port} --c '{\"canvas_length\": 256}'",
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert "--c '{\"canvas_length\": 256}'" in rendered
+
+
+def test_render_command_terminates_on_self_growing_default(caplog):
+    """A default whose value contains itself must not hang the render.
+
+    ``a: "x{a}"`` renders ``x{a}`` -> ``xx{a}`` -> ... and never reaches a
+    fixpoint, so an unbounded loop wedges the process with no output.
+    """
+    import logging
+
+    recipe = Recipe.from_dict(
+        {
+            "name": "cyclic",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"a": "x{a}"},
+            "command": "echo {a}",
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="sparkrun.utils.text"):
+        rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert rendered.endswith("{a}")
+    assert "did not stabilize" in caplog.text
+
+
 def test_render_command_does_not_collapse_braces_for_v2():
     """v2 recipes are unaffected by the v1 brace-escape collapse."""
     recipe = Recipe.from_dict(

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -1,0 +1,148 @@
+"""Tests for sparkrun.utils.text brace masking and template rendering.
+
+These lock down the scan rules shared by recipe command rendering and
+lifecycle-hook rendering: which braces are placeholders, which are literal,
+and how ``{{``/``}}`` behave in each mode.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from sparkrun.utils.text import mask_non_placeholder_braces, render_template, unmask_braces
+
+
+class TestMaskRoundTrip:
+    """mask -> unmask must be lossless apart from the intended escape collapse."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "no braces here",
+            "{key}",
+            '{"a": 1}',
+            '{"a":{"b":2}}',
+            "awk '{print $1}'",
+            "${HF_HOME}",
+            "{}",
+        ],
+    )
+    def test_plain_mode_is_lossless(self, text):
+        """Without escapes every brace comes back exactly as it went in."""
+        assert unmask_braces(mask_non_placeholder_braces(text, escapes=False)) == text
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("{{a}}", "{a}"),
+            ('{{"a": 1}}', '{"a": 1}'),
+            ('{{"a": {{"b": 1}}}}', '{"a": {"b": 1}}'),
+            ("{{{k}", "{{k}"),
+            ("{k}}}", "{k}}"),
+        ],
+    )
+    def test_escape_mode_collapses_doubled_braces(self, text, expected):
+        """With escapes a ``{{``/``}}`` pair restores as one literal brace."""
+        assert unmask_braces(mask_non_placeholder_braces(text, escapes=True)) == expected
+
+    def test_placeholders_survive_masking_verbatim(self):
+        """A ``{key}`` span is left untouched so vpd can still see it."""
+        masked = mask_non_placeholder_braces('{{"n":{tokens}}}', escapes=True)
+
+        assert "{tokens}" in masked
+        assert "{{" not in masked
+
+    def test_json_braces_are_hidden_from_substitution(self):
+        """Braces that merely surround JSON must not look like placeholders."""
+        masked = mask_non_placeholder_braces('{"a":{"b":{n}}}', escapes=False)
+
+        assert masked.count("{") == 1  # only the real placeholder
+        assert "{n}" in masked
+
+
+class TestRenderTemplate:
+    """The mask -> substitute -> unmask pipeline."""
+
+    def test_standalone_placeholders(self):
+        assert render_template("--host {host} --port {port}", {"host": "0.0.0.0", "port": 8000}) == "--host 0.0.0.0 --port 8000"
+
+    def test_unknown_key_left_verbatim(self):
+        """An unresolved placeholder is restored as-is (vpd behavior preserved)."""
+        assert render_template("--x {nope}", {"port": 8000}) == "--x {nope}"
+
+    def test_falsy_values_are_substituted(self):
+        assert render_template("{a}|{b}|{c}", {"a": 0, "b": False, "c": ""}) == "0|False|"
+
+    def test_placeholder_inside_bare_json(self):
+        """A placeholder nested in single-brace JSON resolves.
+
+        This is the v2/hook shape: no ``{{`` escaping, just JSON with a
+        placeholder inside it.  vpd alone matches from the JSON's opening brace
+        through the placeholder's closing brace and restores the span verbatim.
+        """
+        assert render_template('{"method":"mtp","n":{n}}', {"n": 2}) == '{"method":"mtp","n":2}'
+
+    def test_placeholder_inside_nested_bare_json(self):
+        assert render_template('{"a":{"b":{n}}}', {"n": 1}) == '{"a":{"b":1}}'
+
+    def test_placeholder_inside_escaped_json(self):
+        """The v1 shape: escapes collapse, inner placeholder resolves."""
+        rendered = render_template('{{"method":"mtp","n":{n}}}', {"n": 1}, escapes=True)
+
+        assert rendered == '{"method":"mtp","n":1}'
+
+    def test_doubled_braces_preserved_without_escapes(self):
+        """Without escape mode ``{{x}}`` keeps both braces and is not substituted."""
+        assert render_template("{{keep}}", {"keep": "X"}) == "{{keep}}"
+
+    def test_json_without_placeholders_untouched(self):
+        text = "--config '{\"canvas_length\": 256}'"
+
+        assert render_template(text, {"port": 8000}) == text
+
+    def test_awk_program_untouched(self):
+        text = "docker ps | awk '{print $1}'"
+
+        assert render_template(text, {"port": 8000}) == text
+
+    def test_shell_expansion_without_matching_key(self):
+        assert render_template("echo ${HF_HOME}", {"port": 8000}) == "echo ${HF_HOME}"
+
+    def test_nested_reference_resolves(self):
+        assert render_template("{base_url}", {"base_url": "http://h:{port}", "port": 8000}) == "http://h:8000"
+
+    def test_deep_chain_resolves(self):
+        assert render_template("{a}", {"a": "{b}", "b": "{c}", "c": "end"}) == "end"
+
+    def test_self_resolving_value_is_a_fixpoint(self):
+        """``a: "{a}"`` stabilizes on the first pass — not a cycle."""
+        assert render_template("{a}", {"a": "{a}"}) == "{a}"
+
+    def test_self_growing_value_terminates(self, caplog):
+        """``a: "x{a}"`` grows every pass; the loop must stop and say so.
+
+        Without the bound this never reaches a fixpoint and the render hangs
+        while the string grows without limit.
+        """
+        with caplog.at_level(logging.WARNING, logger="sparkrun.utils.text"):
+            rendered = render_template("{a}", {"a": "x{a}"})
+
+        assert rendered.endswith("{a}")
+        assert "did not stabilize" in caplog.text
+
+    def test_mutual_recursion_terminates(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="sparkrun.utils.text"):
+            render_template("{a}", {"a": "1{b}", "b": "2{a}"})
+
+        assert "did not stabilize" in caplog.text
+
+    def test_max_passes_is_configurable(self):
+        assert render_template("{a}", {"a": "x{a}"}, max_passes=3) == "xxx{a}"
+
+    def test_no_warning_for_ordinary_templates(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="sparkrun.utils.text"):
+            render_template("--port {port}", {"port": 8000})
+
+        assert caplog.text == ""


### PR DESCRIPTION
Follow-up to #14b667e (`fix(recipes): substitute placeholders nested inside v1 brace escapes`). That change masks v1 `{{`/`}}` escapes so an escaped span can no longer swallow the placeholder nested inside it. Two paths were left on the raw vpd regex and still hit the original bug.

## 1. v2 recipes — JSON-valued flags

Masking is gated on `recipe_version == "1"`. But v2 has no escaping convention — `RECIPES.md` documents `{key}` and nothing else — so a v2 JSON-valued flag is written with plain braces:

```yaml
command: |
  vllm serve {model} \
      --speculative-config '{"method":"mtp","n":{num_speculative_tokens}}'
```

vpd's `\{(.*?)\}` matches from the JSON's opening brace through the placeholder's closing brace, misses the lookup, and restores the whole span verbatim — so the runtime receives a literal `{num_speculative_tokens}`, exactly the v1 failure.

On `develop-next` today:

```
in : --c '{"a":{"b":{n}}}'   n=1
out: --c '{"a":{"b":{n}}}'    <-- unsubstituted
```

## 2. Lifecycle hooks

`orchestration/hooks.py:render_hook_command` still calls `arg_substitute` directly, so the same bug is live there — and it needs no escapes at all to bite. Any hook that POSTs JSON silently sends an unrendered placeholder:

```
in : curl {base_url}/chat/completions -d '{"model":"{model}","stream":false}'
out: curl http://10.0.0.1:8000/v1/chat/completions -d '{"model":"{model}","stream":false}'
                                                                 ^^^^^^^ never substituted
```

`{base_url}` resolves because it stands alone; `{model}` doesn't because it sits inside JSON.

## Fix

Generalize the mask to hide **every** brace that is not part of a `{key}` span, rather than only `{{`/`}}` runs. The span pattern is `\{[^{}]*\}`, so a brace whose span contains another brace can't be a placeholder — which is exactly what lets JSON through untouched.

- `escapes=True` (v1) collapses a doubled brace to one on restore — unchanged behaviour
- `escapes=False` (v2, hooks) restores both braces, so v2's `{{literal}}` is still preserved

The shared scan lives in `utils/text.py` so both call sites use one implementation; `_mask_brace_escapes` / `_unmask_brace_escapes` remain as thin wrappers.

**All five brace tests from 14b667e pass unmodified**, including the odd-run pairing case (`--a {{{port} --b {port}}} --c {{{port}}}` → `--a {8000 --b 8000} --c {8000}`).

This does drop the run-parity pairing, which had one rough edge: an even-length `}` run consumed the placeholder's own closing brace, so `'{{"a":{n}}}}'` rendered with `{n}` intact. That input is unbalanced JSON and unlikely in a real recipe — noting it as a side effect, not as the motivation.

## Also: bound the substitution fixpoint loop

Both `render_command` and `render_hook_command` loop `while last != rendered` with no bound. That never terminates for a self-growing value — `a: "x{a}"` renders `x{a}` → `xx{a}` → … — so a malformed recipe wedges the process with no output while the string grows without limit. Reproducible on `develop-next` and on released 0.3.1.

Now bounded at 10 passes (real nesting is a short chain, `base_url` → `port`); on hitting the bound it logs and returns the last result, so the failure surfaces as a bad command rather than a hang. `a: "{a}"` is a fixpoint on pass one and is unaffected.

Happy to split this into its own PR if you'd rather keep the two concerns separate.

## Testing

- `tests/test_utils_text.py` — 31 new tests: mask/unmask round-trips in both modes, placeholders inside bare and nested JSON, shell text that only looks like a placeholder (`awk '{print $1}'`, `${VAR}`), the bounded loop
- `tests/test_recipe.py` — 4 added alongside the existing brace tests: v2 bare-JSON substitution, v2 nested JSON, v2 JSON with nothing to substitute, and the self-growing-default termination case
- `tests/test_hooks.py` — 4 added: JSON payload substitution, JSON with no placeholders, `{{` preservation, termination
- Full suite: **4742 passed**. Two failures excluded as pre-existing on `develop-next` (`test_cdi_diagnostics.py::test_probe_counts_missing_spec_paths`, `test_executor_local.py::TestLocalExecutorRoundTrip::test_launch_status_stop`) — both look environment-specific on a macOS control machine.
- All **32 recipes in the eugr registry** render and `json.loads` clean, as do the 9 recipes from eugr/spark-vllm-docker#324.
- Lint/format clean under the pinned ruff 0.15.9.

Hardware: the v1 path from 14b667e was verified on a 2-node DGX Spark cluster (`@eugr/inkling-small-nvfp4` and `@eugr/deepseek-v4-flash` serving with `--speculative-config` parsed as JSON). The v2 and hook paths in this PR are covered by tests only — I don't have a recipe in the wild that exercises them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
