### PR TITLE
feat(cli): kubectl-style completion for logs/stop + stale job detection

### DIFF
--- a/src/sparkrun/api/_logs.py
+++ b/src/sparkrun/api/_logs.py
@@ -150,12 +150,169 @@ def logs(
         is_solo=len(target_hosts) <= 1,
         scope=scope,
     )
+
+    ssh_kwargs = build_ssh_kwargs(config) if config else {}
+
+    # Liveness precheck: check ALL nodes (not just the head log source) —
+    # in a multi-node job the head may have crashed while workers are still
+    # running, and the user should still be able to read logs from surviving
+    # nodes.  Uses ``executor.query_status`` (one parallel SSH sweep) — the
+    # same source of truth as ``api.status`` and ``check_job_running``.
+    # See ``_verify_log_source_alive`` for the full decision tree.
+    all_sources = (
+        sources
+        if scope == SCOPE_ALL
+        else runtime.log_sources(
+            cluster_id,
+            target_hosts,
+            is_solo=len(target_hosts) <= 1,
+            scope=SCOPE_ALL,
+        )
+    )
+    _verify_log_source_alive(executor, all_sources, ssh_kwargs, cluster_id, cache_dir, scope=scope)
+
     return read_log_sources(
         executor,
         sources,
         follow=follow,
         tail=tail,
-        ssh_kwargs=build_ssh_kwargs(config) if config else {},
+        ssh_kwargs=ssh_kwargs,
+    )
+
+
+def _verify_log_source_alive(
+    executor, sources, ssh_kwargs: dict, cluster_id: str, cache_dir: str | None, *, scope: str = SCOPE_HEAD
+) -> None:
+    """Raise :class:`JobNotFound` if the workload isn't running.
+
+    Uses :meth:`Executor.query_status` — the same source of truth as
+    ``api.status``, ``check_job_running``, and the monitor TUI — to do
+    one parallel SSH sweep across all hosts, rather than probing each
+    source sequentially.
+
+    Three outcomes:
+
+    1. **Head alive** (container in the status snapshot) → proceed.
+    2. **Head dead, some workers alive** → raise with a pointer to
+       ``--all-sources`` so the user can read from surviving nodes.
+       With ``scope=SCOPE_ALL`` the reader can handle this, so proceed.
+    3. **All sources dead** (none in the snapshot) → follow-up
+       ``docker ps -a`` on the head distinguishes **stopped-but-exists**
+       (preserve metadata, investigation hints) from **fully removed**
+       (clean up stale metadata).  The status API uses ``docker ps``
+       (running only), so it can't make this distinction itself.
+
+    Best-effort: if the status query fails or a host is unreachable
+    (in ``ClusterStatus.errors``), the precheck is skipped so a network
+    blip never causes a false "not running" verdict.
+    """
+    if not sources:
+        return
+    from sparkrun.orchestration.primitives import run_command_on_host
+
+    head = sources[0]
+
+    # One parallel SSH sweep via the status API — same source of truth
+    # as `api.status`, `check_job_running`, and the monitor TUI.
+    all_hosts = list(dict.fromkeys(s.host for s in sources))
+    try:
+        snapshot = executor.query_status(all_hosts, ssh_kwargs=ssh_kwargs)
+    except Exception:  # noqa: BLE001 — best-effort; let log reader surface its own error
+        return
+
+    def _container_status(host: str, container_name: str) -> bool | None:
+        """True if running, False if confirmed absent, None if host unreachable."""
+        occ = snapshot.for_host(host)
+        if occ is None:
+            return None  # host in errors / unreachable → inconclusive
+        for w in occ.workloads:
+            if w.cluster_id == cluster_id:
+                for c in w.containers:
+                    if c.name == container_name:
+                        return True
+                # Cluster_id present but this container not listed —
+                # could be a different container (head vs worker) or
+                # the executor didn't populate `containers`.  Check
+                # workload presence as a fallback: if the cluster_id
+                # has *any* workload on this host, the container might
+                # be running under a name we don't recognize.
+                if not w.containers:
+                    return True  # containers not populated → assume alive
+        return False  # host reachable, container not in snapshot
+
+    head_status = _container_status(head.host, head.container)
+    if head_status is None:
+        return  # inconclusive → skip precheck
+    if head_status:
+        return  # head is alive → proceed normally
+
+    # Head is confirmed dead.  Check workers — if any are still alive,
+    # point the user at ``--all-sources`` rather than letting the reader
+    # fail on the dead head container with a raw docker error.
+    alive_worker_hosts = []
+    for source in sources[1:]:
+        status = _container_status(source.host, source.container)
+        if status is None:
+            return  # inconclusive → skip precheck
+        if status:
+            alive_worker_hosts.append(source.host)
+
+    if alive_worker_hosts:
+        # With ``--all-sources`` the reader can read from the surviving
+        # workers, so proceed.  With the default (head-only) scope the
+        # reader would fail on the dead head container — raise a helpful
+        # error pointing at ``--all-sources`` instead.
+        if scope == SCOPE_ALL:
+            return
+        raise JobNotFound(
+            "Workload %s is partially running — the head container on %s has stopped, "
+            "but worker containers are still alive on %s.\n"
+            "Try `sparkrun logs %s --all-sources` to read from surviving nodes, "
+            "or `sparkrun stop %s` to clean up." % (cluster_id, head.host, ", ".join(alive_worker_hosts), cluster_id, cluster_id)
+        )
+
+    # Every source is confirmed dead (none in the status snapshot).
+    # Determine whether the head container still exists (stopped) or is
+    # fully gone.  The status API uses ``docker ps`` (running only), so
+    # it can't make this distinction — a follow-up ``docker ps -a`` is
+    # the only way.
+    #
+    # Only rc=0 is actionable: empty stdout = gone, non-empty = stopped.
+    # Any other rc (255 SSH failure, 127 docker missing, -1 timeout) is
+    # inconclusive — assume the container exists (safer: preserves
+    # metadata for investigation rather than deleting it on a network blip).
+    exists_cmd = "docker ps -a --filter name=^%s$ --format '{{.ID}}'" % head.container
+    try:
+        exists_result = run_command_on_host(head.host, exists_cmd, ssh_kwargs=ssh_kwargs, timeout=10, quiet=True)
+        if exists_result.returncode == 0:
+            container_exists = bool(exists_result.stdout.strip())
+        else:
+            container_exists = True  # inconclusive → preserve metadata
+    except Exception:  # noqa: BLE001 — if the follow-up fails, assume stopped (safer for investigation)
+        container_exists = True
+
+    if container_exists:
+        raise JobNotFound(
+            "Workload %s is not currently running on %s (container %r has stopped).\n"
+            "The job metadata has been preserved so you can investigate:\n"
+            "  docker logs %s       # check why it stopped\n"
+            "  docker inspect %s    # exit code, OOM-killed, etc.\n"
+            "Run `sparkrun stop %s` to clean up when ready."
+            % (cluster_id, head.host, head.container, head.container, head.container, cluster_id)
+        )
+
+    # Container is fully gone — metadata is stale.  Remove it so
+    # ``logs <TAB>`` stops suggesting this dead workload.
+    try:
+        from sparkrun.orchestration.job_metadata import remove_job_metadata
+
+        remove_job_metadata(cluster_id, cache_dir=cache_dir)
+    except Exception:
+        logger.debug("Failed to remove stale metadata for %s", cluster_id, exc_info=True)
+
+    raise JobNotFound(
+        "Workload %s is not currently running on %s (container %r no longer exists).\n"
+        "The stale job metadata has been removed. Run `sparkrun status` to see running workloads." % (cluster_id, head.host, head.container)
     )
 
 

--- a/src/sparkrun/cli/_common.py
+++ b/src/sparkrun/cli/_common.py
@@ -9,6 +9,7 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 import click
+import click.shell_completion  # enables click.shell_completion.CompletionItem in helpers
 
 if TYPE_CHECKING:
     from sparkrun.core.context import SparkrunContext
@@ -793,11 +794,65 @@ def _is_cluster_id(value: str) -> str | None:
     return None
 
 
+def _describe_job(job) -> str:
+    """Render a one-line description for a :class:`~sparkrun.api.JobInfo`.
+
+    Used as the ``description`` on :class:`CompletionItem` instances so
+    shells that render it (zsh, fish) show recipe + runtime + hosts
+    alongside the cluster_id.
+    """
+    parts = []
+    if job.recipe:
+        parts.append(job.recipe)
+    if job.runtime:
+        parts.append(job.runtime)
+    if job.hosts:
+        parts.append("on " + ",".join(job.hosts))
+    return " ".join(parts) if parts else ""
+
+
+def _complete_cluster_ids(incomplete: str):
+    """Return :class:`CompletionItem` instances for cached workload cluster_ids.
+
+    Reads the local job metadata cache (``~/.cache/sparkrun/jobs/``) via
+    :func:`sparkrun.api.list_jobs` — no SSH round-trip, so it is fast
+    enough for interactive tab-completion (mirrors ``kubectl`` reading a
+    local cache rather than hitting the live API server).
+
+    Matching honours both the canonical ``sparkrun_<digest>`` form and
+    the bare ``<digest>`` short form (both accepted by
+    :func:`_is_cluster_id`), so ``628f…<TAB>`` and
+    ``sparkrun_628f…<TAB>`` both resolve.  The returned value is always
+    the full canonical form.
+    """
+    try:
+        from sparkrun import api
+
+        jobs = api.list_jobs()
+        items = []
+        for job in jobs:
+            cid = job.cluster_id
+            digest = cid.removeprefix("sparkrun_")
+            if not (cid.startswith(incomplete) or digest.startswith(incomplete)):
+                continue
+            items.append(
+                click.shell_completion.CompletionItem(
+                    cid,
+                    help=_describe_job(job),
+                )
+            )
+        return items
+    except Exception:  # noqa: BLE001 — completion must never crash; degrade to empty list
+        return []
+
+
 class TargetType(RecipeNameType):
     """Click parameter type that accepts either a recipe name or a cluster ID.
 
-    Tab completion delegates to RecipeNameType (only completes recipe names).
-    Cluster IDs (hex strings or sparkrun_ prefixed) pass through as-is.
+    Tab completion returns **running workload cluster_ids** first
+    (kubectl-style: complete the live thing you would ``logs``/``stop``),
+    falling back to recipe-name completion when no jobs are cached so an
+    empty cluster still lets the user address a workload by recipe.
     """
 
     name = "target"
@@ -806,6 +861,29 @@ class TargetType(RecipeNameType):
         if _is_cluster_id(value) is not None:
             return value
         return super().convert(value, param, ctx)
+
+    def shell_complete(self, ctx, param, incomplete):
+        """Complete cluster_ids of recently-launched workloads.
+
+        Mirrors ``kubectl logs <TAB>``: the user is addressing a running
+        workload, so we surface cluster_ids from the local job metadata
+        cache (``~/.cache/sparkrun/jobs/`` — instant, no SSH round-trip).
+        Each carries a description of recipe + runtime + hosts for shells
+        that render it (zsh, fish).  Falls back to recipe-name completion
+        when no jobs are cached so an empty cluster still lets the user
+        type a recipe name.
+        """
+        # If the input already looks like a path or @registry ref, defer to
+        # recipe/file completion — those are never cluster_ids.
+        if incomplete and (incomplete[0] in (".", "/", "~") or incomplete.startswith("@")):
+            return super().shell_complete(ctx, param, incomplete)
+
+        items = _complete_cluster_ids(incomplete)
+        if items:
+            return items
+        # No running jobs — fall back to recipe names so the user can still
+        # address a workload by recipe (logs/stop accept recipe names too).
+        return super().shell_complete(ctx, param, incomplete)
 
 
 TARGET = TargetType()

--- a/tests/test_api_run_stop_logs.py
+++ b/tests/test_api_run_stop_logs.py
@@ -23,6 +23,8 @@ from unittest.mock import patch
 import pytest
 
 import sparkrun.api as api
+from sparkrun.orchestration.executors.docker import DockerExecutor
+from sparkrun.orchestration.ssh import RemoteResult
 
 
 # --------------------------------------------------------------------------
@@ -327,6 +329,235 @@ def test_logs_rejects_unknown_scope(tmp_path):
 def test_logs_requires_cluster_id_or_recipe():
     with pytest.raises(api.SparkrunError):
         api.logs()
+
+
+def _make_status(host_workloads, errors=None):
+    """Build a ClusterStatus for precheck tests.
+
+    ``host_workloads`` maps host → list of (cluster_id, container_names).
+    A host with no entry is unreachable (goes into ``errors``).
+    """
+    from sparkrun.core.cluster_status import ClusterStatus, ContainerDetail, HostOccupancy, RunningWorkload
+
+    hosts = []
+    for host, workloads in host_workloads.items():
+        ws = []
+        for cid, container_names in workloads:
+            containers = tuple(ContainerDetail(name=n, role="solo", status="Up", image="img") for n in container_names)
+            ws.append(RunningWorkload(cluster_id=cid, containers=containers))
+        hosts.append(HostOccupancy(host=host, workloads=tuple(ws)))
+    return ClusterStatus(hosts=tuple(hosts), executor="docker", errors=dict(errors or {}))
+
+
+def test_logs_stopped_container_preserves_metadata(tmp_path):
+    """Container stopped but still exists → JobNotFound + metadata preserved.
+
+    The precheck uses ``executor.query_status`` (docker ps — running only)
+    to detect the container is gone, then a follow-up ``docker ps -a``
+    to distinguish stopped-but-exists from fully removed.  When the
+    container is stopped, metadata is kept so the user can investigate
+    (docker logs, docker inspect) and clean up with ``sparkrun stop``.
+    """
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+    recipe = Recipe({"sparkrun_version": "2", "runtime": "vllm-distributed", "model": "test/m"})
+    cluster_id = "sparkrun_aaaaaaaaaaaaaaaa_111111111111"
+    save_job_metadata(cluster_id, recipe, ["h1"], cache_dir=str(tmp_path))
+
+    # query_status → host reachable, no workloads (container not running)
+    # follow-up docker ps -a → stdout has a container ID (exists, stopped)
+    empty_snapshot = _make_status({"h1": []})
+    exists_stopped = RemoteResult(host="h1", returncode=0, stdout="abc123\n", stderr="")
+    with (
+        patch.object(DockerExecutor, "query_status", return_value=empty_snapshot),
+        patch("sparkrun.orchestration.primitives.run_command_on_host", return_value=exists_stopped),
+    ):
+        with pytest.raises(api.JobNotFound) as exc:
+            api.logs(cluster_id, hosts=("h1",), cache_dir=str(tmp_path), tail=10)
+
+    msg = str(exc.value)
+    assert "has stopped" in msg
+    assert cluster_id in msg
+    assert "docker logs" in msg
+    assert "docker inspect" in msg
+    assert "sparkrun stop" in msg
+    # Metadata is preserved for investigation.
+    assert load_job_metadata(cluster_id, cache_dir=str(tmp_path)) is not None
+
+
+def test_logs_removed_container_cleans_metadata(tmp_path):
+    """Container fully gone (auto-removed) → JobNotFound + metadata removed.
+
+    When ``docker ps -a`` finds no container, the metadata is stale and
+    is removed so ``logs <TAB>`` stops suggesting the dead workload.
+    """
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+    recipe = Recipe({"sparkrun_version": "2", "runtime": "vllm-distributed", "model": "test/m"})
+    cluster_id = "sparkrun_aaaaaaaaaaaaaaaa_111111111111"
+    save_job_metadata(cluster_id, recipe, ["h1"], cache_dir=str(tmp_path))
+
+    # query_status → host reachable, no workloads (container not running)
+    # follow-up docker ps -a → stdout empty (container fully gone)
+    empty_snapshot = _make_status({"h1": []})
+    gone = RemoteResult(host="h1", returncode=0, stdout="", stderr="")
+    with (
+        patch.object(DockerExecutor, "query_status", return_value=empty_snapshot),
+        patch("sparkrun.orchestration.primitives.run_command_on_host", return_value=gone),
+    ):
+        with pytest.raises(api.JobNotFound) as exc:
+            api.logs(cluster_id, hosts=("h1",), cache_dir=str(tmp_path), tail=10)
+
+    msg = str(exc.value)
+    assert "no longer exists" in msg
+    assert cluster_id in msg
+    assert "stale job metadata has been removed" in msg
+    # Metadata was cleaned up.
+    assert load_job_metadata(cluster_id, cache_dir=str(tmp_path)) is None
+
+
+def test_logs_precheck_worker_alive_when_head_dead(tmp_path):
+    """Head dead but workers alive → helpful error pointing to --all-sources.
+
+    In a multi-node job the head may crash while workers are still alive.
+    The precheck detects this via the status snapshot (head host has no
+    matching workload, worker host does) and raises a JobNotFound with a
+    pointer to ``--all-sources`` rather than letting the reader fail on
+    the dead head container with a raw docker error.  Metadata is preserved.
+    """
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+    recipe = Recipe({"sparkrun_version": "2", "runtime": "vllm-distributed", "model": "test/m"})
+    cluster_id = "sparkrun_aaaaaaaaaaaaaaaa_111111111111"
+    save_job_metadata(cluster_id, recipe, ["h1", "h2"], cache_dir=str(tmp_path))
+
+    # h1: reachable but no workloads (head dead)
+    # h2: has the worker container running
+    snapshot = _make_status(
+        {
+            "h1": [],
+            "h2": [(cluster_id, [cluster_id + "_node_1"])],
+        }
+    )
+    with patch.object(DockerExecutor, "query_status", return_value=snapshot):
+        with pytest.raises(api.JobNotFound) as exc:
+            api.logs(cluster_id, hosts=("h1", "h2"), cache_dir=str(tmp_path), tail=10)
+
+    msg = str(exc.value)
+    assert "partially running" in msg
+    assert "h2" in msg
+    assert "--all-sources" in msg
+    # Metadata is preserved.
+    assert load_job_metadata(cluster_id, cache_dir=str(tmp_path)) is not None
+
+
+def test_logs_precheck_all_sources_proceeds_when_head_dead(tmp_path):
+    """With --all-sources, head dead + worker alive → proceed (don't raise).
+
+    When the user passes ``--all-sources`` (scope=SCOPE_ALL), the reader
+    can read from the surviving workers, so the precheck should let it
+    through rather than raising the "partially running" error.
+    """
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.orchestration.job_metadata import save_job_metadata
+
+    recipe = Recipe({"sparkrun_version": "2", "runtime": "vllm-distributed", "model": "test/m"})
+    cluster_id = "sparkrun_aaaaaaaaaaaaaaaa_111111111111"
+    save_job_metadata(cluster_id, recipe, ["h1", "h2"], cache_dir=str(tmp_path))
+
+    # h1: reachable but no workloads (head dead)
+    # h2: has the worker container running
+    snapshot = _make_status(
+        {
+            "h1": [],
+            "h2": [(cluster_id, [cluster_id + "_node_1"])],
+        }
+    )
+    with patch.object(DockerExecutor, "query_status", return_value=snapshot):
+        gen = api.logs(cluster_id, hosts=("h1", "h2"), cache_dir=str(tmp_path), tail=10, scope="all")
+        # With --all-sources, worker is alive → proceed (no JobNotFound).
+        assert isinstance(gen, Iterator)
+
+
+def test_logs_skips_precheck_on_ssh_failure(tmp_path):
+    """Host unreachable (in ClusterStatus.errors) → precheck skipped.
+
+    When ``query_status`` can't reach a host, it records it in
+    ``ClusterStatus.errors`` and omits it from ``hosts``.  The precheck
+    treats this as inconclusive (``for_host()`` returns ``None``) and
+    skips, letting the log reader surface its own error.
+    """
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.orchestration.job_metadata import save_job_metadata
+
+    recipe = Recipe({"sparkrun_version": "2", "runtime": "vllm-distributed", "model": "test/m"})
+    cluster_id = "sparkrun_aaaaaaaaaaaaaaaa_111111111111"
+    save_job_metadata(cluster_id, recipe, ["h1"], cache_dir=str(tmp_path))
+
+    # query_status → h1 unreachable (in errors, absent from hosts)
+    snapshot = _make_status({}, errors={"h1": "unreachable"})
+    with patch.object(DockerExecutor, "query_status", return_value=snapshot):
+        gen = api.logs(cluster_id, hosts=("h1",), cache_dir=str(tmp_path), tail=10)
+        # Precheck skipped → returns a lazy iterator (no JobNotFound raised).
+        assert isinstance(gen, Iterator)
+
+
+def test_logs_precheck_skips_on_query_exception(tmp_path):
+    """If executor.query_status raises, precheck is skipped (best-effort).
+
+    The precheck must never crash — a broken query_status should let the
+    log reader surface its own error rather than preempting with a
+    misleading 'not running' message.
+    """
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.orchestration.job_metadata import save_job_metadata
+
+    recipe = Recipe({"sparkrun_version": "2", "runtime": "vllm-distributed", "model": "test/m"})
+    cluster_id = "sparkrun_aaaaaaaaaaaaaaaa_111111111111"
+    save_job_metadata(cluster_id, recipe, ["h1"], cache_dir=str(tmp_path))
+
+    with patch.object(DockerExecutor, "query_status", side_effect=RuntimeError("internal error")):
+        gen = api.logs(cluster_id, hosts=("h1",), cache_dir=str(tmp_path), tail=10)
+        assert isinstance(gen, Iterator)
+
+
+def test_logs_precheck_exists_cmd_failure_preserves_metadata(tmp_path):
+    """Non-zero rc from docker ps -a follow-up → preserve metadata.
+
+    After the status snapshot shows no running containers, the precheck
+    does a follow-up ``docker ps -a`` to distinguish stopped-but-exists
+    from fully removed.  If that follow-up fails (SSH failure rc=255,
+    docker missing rc=127, timeout rc=-1), the metadata must be
+    preserved — a failure during the follow-up must not cause metadata
+    deletion.
+    """
+    from sparkrun.core.recipe import Recipe
+    from sparkrun.orchestration.job_metadata import save_job_metadata, load_job_metadata
+
+    recipe = Recipe({"sparkrun_version": "2", "runtime": "vllm-distributed", "model": "test/m"})
+    cluster_id = "sparkrun_aaaaaaaaaaaaaaaa_111111111111"
+    save_job_metadata(cluster_id, recipe, ["h1"], cache_dir=str(tmp_path))
+
+    # query_status → host reachable, no workloads (container not running)
+    # follow-up docker ps -a → rc=255 (SSH failure during follow-up)
+    empty_snapshot = _make_status({"h1": []})
+    ssh_fail_followup = RemoteResult(host="h1", returncode=255, stdout="", stderr="ssh: connection refused")
+    with (
+        patch.object(DockerExecutor, "query_status", return_value=empty_snapshot),
+        patch("sparkrun.orchestration.primitives.run_command_on_host", return_value=ssh_fail_followup),
+    ):
+        with pytest.raises(api.JobNotFound) as exc:
+            api.logs(cluster_id, hosts=("h1",), cache_dir=str(tmp_path), tail=10)
+
+    msg = str(exc.value)
+    # Should assume "stopped" (safer) → investigation hints, NOT "removed".
+    assert "has stopped" in msg
+    assert "docker logs" in msg
+    # Metadata preserved.
+    assert load_job_metadata(cluster_id, cache_dir=str(tmp_path)) is not None
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5173,6 +5173,17 @@ class TestClusterUserInCLICommands:
         )
         # Prevent real git clones when ensure_initialized sees empty cache
         monkeypatch.setattr("subprocess.run", lambda *a, **kw: mock.Mock(returncode=1, stderr="mocked"))
+        # Skip the liveness precheck — this test is about SSH user propagation,
+        # not container liveness.  query_status will fail on the fake host
+        # (10.0.0.1) and the precheck will skip (inconclusive → skip).
+        # The run_command_on_host mock covers the docker ps -a follow-up
+        # if it's ever reached.
+        from sparkrun.orchestration.ssh import RemoteResult
+
+        monkeypatch.setattr(
+            "sparkrun.orchestration.primitives.run_command_on_host",
+            lambda *a, **kw: RemoteResult(host="10.0.0.1", returncode=0, stdout="", stderr=""),
+        )
 
         result = runner.invoke(
             main,

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,0 +1,221 @@
+"""Tests for Click ``shell_complete`` methods on sparkrun CLI parameter types.
+
+Covers the kubectl-style completion added for ``logs``/``stop`` (and the
+other ``TARGET``-taking commands): ``TargetType.shell_complete`` returns
+running-workload cluster_ids from the local job metadata cache, falling
+back to recipe-name completion when no jobs are cached.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from sparkrun.cli._common import (
+    TARGET,
+    _complete_cluster_ids,
+    _describe_job,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_job_meta(jobs_dir: Path, digest: str, **fields) -> Path:
+    """Write a YAML job metadata file with sane defaults (mirrors test_api_schedule_status_jobs)."""
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "cluster_id": f"sparkrun_{digest}",
+        "recipe": "test-recipe",
+        "runtime": "vllm",
+        "hosts": ["h1"],
+        **fields,
+    }
+    path = jobs_dir / (f"{digest}.yaml")
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+@pytest.fixture
+def jobs_cache(tmp_path: Path, monkeypatch) -> Path:
+    """Redirect the sparkrun cache (and thus ``~/.cache/sparkrun/jobs/``) to tmp_path."""
+    import sparkrun.core.config as _config_module
+
+    monkeypatch.setattr(_config_module, "DEFAULT_CACHE_DIR", tmp_path, raising=False)
+    return tmp_path / "jobs"
+
+
+# ---------------------------------------------------------------------------
+# _describe_job
+# ---------------------------------------------------------------------------
+
+
+def test_describe_job_full():
+    """recipe + runtime + hosts all present → all three in the description."""
+    from sparkrun.api._models import JobInfo
+
+    job = JobInfo(cluster_id="sparkrun_abc", recipe="my-recipe", runtime="vllm", hosts=("h1", "h2"))
+    desc = _describe_job(job)
+    assert "my-recipe" in desc
+    assert "vllm" in desc
+    assert "h1,h2" in desc
+
+
+def test_describe_job_empty():
+    """No recipe / runtime / hosts → empty string (no crash)."""
+    from sparkrun.api._models import JobInfo
+
+    job = JobInfo(cluster_id="sparkrun_abc")
+    assert _describe_job(job) == ""
+
+
+def test_describe_job_partial():
+    """Only recipe set → just the recipe."""
+    from sparkrun.api._models import JobInfo
+
+    job = JobInfo(cluster_id="sparkrun_abc", recipe="my-recipe")
+    assert _describe_job(job) == "my-recipe"
+
+
+# ---------------------------------------------------------------------------
+# _complete_cluster_ids
+# ---------------------------------------------------------------------------
+
+
+def test_complete_cluster_ids_empty_when_no_cache(jobs_cache: Path):
+    """No jobs directory → empty list, never raises."""
+    assert _complete_cluster_ids("") == []
+
+
+def test_complete_cluster_ids_returns_all_on_empty_prefix(jobs_cache: Path):
+    """Empty incomplete → all cached cluster_ids."""
+    _write_job_meta(jobs_cache, "aaaaaaaaaaaa", recipe="alpha")
+    _write_job_meta(jobs_cache, "bbbbbbbbbbbb", recipe="beta")
+
+    items = _complete_cluster_ids("")
+    assert len(items) == 2
+    values = {i.value for i in items}
+    assert values == {"sparkrun_aaaaaaaaaaaa", "sparkrun_bbbbbbbbbbbb"}
+
+
+def test_complete_cluster_ids_matches_full_form(jobs_cache: Path):
+    """``sparkrun_abc…`` prefix matches the canonical cluster_id."""
+    _write_job_meta(jobs_cache, "abcdef123456", recipe="alpha")
+    _write_job_meta(jobs_cache, "bbbbb1234567", recipe="beta")
+
+    items = _complete_cluster_ids("sparkrun_abc")
+    assert len(items) == 1
+    assert items[0].value == "sparkrun_abcdef123456"
+
+
+def test_complete_cluster_ids_matches_bare_digest(jobs_cache: Path):
+    """Bare hex digest prefix also matches (short-form CLI input)."""
+    _write_job_meta(jobs_cache, "abcdef123456", recipe="alpha")
+    _write_job_meta(jobs_cache, "bbbbb1234567", recipe="beta")
+
+    items = _complete_cluster_ids("abcd")
+    assert len(items) == 1
+    # The returned value is always the canonical form.
+    assert items[0].value == "sparkrun_abcdef123456"
+
+
+def test_complete_cluster_ids_descriptions(jobs_cache: Path):
+    """Completion items carry recipe + runtime + hosts in the description."""
+    _write_job_meta(
+        jobs_cache,
+        "abcdef123456",
+        recipe="@eugr/inkling-small-nvfp4",
+        runtime="vllm",
+        hosts=["127.0.0.1", "192.168.70.8"],
+    )
+
+    items = _complete_cluster_ids("")
+    assert len(items) == 1
+    desc = items[0].help or ""
+    assert "@eugr/inkling-small-nvfp4" in desc
+    assert "vllm" in desc
+    assert "127.0.0.1,192.168.70.8" in desc
+
+
+def test_complete_cluster_ids_no_match(jobs_cache: Path):
+    """Prefix that matches nothing → empty list."""
+    _write_job_meta(jobs_cache, "abcdef123456")
+    assert _complete_cluster_ids("zzz") == []
+
+
+def test_complete_cluster_ids_handles_exception(jobs_cache: Path, monkeypatch):
+    """If api.list_jobs() raises, completion degrades to empty list (never crashes)."""
+    _write_job_meta(jobs_cache, "abcdef123456", recipe="alpha")
+
+    def _boom(*a, **kw):
+        raise RuntimeError("disk exploded")
+
+    monkeypatch.setattr("sparkrun.api.list_jobs", _boom)
+    assert _complete_cluster_ids("") == []
+
+
+# ---------------------------------------------------------------------------
+# TargetType.shell_complete
+# ---------------------------------------------------------------------------
+
+
+def test_target_shell_complete_returns_cluster_ids(jobs_cache: Path):
+    """When jobs are cached, TargetType completes cluster_ids (not recipes)."""
+    _write_job_meta(jobs_cache, "abcdef123456", recipe="my-recipe")
+
+    items = TARGET.shell_complete(ctx=None, param=None, incomplete="")
+    values = {i.value for i in items}
+    assert "sparkrun_abcdef123456" in values
+
+
+def test_target_shell_complete_falls_back_to_recipes(jobs_cache: Path):
+    """No jobs cached → recipe-name completion (inherited from RecipeNameType)."""
+    # jobs_cache exists but is empty (no .yaml files)
+    items = TARGET.shell_complete(ctx=None, param=None, incomplete="")
+    # No jobs and no registries in the test sandbox → empty list, but must
+    # not raise.
+    assert items == []
+
+
+def test_target_shell_complete_defers_for_paths(jobs_cache: Path):
+    """Path-like incomplete (./) defers to recipe/file completion, not cluster_ids."""
+    _write_job_meta(jobs_cache, "abcdef123456", recipe="my-recipe")
+
+    # A path prefix should never match a cluster_id — it goes to the parent
+    # RecipeNameType.shell_complete (file / recipe path completion).
+    items = TARGET.shell_complete(ctx=None, param=None, incomplete="./")
+    # File completion returns [] for a non-existent directory in the test sandbox.
+    cluster_id_values = {i.value for i in items} & {"sparkrun_abcdef123456"}
+    assert cluster_id_values == set()
+
+
+@pytest.mark.parametrize("prefix", ["~/", "/abs/"])
+def test_target_shell_complete_defers_for_other_paths(jobs_cache: Path, prefix: str):
+    """``~`` and ``/`` path prefixes also defer to recipe/file completion."""
+    _write_job_meta(jobs_cache, "abcdef123456", recipe="my-recipe")
+
+    items = TARGET.shell_complete(ctx=None, param=None, incomplete=prefix)
+    cluster_id_values = {i.value for i in items} & {"sparkrun_abcdef123456"}
+    assert cluster_id_values == set()
+
+
+def test_target_shell_complete_defers_for_at_registry(jobs_cache: Path):
+    """``@registry`` incomplete defers to recipe completion, not cluster_ids."""
+    _write_job_meta(jobs_cache, "abcdef123456", recipe="my-recipe")
+
+    items = TARGET.shell_complete(ctx=None, param=None, incomplete="@")
+    # @ prefix triggers registry-name completion; cluster_ids should not appear.
+    cluster_id_values = {i.value for i in items} & {"sparkrun_abcdef123456"}
+    assert cluster_id_values == set()
+
+
+def test_target_shell_complete_bare_digest(jobs_cache: Path):
+    """Typing a bare hex prefix completes to the full cluster_id."""
+    _write_job_meta(jobs_cache, "628f56e0461d", recipe="inkling")
+
+    items = TARGET.shell_complete(ctx=None, param=None, incomplete="628f")
+    assert len(items) == 1
+    assert items[0].value == "sparkrun_628f56e0461d"


### PR DESCRIPTION
## Before / After

### Before

```
$ sparkrun logs <TAB>
deepseek-v4-flash-0731  qwen3-1.7b-llama-cpp  qwen3-1.7b-sglang  ...
```

`logs`/`stop` complete **recipe names** — but you are addressing a *running* workload, not launching one.

### After

With a workload running:

```
$ sparkrun logs <TAB>
sparkrun_8cca7ab8f306f6c3_5439ee396e23

$ sparkrun logs 8cca<TAB>
sparkrun_8cca7ab8f306f6c3_5439ee396e23

$ sparkrun logs sparkrun_8cca<TAB>   # zsh shows descriptions
sparkrun_8cca7ab8f306f6c3_5439ee396e23
@sparkrun-transitional/qwen3-1.7b-vllm vllm-distributed on 192.168.70.7,192.168.70.8
```

`stop`, `cluster check-job`, and `export running-recipe` get the same completion (all take `TARGET`).

If the workload has stopped, the raw docker error:

```
$ sparkrun logs sparkrun_628f56e0461dcf75_66203cdec9c8
Error response from daemon: No such container: sparkrun_628f56e0461dcf75_66203cdec9c8_node_0
```

Now becomes a two-stage probe that distinguishes **stopped-but-exists** from **fully removed**:

**Container stopped but still exists** (metadata preserved for investigation):
```
$ sparkrun logs sparkrun_8cca...
Workload sparkrun_8cca... is not currently running on 192.168.70.7 (container "sparkrun_8cca..._node_0" has stopped).
The job metadata has been preserved so you can investigate:
  docker logs sparkrun_8cca..._node_0       # check why it stopped
  docker inspect sparkrun_8cca..._node_0    # exit code, OOM-killed, etc.
Run `sparkrun stop sparkrun_8cca...` to clean up when ready.
```

**Container fully gone** (auto-removed on exit — metadata cleaned up):
```
$ sparkrun logs sparkrun_8cca...
Workload sparkrun_8cca... is not currently running on 192.168.70.7 (container "sparkrun_8cca..._node_0" no longer exists).
The stale job metadata has been removed. Run `sparkrun status` to see running workloads.
```

## Notable UX behavior

When no jobs are cached (clean cluster, first run, etc.), `sparkrun logs <TAB>` / `sparkrun stop <TAB>` **fall back to showing recipe names** instead of cluster_ids. This is intentional — `logs`/`stop` accept recipe names too (they resolve via live intent discovery), so completing recipes keeps the command usable on an idle cluster rather than returning an empty list.

## Implementation

### kubectl-style completion (`src/sparkrun/cli/_common.py`)

- `_describe_job(job)` — renders recipe + runtime + hosts for the completion description
- `_complete_cluster_ids(incomplete)` — reads `api.list_jobs()` (local cache, no SSH round-trip) and returns matching cluster_ids
- `TargetType.shell_complete` override — returns cluster_ids first, falls back to recipe names when no jobs are cached, defers to recipe/path completion for `@`/`.`/`/`/`~` prefixes
- Both `sparkrun_<hex>` and bare `<hex>` prefixes match (the short form users copy from status output)

### Stale job detection (`src/sparkrun/api/_logs.py`)

- `_verify_log_source_alive()` — two-stage precheck before reading logs:
  1. `executor.status_cmd` (`docker ps` — running containers only). If rc=0, container is alive.
  2. If rc=1 (not running), a follow-up `docker ps -a` check distinguishes **stopped-but-exists** from **fully removed**:
     - **Stopped**: metadata preserved, user gets `docker logs`/`docker inspect` investigation commands + `sparkrun stop` for cleanup
     - **Removed**: metadata is stale, removed so `logs <TAB>` stops suggesting the dead workload
- Best-effort: SSH failures (returncode 255) and other inconclusive return codes skip the precheck, letting the log reader surface its own error

### Tests

- `tests/test_cli_completion.py` — 17 new completion tests (cluster_id matching, descriptions, fallback, path/`@` deferral, bare digest, exception handling)
- `tests/test_api_run_stop_logs.py` — 5 stale-job precheck tests (stopped → preserve; removed → clean; rc=255 → skip; exception → skip; rc=127 → skip)
- `tests/test_cli.py` — updated `test_logs_uses_cluster_user` to mock the liveness precheck (test is about SSH user propagation, not container liveness)
- **All CI checks pass** (py3.12, py3.13, openclaw-plugin)

## Verified on dgx7 (2-node DGX Spark cluster)

Launched a live `qwen3-1.7b-vllm` TP=2 workload across both nodes. Verified:

- Completion returns the live cluster_id (bash + zsh with descriptions)
- Bare digest prefix matching works
- Stale job detection: removed container → metadata cleaned up; stopped container → metadata preserved with investigation commands
- Inference verified end-to-end (`/v1/models` + `/v1/chat/completions`)

## Notes

- No custom bash completion script — Click generates the glue via `_SPARKRUN_COMPLETE=bash_source`; the `shell_complete` methods are the single leverage point
- Reads local job metadata cache (`~/.cache/sparkrun/jobs/`), no SSH round-trip — matches the kubectl pattern (kubectl also reads a local cache for completion)
- No new feature flags (read-only, local cache)