### PR TITLE
v0.3.2 Alpha to Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ For the long-form 0.3.0 narrative, see [`docs/RELEASE_NOTES.md`](docs/RELEASE_NO
   applies to both solo and multi-node runs (unlike `-p/--publish`, solo-only).
 - `tests/test_run_recipe_shim.py` — argv-mapping coverage for the shim, driven
   through its `RUN_RECIPE_DEBUG=1` hook.
+- eugr builder: support for `build-and-copy.sh`'s `--exp-b12x` /
+  `--experimental-b12x` preset. As upstream, it does not set
+  `CUSTOM_BUILD_REQUESTED`, so on its own it only changes *which* prebuilt image
+  is pulled: a nightly `:latest` sentinel (or a missing non-pullable eugr image)
+  resolves to `ghcr.io/spark-arena/dgx-vllm-eugr-nightly-b12x:latest` — sparkrun's
+  mirror of upstream's `eugr/spark-vllm-b12x:latest` — instead of the standard
+  nightly. Naming a b12x prebuilt image selects the variant the same way. With a
+  custom build flag alongside it the build runs under the `sparkrun-eugr-vllm-b12x`
+  local tag (upstream tags `vllm-node-b12x`) and the flag is forwarded verbatim.
+  Long-term image pinning resolves against the `nightly-b12x` variant.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ follows semantic versioning.
 
 For the long-form 0.3.0 narrative, see [`docs/RELEASE_NOTES.md`](docs/RELEASE_NOTES.md).
 
+## [Unreleased]
+
+### Added
+
+- `run-recipe.sh` shim: `-v/--volume LOCAL:CONTAINER` (repeatable), matching
+  spark-vllm-docker upstream. It maps to `--executor-args "-v ..."`, which the
+  docker executor shlex-splits back into the `docker run` argv. As upstream, it
+  applies to both solo and multi-node runs (unlike `-p/--publish`, solo-only).
+- `tests/test_run_recipe_shim.py` — argv-mapping coverage for the shim, driven
+  through its `RUN_RECIPE_DEBUG=1` hook.
+
+### Changed
+
+- `run-recipe.sh` shim: `--ray`/`--no-ray` combined with `--solo` now warn and
+  are ignored instead of erroring, matching upstream's
+  `use_ray = args.ray and not is_solo`. The flags are recorded during parsing
+  and resolved afterwards, so a trailing `--solo` suppresses them too.
+- `run-recipe.sh` shim: `--earlyoom` / `--earlyoom-args` are now rejected with
+  the standard "not supported" pointer rather than a bare "unknown option"
+  error. sparkrun runs the server as the container foreground process, so there
+  is no earlyoom supervisor to substitute.
+
 ## [0.3.0] — 2026-07-30
 
 The largest release since 0.1: multiplatform foundations, a console-free

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,34 @@ All remote operations use **SSH stdin piping** — scripts are generated as Pyth
 - **`collectives/`** — `CollectiveBackend` ABC + implementations: `nccl.py` (default; wraps `infiniband.py`), `rccl.py` (AMD scaffold), `hccl.py` (Intel Gaudi scaffold). `get_backend(vendor)` is the lookup.
 - **`hooks.py`** — `pre_exec` / `post_exec` / `post_commands` runners. Trust gating via `_confirm_hook_execution(trust=...)`.
 
+**Session guard** (`ssh.py:wrap_with_session_guard` + `scripts/session_guard.sh`):
+remote payloads run via `ssh <host> bash -s`, i.e. **without a PTY**, so on
+disconnect sshd's session process exits without signalling its child (the
+SIGHUP-on-disconnect path is PTY-only) and the payload is merely reparented —
+a killed `sparkrun` would leave `hf download` / `docker pull` / rsync fan-outs
+running on the cluster, invisible from the control node and stacking across
+retries (issue #240). The guard backgrounds the payload in its own process
+group (`set -m` outside, `set +m` *inside*, so a payload that backgrounds its
+own jobs stays in one killable group) and polls its own PPID; on reparent it
+TERMs then KILLs the group. Transparent otherwise — stdout, stderr and rc pass
+through.
+
+It is **opt-in** per call site via `session_guard=True` on `run_remote_script`,
+`run_remote_scripts_parallel` and `run_remote_script_streaming` (mirroring the
+`allow_local` precedent), and is on for the long, expensive payloads only:
+`_distribute_from_head` (both steps), `sync_resource_to_hosts` (model + image
+parallel sync), and the eugr container build. Short status probes stay
+unguarded — an orphaned `docker ps` is harmless. Never applied on the
+local-dispatch path (no session to lose) or under `--dry-run`. Kill switch:
+`SPARKRUN_NO_SESSION_GUARD=1`.
+
+The control-node half is `cli/_common.py:install_termination_handlers`, called
+from the `main` group callback: SIGTERM/SIGHUP raise `KeyboardInterrupt`, so
+`subprocess.run`'s existing kill-on-exception cleanup drops the SSH client (and
+every `KeyboardInterrupt` state-preservation path already in the codebase runs).
+`SIGKILL` remains unreachable — it leaves the ssh client alive, the session
+healthy, and the guard correctly dormant.
+
 ### Status Discovery ("what's running where?")
 
 All workload-status discovery flows through **one source**, `api.status`, in two

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -230,6 +230,29 @@ command: |
 - Trailing spaces after backslash continuations (`\ \n`) are auto-fixed
 - The runtime may auto-append flags (e.g. `--served-model-name`) if the template omits them
 
+### Literal braces (JSON-valued flags)
+
+**Write literal braces plainly. No escaping.** A `{...}` span containing another brace can't be a placeholder, so JSON
+passes through untouched — and a placeholder nested inside it still resolves:
+
+```yaml
+command: |
+  vllm serve {model} \
+      --speculative-config '{"method":"mtp","num_speculative_tokens":{num_speculative_tokens}}' \
+      --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+```
+
+This applies to `defaults` values as well as to the command template.
+
+> **Deprecated: doubled braces.** v1 (eugr) recipes escape a literal brace by doubling it (`'{{"a":1}}'`). sparkrun
+> still honors that — a doubled brace collapses to one, so a v1 command pasted into a v2 recipe works rather than
+> shipping `{{...}}` to the runtime — but it logs a deprecation warning outside v1 and **will not be supported in v3**.
+> Do not write new recipes this way. The convention is detected from `{{` and then applies to the whole template, so a
+> template mixing both spellings collapses the `}}` that merely closes a nested plain-JSON object.
+
+Lifecycle hooks (`pre_exec` / `post_exec` / `post_commands`) render `{key}` and pass plain JSON through identically,
+but never collapse `{{` — a hook body is shell, where a doubled brace may be meant literally.
+
 **When to use templates:** full control over flags, ordering, runtime-specific features not in the flag map. **When to
 omit:** standard configs where the runtime's `generate_command()` is sufficient.
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -569,13 +569,23 @@ builds from wheels when `build_args` request it**. A build is requested when `bu
 - Any other non-pullable eugr image (e.g. a v1 `container: vllm-node`) is reused if already present,
   otherwise substituted with our nightly and pulled — eugr no longer builds it implicitly.
 - `--rebuild` force-pulls a fresh copy.
+- `--exp-b12x` (alias `--experimental-b12x`) selects the b12x preset. Like upstream — where it swaps
+  the vLLM fork/ref and Torch family and points `PREBUILT_RUNNER_IMAGE` at `eugr/spark-vllm-b12x`
+  *without* setting `CUSTOM_BUILD_REQUESTED` — it does not trigger a build on its own: the sentinel
+  resolves to `ghcr.io/spark-arena/dgx-vllm-eugr-nightly-b12x:latest` and is pulled. Naming a b12x
+  prebuilt image (ours, or `eugr/spark-vllm-b12x:latest`) selects the variant the same way.
 
 **Build path (`--use-wheels` or a custom build flag):**
 
-- The nightly sentinels build locally as `sparkrun-eugr-vllm`; other images build under their own name.
-- `build_args` are forwarded verbatim to `build-and-copy.sh` (so `--use-wheels`, `--vllm-ref`, etc. take
-  effect). The build cache is honored for the standard `--use-wheels` build; `--rebuild` forces a
-  from-scratch rebuild.
+- The nightly sentinels build locally as `sparkrun-eugr-vllm` (or `sparkrun-eugr-vllm-b12x` when
+  `--exp-b12x` is present, mirroring upstream's `vllm-node-b12x` default tag, so a b12x source build
+  can't overwrite the standard nightly); other images build under their own name.
+- `build_args` are forwarded verbatim to `build-and-copy.sh` (so `--use-wheels`, `--vllm-ref`,
+  `--exp-b12x`, etc. take effect). The build cache is honored for the standard `--use-wheels` build;
+  `--rebuild` forces a from-scratch rebuild.
+- Flag incompatibilities are the script's to enforce — e.g. `--exp-b12x --use-wheels` is rejected
+  upstream (b12x vLLM wheels aren't published) and surfaces as a build failure rather than being
+  second-guessed here.
 
 Set `defaults.builders.eugr.use_sentinel_image: false` in `~/.config/sparkrun/config.yaml` to opt out of
 pull-first entirely: images are used verbatim and a missing one is built via `build-and-copy.sh`.

--- a/run-recipe.sh
+++ b/run-recipe.sh
@@ -26,7 +26,11 @@
 #   * No-Ray is the default multi-node backend (matching upstream). `--ray`
 #     opts into Ray (-> -o distributed_executor_backend=ray, i.e. vllm-ray);
 #     `--no-ray` is accepted for compatibility (-> vllm-distributed, the
-#     default). The two are mutually exclusive and both are rejected with --solo.
+#     default). The two are mutually exclusive. In solo mode both are ignored
+#     with a note (upstream: `use_ray = args.ray and not is_solo`).
+#   * -v/--volume becomes `--executor-args "-v ..."`, which the docker executor
+#     shlex-splits back into the `docker run` argv. Like upstream, it applies to
+#     both solo and multi-node runs (unlike -p/--publish, which is solo-only).
 #
 # Hidden testing hook:
 #   RUN_RECIPE_DEBUG=1  -> print the assembled `sparkrun` argv to stderr and
@@ -83,6 +87,7 @@ Common options (mapped onto \`sparkrun run\`):
   --no-ray                      Default multi-node backend; accepted for compat (-> -o distributed_executor_backend=mp)
   -e, --env VAR=VAL             Container env var (repeatable)
   -p, --publish H:C             Publish port, solo only (repeatable)
+  -v, --volume LOCAL:CONTAINER  Bind-mount a volume (repeatable)
   --nccl-debug LEVEL            -> -e NCCL_DEBUG=LEVEL
   --dry-run                     Show the plan without launching
 
@@ -215,6 +220,8 @@ parse_args() {
                 consume_value "--nccl-debug"; ARGS+=(--executor-args "-e NCCL_DEBUG=${VAL}"); shift; [[ $DBL -eq 1 ]] && shift; continue ;;
             -p|--publish)
                 consume_value "--publish"; ARGS+=(--executor-args "-p ${VAL}"); HAVE_PUBLISH=1; shift; [[ $DBL -eq 1 ]] && shift; continue ;;
+            -v|--volume)
+                consume_value "--volume"; ARGS+=(--executor-args "-v ${VAL}"); shift; [[ $DBL -eq 1 ]] && shift; continue ;;
             --mem-limit-gb)
                 consume_value "--mem-limit-gb"; ARGS+=(--memory-limit "${VAL}G"); shift; [[ $DBL -eq 1 ]] && shift; continue ;;
             --shm-size-gb)
@@ -225,9 +232,12 @@ parse_args() {
                 consume_value "--pids-limit"; ARGS+=(--executor-args "--pids-limit ${VAL}"); shift; [[ $DBL -eq 1 ]] && shift; continue ;;
 
             # ----- boolean / mode flags -----
+            # --ray/--no-ray are recorded, not emitted: solo suppresses both and
+            # may appear after them on the command line, so the backend override
+            # is resolved in main() once the whole argv has been seen.
             --solo)            SOLO=1; ARGS+=(--solo); shift; continue ;;
-            --ray)             RAY=1; ARGS+=(-o distributed_executor_backend=ray); shift; continue ;;
-            --no-ray)          NO_RAY=1; ARGS+=(-o distributed_executor_backend=mp); shift; continue ;;
+            --ray)             RAY=1; shift; continue ;;
+            --no-ray)          NO_RAY=1; shift; continue ;;
             -d|--daemon)       DAEMON=1; shift; continue ;;
             --dry-run)         ARGS+=(--dry-run); shift; continue ;;
             --non-privileged)  ARGS+=(-o privileged=false); shift; continue ;;
@@ -250,6 +260,8 @@ parse_args() {
             -j)                unsupported "-j" "no in-container build step under sparkrun." ;;
             --keep-entrypoint) unsupported "--keep-entrypoint" "sparkrun manages the container entrypoint." ;;
             --no-cache-dirs)   unsupported "--no-cache-dirs" "sparkrun manages cache mounts." ;;
+            --earlyoom)        unsupported "--earlyoom" "sparkrun runs the server as the container foreground process; there is no earlyoom supervisor to substitute." ;;
+            --earlyoom-args)   unsupported "--earlyoom-args" "sparkrun runs the server as the container foreground process; there is no earlyoom supervisor to substitute." ;;
 
             # ----- unknown options -----
             -*) die "unknown option: ${arg} (run \`sparkrun run --help\` for native options)" ;;
@@ -327,11 +339,18 @@ main() {
     if [[ $RAY -eq 1 && $NO_RAY -eq 1 ]]; then
         die "--ray and --no-ray are mutually exclusive."
     fi
-    if [[ $SOLO -eq 1 && ( $RAY -eq 1 || $NO_RAY -eq 1 ) ]]; then
-        die "--ray/--no-ray are incompatible with --solo or a single-node configuration."
-    fi
     if [[ $HAVE_PUBLISH -eq 1 && $SOLO -eq 0 ]]; then
         die "-p/--publish is only supported in solo mode; add --solo or drop the port mapping."
+    fi
+
+    # Ray selection. Upstream computes `use_ray = args.ray and not is_solo`, so
+    # solo silently drops the backend choice rather than erroring; match that.
+    if [[ $SOLO -eq 1 && ( $RAY -eq 1 || $NO_RAY -eq 1 ) ]]; then
+        err "${PROG}: note: --ray/--no-ray are ignored in solo mode (a single node needs no distributed backend)."
+    elif [[ $RAY -eq 1 ]]; then
+        ARGS+=(-o distributed_executor_backend=ray)
+    elif [[ $NO_RAY -eq 1 ]]; then
+        ARGS+=(-o distributed_executor_backend=mp)
     fi
 
     # Solo defaults tensor_parallel=1 unless the user set --tp.

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -1283,6 +1283,9 @@ class EugrBuilder(BuilderPlugin):
             ssh_options=kw.get("ssh_options"),
             timeout=1800,
             quiet=True,
+            # A 30-minute container build must not outlive the launch that
+            # started it — see wrap_with_session_guard.
+            session_guard=True,
         )
 
         # Persist captured output to the local log file (best-effort)

--- a/src/sparkrun/builders/eugr.py
+++ b/src/sparkrun/builders/eugr.py
@@ -32,21 +32,39 @@ EUGR_BUILD_INDEX_CACHE_NAME = "eugr-vllm-build-index.json"
 # GHCR image names for standard eugr nightly variants
 GHCR_EUGR_NIGHTLY = "ghcr.io/spark-arena/dgx-vllm-eugr-nightly"
 GHCR_EUGR_NIGHTLY_TF5 = "ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5"
+GHCR_EUGR_NIGHTLY_B12X = "ghcr.io/spark-arena/dgx-vllm-eugr-nightly-b12x"
 
 DOCKER_EUGR_NIGHTLY_SHORT = "eugr/spark-vllm:latest"
 DOCKER_EUGR_NIGHTLY = f"docker.io/{DOCKER_EUGR_NIGHTLY_SHORT}"
 
+# build-and-copy.sh's PREBUILT_B12X_RUNNER_IMAGE — the prebuilt image the b12x
+# preset pulls upstream. Our GHCR nightly-b12x is the sparkrun-side equivalent.
+DOCKER_EUGR_B12X_SHORT = "eugr/spark-vllm-b12x:latest"
+DOCKER_EUGR_B12X = f"docker.io/{DOCKER_EUGR_B12X_SHORT}"
+
 # GHCR package paths (without registry prefix) for API calls
 GHCR_EUGR_PKG = "spark-arena/dgx-vllm-eugr-nightly"
 GHCR_EUGR_PKG_TF5 = "spark-arena/dgx-vllm-eugr-nightly-tf5"
+GHCR_EUGR_PKG_B12X = "spark-arena/dgx-vllm-eugr-nightly-b12x"
 
-# Local image names produced by prepare_image() for nightly builds
+# ``variant`` values used by build-index.json entries, keyed by GHCR image; an
+# image not listed here is the plain "nightly" variant.
+_BUILD_INDEX_VARIANTS = {
+    GHCR_EUGR_NIGHTLY_TF5: "nightly-tf5",
+    GHCR_EUGR_NIGHTLY_B12X: "nightly-b12x",
+}
+
+# Local image names produced by prepare_image() for nightly builds. b12x keeps its
+# own tag (as upstream's default ``vllm-node-b12x`` does) so a b12x source build
+# can't overwrite the standard nightly's local image.
 LOCAL_EUGR_NIGHTLY = "sparkrun-eugr-vllm"
 LOCAL_EUGR_NIGHTLY_TF5 = "sparkrun-eugr-vllm-tf5"
+LOCAL_EUGR_NIGHTLY_B12X = "sparkrun-eugr-vllm-b12x"
 
 # Fully-qualified ":latest" refs for the GHCR nightly variants.
 GHCR_EUGR_NIGHTLY_LATEST = GHCR_EUGR_NIGHTLY + ":latest"
 GHCR_EUGR_NIGHTLY_TF5_LATEST = GHCR_EUGR_NIGHTLY_TF5 + ":latest"
+GHCR_EUGR_NIGHTLY_B12X_LATEST = GHCR_EUGR_NIGHTLY_B12X + ":latest"
 
 # ":latest" image refs recognized as eugr nightly sentinels. Following eugr's
 # pull-first switch, sparkrun PULLS our authoritative GHCR nightly
@@ -64,15 +82,32 @@ EUGR_NIGHTLY_LATEST_SENTINELS = (
     DOCKER_EUGR_NIGHTLY,
 )
 
+# The b12x peers of the above: a recipe naming the b12x prebuilt image is asking
+# for the b12x variant just as ``--exp-b12x`` in build_args does, so the image
+# itself selects the variant and resolves to OUR b12x nightly.
+EUGR_B12X_LATEST_SENTINELS = (
+    GHCR_EUGR_NIGHTLY_B12X_LATEST,
+    DOCKER_EUGR_B12X_SHORT,
+    DOCKER_EUGR_B12X,
+)
+
 USE_WHEELS_BUILD_ARG = "--use-wheels"
+
+# build-and-copy.sh's b12x preset selector. Upstream it swaps in the b12x vLLM
+# fork/ref and Torch family and points PREBUILT_RUNNER_IMAGE at the b12x prebuilt
+# image; it does NOT set CUSTOM_BUILD_REQUESTED, so on its own the script still
+# pulls. sparkrun mirrors that: the flag selects the b12x variant on both the pull
+# and build paths and is forwarded verbatim like every other script flag.
+B12X_BUILD_ARGS = frozenset({"--exp-b12x", "--experimental-b12x"})
 
 # build_args that do NOT trigger a build. These mirror the flags that leave
 # build-and-copy.sh's CUSTOM_BUILD_REQUESTED false, so the script still pulls the
-# prebuilt runner. Only the deprecated ``--tf5`` family qualifies — every other
-# flag (``--use-wheels``, ``--rebuild-vllm``, ``--rebuild-flashinfer``,
-# ``--vllm-ref``, ``--exp-mxfp4``, ``--force-*-download``, ``--apply-*-pr`` …)
-# requests a wheels/custom build and is forwarded verbatim to the script.
-_PULL_COMPATIBLE_BUILD_ARGS = frozenset({"--tf5", "--pre-tf", "--pre-transformers"})
+# prebuilt runner: the deprecated ``--tf5`` family and the ``--exp-b12x`` preset
+# (which only picks *which* prebuilt image is pulled). Every other flag
+# (``--use-wheels``, ``--rebuild-vllm``, ``--rebuild-flashinfer``, ``--vllm-ref``,
+# ``--exp-mxfp4``, ``--force-*-download``, ``--apply-*-pr`` …) requests a
+# wheels/custom build.
+_PULL_COMPATIBLE_BUILD_ARGS = frozenset({"--tf5", "--pre-tf", "--pre-transformers"}) | B12X_BUILD_ARGS
 
 
 def _wants_build(build_args: list[str]) -> bool:
@@ -84,6 +119,11 @@ def _wants_build(build_args: list[str]) -> bool:
     fine — the presence of the flag itself already forces the build.
     """
     return any(a not in _PULL_COMPATIBLE_BUILD_ARGS for a in build_args)
+
+
+def _wants_b12x(build_args: list[str]) -> bool:
+    """Return True when *build_args* select build-and-copy.sh's b12x preset."""
+    return any(a in B12X_BUILD_ARGS for a in build_args)
 
 
 # Build cache file name (stored under cache_dir)
@@ -106,7 +146,8 @@ _CACHEABLE_BUILD_ARGS: list[list[str]] = [[], ["--tf5"], [USE_WHEELS_BUILD_ARG]]
 
 # Flags dropped when computing a build's cache identity: ``--cleanup`` is
 # unconditional hygiene and ``--tf5`` is a deprecated no-op (the tag it would set
-# is always overridden by ``-t``), so neither changes the produced image.
+# is always overridden by ``-t``), so neither changes the produced image. The b12x
+# selector is NOT dropped — it changes the vLLM fork the image is built from.
 _CACHE_IGNORED_BUILD_ARGS = frozenset({"--cleanup", "--tf5"})
 
 
@@ -397,6 +438,16 @@ class EugrBuilder(BuilderPlugin):
         # built via `build-and-copy.sh` the legacy way.
         wants_build = _wants_build(build_args)
 
+        # `--exp-b12x` / `--experimental-b12x` selects build-and-copy.sh's b12x
+        # preset. It doesn't set CUSTOM_BUILD_REQUESTED upstream (so it pulls on its
+        # own — see `_PULL_COMPATIBLE_BUILD_ARGS`), and it swaps the *variant* on
+        # both paths: our b12x nightly when pulling, the b12x local tag when a
+        # custom build flag alongside it does request a build. Naming the b12x
+        # prebuilt image selects the variant just as the flag does.
+        wants_b12x = _wants_b12x(build_args) or image.strip() in EUGR_B12X_LATEST_SENTINELS
+        nightly_latest = GHCR_EUGR_NIGHTLY_B12X_LATEST if wants_b12x else GHCR_EUGR_NIGHTLY_LATEST
+        local_nightly = LOCAL_EUGR_NIGHTLY_B12X if wants_b12x else LOCAL_EUGR_NIGHTLY
+
         def _image_present(img: str) -> bool:
             if delegated:
                 return self._image_exists_on_host(img, head, ssh_kwargs)
@@ -406,18 +457,19 @@ class EugrBuilder(BuilderPlugin):
 
         # Recognized nightly ":latest" sentinels map to our canonical names — the
         # sparkrun-prefixed local tag when building, our GHCR nightly when pulling.
-        # tf5 and non-tf5 nightlies are identical now, so both map the same way.
-        if use_sentinel_image and image.strip() in EUGR_NIGHTLY_LATEST_SENTINELS:
+        # tf5 and non-tf5 nightlies are identical now, so both map the same way;
+        # b12x keeps its own pair of names.
+        if use_sentinel_image and image.strip() in EUGR_NIGHTLY_LATEST_SENTINELS + EUGR_B12X_LATEST_SENTINELS:
             if wants_build:
-                logger.info("Mapped eugr nightly image '%s' to local build '%s'", image.strip(), LOCAL_EUGR_NIGHTLY)
-                image = LOCAL_EUGR_NIGHTLY
+                logger.info("Mapped eugr nightly image '%s' to local build '%s'", image.strip(), local_nightly)
+                image = local_nightly
             else:
                 logger.info(
                     "Mapped eugr nightly image '%s' to pullable '%s' (add --use-wheels to build_args to build from wheels)",
                     image.strip(),
-                    GHCR_EUGR_NIGHTLY_LATEST,
+                    nightly_latest,
                 )
-                image = GHCR_EUGR_NIGHTLY_LATEST
+                image = nightly_latest
 
         is_pullable = any(image.startswith(prefix) for prefix in PULLABLE_REGISTRY_PREFIXES)
 
@@ -454,9 +506,9 @@ class EugrBuilder(BuilderPlugin):
                 logger.info(
                     "image '%s' not available; substituting our nightly '%s' (add --use-wheels to build_args to build from wheels)",
                     image,
-                    GHCR_EUGR_NIGHTLY_LATEST,
+                    nightly_latest,
                 )
-                image = GHCR_EUGR_NIGHTLY_LATEST
+                image = nightly_latest
                 if force_rebuild:
                     self._force_pull_image(image, head if delegated else None, ssh_kwargs if delegated else None, dry_run=dry_run)
             needs_build = False
@@ -492,10 +544,11 @@ class EugrBuilder(BuilderPlugin):
 
         # Build image if needed
         if needs_build:
-            # Forward the recipe's build_args verbatim (so `--use-wheels` actually
-            # reaches build-and-copy.sh) plus the `--cleanup` hygiene flag. The cache
-            # identity uses the normalized args (`_cache_build_args`) so `--cleanup`
-            # and the deprecated `--tf5` don't cause spurious cache misses.
+            # Forward the recipe's build_args verbatim (so `--use-wheels` and
+            # `--exp-b12x` actually reach build-and-copy.sh) plus the `--cleanup`
+            # hygiene flag. The cache identity uses the normalized args
+            # (`_cache_build_args`) so `--cleanup` and the deprecated `--tf5` don't
+            # cause spurious cache misses.
             effective_build_args = list(build_args)
             if "--cleanup" not in effective_build_args:
                 effective_build_args.append("--cleanup")
@@ -634,6 +687,19 @@ class EugrBuilder(BuilderPlugin):
         """
         build_args = recipe.runtime_config.get("build_args", [])
 
+        # Match by local image name or GHCR :latest reference
+        img_stripped = container_image.split(":")[0].strip()
+
+        # b12x is a preset variant, identified by the selector or by the image name
+        # it resolved to. Like the standard variants it is only resolvable while no
+        # *other* custom build flag is in play (the b12x selectors alone leave
+        # `_wants_build` False, mirroring the script's CUSTOM_BUILD_REQUESTED).
+        if _wants_b12x(build_args) or img_stripped in (LOCAL_EUGR_NIGHTLY_B12X, GHCR_EUGR_NIGHTLY_B12X):
+            if _wants_build(build_args):
+                logger.debug("Custom build_args %r — skipping long-term resolution", build_args)
+                return None, None
+            return GHCR_EUGR_NIGHTLY_B12X, GHCR_EUGR_PKG_B12X
+
         # Only resolve standard variants
         is_tf5 = build_args == ["--tf5"] or ("-tf5" in container_image)
         is_plain = not build_args
@@ -641,9 +707,6 @@ class EugrBuilder(BuilderPlugin):
         if not (is_tf5 or is_plain):
             logger.debug("Custom build_args %r — skipping long-term resolution", build_args)
             return None, None
-
-        # Match by local image name or GHCR :latest reference
-        img_stripped = container_image.split(":")[0].strip()
 
         if is_tf5 or img_stripped in (LOCAL_EUGR_NIGHTLY_TF5, GHCR_EUGR_NIGHTLY_TF5):
             return GHCR_EUGR_NIGHTLY_TF5, GHCR_EUGR_PKG_TF5
@@ -665,7 +728,7 @@ class EugrBuilder(BuilderPlugin):
         from sparkrun.builders._ghcr import fetch_build_index
 
         # Determine variant suffix for filtering index entries
-        variant = "nightly-tf5" if ghcr_image == GHCR_EUGR_NIGHTLY_TF5 else "nightly"
+        variant = _BUILD_INDEX_VARIANTS.get(ghcr_image, "nightly")
 
         # Resolve cache dir for index caching
         cache_dir = None

--- a/src/sparkrun/cli/__init__.py
+++ b/src/sparkrun/cli/__init__.py
@@ -13,6 +13,7 @@ from ._common import (
     RUNTIME_NAME,
     _setup_logging,
     _get_context,
+    install_termination_handlers,
     dry_run_option,
     host_options,
     json_option,
@@ -65,6 +66,10 @@ def main(ctx, verbose, quiet):
         verbose = -1  # sentinel: WARNING+ only
     ctx.obj["verbose"] = verbose
     _setup_logging(verbose)
+    # SIGTERM/SIGHUP unwind like Ctrl-C so a killed launch tears down its ssh
+    # children (and, through them, the remote session guard) instead of
+    # orphaning multi-GB work on the cluster.
+    install_termination_handlers()
 
 
 # Register command groups and commands

--- a/src/sparkrun/cli/_common.py
+++ b/src/sparkrun/cli/_common.py
@@ -91,6 +91,62 @@ def _get_context(ctx, config_path=None) -> "SparkrunContext":
     return sctx
 
 
+def _terminate_as_interrupt(signum, _frame):
+    """Turn a termination signal into :class:`KeyboardInterrupt`.
+
+    See :func:`install_termination_handlers` for why.
+    """
+    logger.debug("Received signal %s — unwinding as KeyboardInterrupt", signum)
+    raise KeyboardInterrupt
+
+
+def install_termination_handlers() -> list[int]:
+    """Make ``SIGTERM`` / ``SIGHUP`` unwind like Ctrl-C.
+
+    Two things follow from raising :class:`KeyboardInterrupt` instead of dying
+    where the default handler would:
+
+    - **Remote work is torn down.** ``subprocess.run`` kills its child from the
+      bare ``except`` in its cleanup path, so the ``ssh`` client dies, sshd
+      exits, and the remote session guard
+      (:func:`~sparkrun.orchestration.ssh.wrap_with_session_guard`) fires.
+      Without this, ``kill <sparkrun-pid>`` leaves the ``ssh`` client running
+      as a local orphan, the session stays healthy, and the guard correctly
+      never fires — the remote download keeps going.
+    - **Existing cleanup runs.** ``KeyboardInterrupt`` is already the signal
+      every state-preserving path in the codebase handles (``api._run``,
+      ``api._benchmark``, the benchmark scheduler), so ``SIGTERM`` now gets the
+      same treatment Ctrl-C has always had.
+
+    ``SIGKILL`` is unreachable by definition; a launch killed with ``-9`` can
+    still orphan the *streaming* distribution path, whose ``ssh`` stdout is an
+    inherited terminal rather than a pipe back to us.
+
+    Best-effort: signal handlers can only be installed from the main thread, so
+    a non-main-thread caller (embedded use, a test runner) is a silent no-op.
+    An already-customised handler is left alone rather than clobbered.
+
+    Returns:
+        The signal numbers for which a handler was installed.
+    """
+    import signal
+
+    installed: list[int] = []
+    candidates = [getattr(signal, name, None) for name in ("SIGTERM", "SIGHUP")]
+    for sig in candidates:
+        if sig is None:  # e.g. SIGHUP on Windows
+            continue
+        try:
+            if signal.getsignal(sig) is not signal.SIG_DFL:
+                continue  # someone else owns it — don't clobber
+            signal.signal(sig, _terminate_as_interrupt)
+        except (ValueError, OSError, RuntimeError):
+            # Not the main thread, or the platform refuses this signal.
+            continue
+        installed.append(int(sig))
+    return installed
+
+
 def _setup_logging(verbose: int | bool):
     """Configure logging based on verbosity.
 

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -13,10 +13,10 @@ from typing import Any, TYPE_CHECKING, Optional
 import yaml
 
 from vpd.next.util import read_yaml
-from vpd.legacy.arguments import arg_substitute
 from scitrera_app_framework.api import Variables, EnvPlacement
 
 from sparkrun.core.layout import RecipeLayout
+from sparkrun.utils.text import mask_non_placeholder_braces, render_template, unmask_braces
 
 if TYPE_CHECKING:
     from sparkrun.core.registry import RegistryManager
@@ -29,14 +29,6 @@ logger = logging.getLogger(__name__)
 # an escaped space — a common YAML editing mistake that silently breaks
 # multi-line commands.
 _TRAILING_SPACE_CONTINUATION_RE = re.compile(r"\\ +\n")
-
-# v1 brace-escape masking (see _mask_brace_escapes).  The sentinels are control
-# characters YAML 1.2 forbids in scalar content, so they cannot collide with
-# anything a recipe or an override value can legitimately carry.
-_LBRACE_SENTINEL = "\x00"
-_RBRACE_SENTINEL = "\x01"
-_LBRACE_RUN_RE = re.compile(r"\{+")
-_RBRACE_RUN_RE = re.compile(r"\}+")
 
 _RAY_BACKEND_RE = re.compile(r"--distributed-executor-backend\s+ray\b")
 _CMD_VLLM_RE = re.compile(r"^vllm\s+serve\b")
@@ -204,11 +196,11 @@ class DistributionConfig:
 
         for entry in self.models.entries:
             if isinstance(entry, DistributionModelEntry):
-                entry.name = arg_substitute(entry.name, config_chain)
+                entry.name = render_template(entry.name, config_chain)
 
         for entry in self.containers.entries:
             if isinstance(entry, DistributionContainerEntry):
-                entry.name = arg_substitute(entry.name, config_chain)
+                entry.name = render_template(entry.name, config_chain)
 
         return self
 
@@ -361,39 +353,18 @@ def _collapse_brace_escapes(value: str) -> str:
 
 
 def _mask_brace_escapes(value: str) -> str:
-    """Replace v1 ``{{``/``}}`` escapes with sentinels so substitution can't see them.
+    """Hide v1 ``{{``/``}}`` escapes (and other literal braces) from substitution.
 
-    Collapsing escapes *after* substitution is not enough: vpd's placeholder
-    regex is ``\\{(.*?)\\}``, so the leading brace of a ``{{`` escape opens a
-    match that runs to the first ``}`` — swallowing any placeholder nested
-    inside the escaped span.  ``'{{"n":{tokens}}}'`` therefore matches as one
-    bogus key and ``{tokens}`` is never substituted.  Masking first leaves the
-    escaped braces invisible to the regex, so only real placeholders match.
-
-    Brace runs are paired from the side away from the placeholder name, which
-    is what disambiguates an odd-length run:
-
-    - ``{`` runs pair left-to-right, so ``{{{k}`` is a literal ``{`` followed
-      by the placeholder ``{k}``.
-    - ``}`` runs pair right-to-left, so ``{k}}}`` is the placeholder ``{k}``
-      followed by a literal ``}`` (the DeepSeek ``--speculative-config`` shape,
-      where a placeholder ends a JSON object).
+    Thin wrapper over :func:`sparkrun.utils.text.mask_non_placeholder_braces`,
+    which is shared with lifecycle-hook rendering so both paths treat braces
+    identically.  See that function for the scan rules.
     """
-
-    def _mask_open(m: re.Match) -> str:
-        pairs, odd = divmod(len(m.group()), 2)
-        return _LBRACE_SENTINEL * pairs + "{" * odd
-
-    def _mask_close(m: re.Match) -> str:
-        pairs, odd = divmod(len(m.group()), 2)
-        return "}" * odd + _RBRACE_SENTINEL * pairs
-
-    return _RBRACE_RUN_RE.sub(_mask_close, _LBRACE_RUN_RE.sub(_mask_open, value))
+    return mask_non_placeholder_braces(value, escapes=True)
 
 
 def _unmask_brace_escapes(value: str) -> str:
-    """Restore :func:`_mask_brace_escapes` sentinels as single literal braces."""
-    return value.replace(_LBRACE_SENTINEL, "{").replace(_RBRACE_SENTINEL, "}")
+    """Restore :func:`_mask_brace_escapes` sentinels as literal braces."""
+    return unmask_braces(value)
 
 
 def _resolve_v1_migration(recipe: Recipe) -> None:
@@ -1057,26 +1028,14 @@ class Recipe:
 
         rendered = self.command.strip()
 
-        # v1 (eugr) recipes escape literal braces as '{{'/'}}' so they survive
-        # the {placeholder} substitution below (e.g. JSON-valued flags like
-        # --diffusion-config '{{...}}').  Mask them to sentinels *first* so the
-        # escaped braces are invisible to vpd's placeholder regex — otherwise
-        # an escaped span swallows any placeholder nested inside it — then
-        # restore them as single literal braces once substitution is done, so
-        # the runtime receives valid JSON rather than doubled braces.
-        escaped = self.recipe_version == "1"
-        if escaped:
-            rendered = _mask_brace_escapes(rendered)
-
-        # Use vpd arg_substitute for {placeholder} replacement
-        # Iterate to handle nested substitutions
-        last = None
-        while last != rendered:
-            last = rendered
-            rendered = arg_substitute(rendered, config_chain)
-
-        if escaped:
-            rendered = _unmask_brace_escapes(rendered)
+        # Literal braces are masked to sentinels *first* so they are invisible
+        # to vpd's placeholder regex — otherwise a JSON-valued flag swallows any
+        # placeholder nested inside it — then restored once substitution is
+        # done, so the runtime receives valid JSON.  v1 (eugr) recipes write
+        # their literal braces doubled ('{{'/'}}') and those collapse to one
+        # brace on restore; v2 recipes write JSON with plain braces and get them
+        # back unchanged.  Substitution iterates to resolve nested references.
+        rendered = render_template(rendered, config_chain, escapes=self.recipe_version == "1")
 
         # Fix trailing spaces after backslash line-continuations.
         # ``\<space><newline>`` → ``\<newline>``

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -16,7 +16,7 @@ from vpd.next.util import read_yaml
 from scitrera_app_framework.api import Variables, EnvPlacement
 
 from sparkrun.core.layout import RecipeLayout
-from sparkrun.utils.text import mask_non_placeholder_braces, render_template, unmask_braces
+from sparkrun.utils.text import mask_non_placeholder_braces, render_template, unmask_braces, uses_brace_escapes
 
 if TYPE_CHECKING:
     from sparkrun.core.registry import RegistryManager
@@ -339,21 +339,28 @@ def _resolve_runtime_from_command_hint(recipe: Recipe) -> None:
 def _collapse_brace_escapes(value: str) -> str:
     """Collapse vpd-style brace escapes (``{{`` -> ``{``, ``}}`` -> ``}``).
 
-    v1 (eugr) recipes double their braces so a literal ``{`` survives vpd
+    Recipes double their braces so a literal ``{`` survives vpd
     ``{placeholder}`` substitution — e.g. a JSON-valued flag written as
     ``--diffusion-config '{{"canvas_length": 256}}'``.  Once substitution has
     run, the doubled braces are collapsed back to single braces, matching
     eugr's own ``run-recipe.sh``.
 
+    A value not written in that convention is returned untouched.  Collapsing
+    unconditionally would rewrite the ``}}`` that merely closes nested plain
+    JSON (``{"a":{"b":1}}``), dropping a brace from a value that was already
+    correct.
+
     Used for *values* (recipe defaults), which are never placeholder templates
     themselves.  Command templates go through :func:`_mask_brace_escapes` /
     :func:`_unmask_brace_escapes` instead, which survive substitution.
     """
+    if not uses_brace_escapes(value):
+        return value
     return value.replace("{{", "{").replace("}}", "}")
 
 
 def _mask_brace_escapes(value: str) -> str:
-    """Hide v1 ``{{``/``}}`` escapes (and other literal braces) from substitution.
+    """Hide ``{{``/``}}`` escapes (and other literal braces) from substitution.
 
     Thin wrapper over :func:`sparkrun.utils.text.mask_non_placeholder_braces`,
     which is shared with lifecycle-hook rendering so both paths treat braces
@@ -374,11 +381,34 @@ def _resolve_v1_migration(recipe: Recipe) -> None:
     if recipe.runtime in ("vllm", ""):
         if not recipe.builder:
             recipe.builder = "eugr"
-        # v1 recipes may escape literal braces as '{{'/'}}' in defaults values
-        # (e.g. a JSON-valued flag default).  Collapse them for string values
-        # only; non-string defaults (numeric port, max_num_seqs,
-        # gpu_memory_utilization, ...) are passed through untouched.
-        recipe.defaults = {k: (_collapse_brace_escapes(v) if isinstance(v, str) else v) for k, v in recipe.defaults.items()}
+
+
+def _resolve_brace_escapes(recipe: Recipe) -> None:
+    """Collapse ``{{``/``}}`` escapes in defaults values, for every recipe version.
+
+    A recipe may escape literal braces in a *value* as well as in the command
+    template (e.g. a JSON-valued flag supplied as a default).  Collapse them
+    for string values only; non-string defaults (numeric port, max_num_seqs,
+    gpu_memory_utilization, ...) are passed through untouched — the regression
+    behind the ``'int' object has no attribute 'replace'`` crash in issue #213.
+
+    Gated on the *value* rather than on ``recipe_version``, matching
+    :meth:`Recipe.render_command`.  This previously lived inside
+    ``_resolve_v1_migration``, so it reached only v1 recipes whose runtime was
+    vllm — a v2 (or v1 sglang) recipe leaked ``{{...}}`` into the rendered
+    command, one layer below the same bug the command template had.
+    """
+    escaped = sorted(k for k, v in recipe.defaults.items() if isinstance(v, str) and uses_brace_escapes(v))
+    if escaped and recipe.recipe_version != "1":
+        logger.warning(
+            "Recipe '%s' declares recipe_version '%s' but these defaults use the v1 doubled-brace escape "
+            "('{{' / '}}'): %s. Write literal braces plainly instead. The escape is honored for now but will not "
+            "be supported by v3 recipes.",
+            recipe.name,
+            recipe.recipe_version,
+            ", ".join(escaped),
+        )
+    recipe.defaults = {k: (_collapse_brace_escapes(v) if isinstance(v, str) else v) for k, v in recipe.defaults.items()}
 
 
 def _resolve_eugr_signals(recipe: Recipe) -> None:
@@ -415,6 +445,7 @@ def _resolve_vllm_variant(recipe: Recipe) -> None:
 _RECIPE_RESOLVERS = [
     _resolve_runtime_from_command_hint,
     _resolve_v1_migration,
+    _resolve_brace_escapes,
     _resolve_eugr_signals,
     _resolve_vllm_variant,
 ]
@@ -1031,11 +1062,33 @@ class Recipe:
         # Literal braces are masked to sentinels *first* so they are invisible
         # to vpd's placeholder regex — otherwise a JSON-valued flag swallows any
         # placeholder nested inside it — then restored once substitution is
-        # done, so the runtime receives valid JSON.  v1 (eugr) recipes write
-        # their literal braces doubled ('{{'/'}}') and those collapse to one
-        # brace on restore; v2 recipes write JSON with plain braces and get them
-        # back unchanged.  Substitution iterates to resolve nested references.
-        rendered = render_template(rendered, config_chain, escapes=self.recipe_version == "1")
+        # done, so the runtime receives valid JSON.  Substitution iterates to
+        # resolve nested references.
+        #
+        # Escape mode is read off the *template*, not the recipe version.  It
+        # used to be `recipe_version == "1"`, so a v1 command pasted into a v2
+        # recipe emitted literal '{{...}}' to the runtime — a launch that dies
+        # on the serve command after the model has downloaded, with an error
+        # naming neither sparkrun nor the recipe.  Forcing escapes on for every
+        # version is *not* the fix: '}}' closes nested plain JSON
+        # ('{"a":{"b":1}}') as often as it escapes one brace, so it would
+        # silently eat a closing brace from the idiomatic v2 spelling.  '{{' is
+        # the disambiguator (see utils.text.uses_brace_escapes).
+        escapes = uses_brace_escapes(rendered)
+        if escapes and self.recipe_version != "1":
+            logger.warning(
+                "Recipe '%s' declares recipe_version '%s' but its command template uses the doubled-brace escape "
+                "('{{' / '}}'), which is the v1 convention — usually a command pasted from a v1 recipe. Write literal "
+                "braces plainly instead ('--flag '%s''); a placeholder nested inside JSON still resolves. The escape "
+                "is honored for now but will not be supported by v3 recipes.",
+                self.name,
+                self.recipe_version,
+                '{"key": "value"}',
+            )
+
+        # Hook templates deliberately stay unescaped (see
+        # sparkrun.orchestration.hooks.render_hook_command).
+        rendered = render_template(rendered, config_chain, escapes=escapes)
 
         # Fix trailing spaces after backslash line-continuations.
         # ``\<space><newline>`` → ``\<newline>``

--- a/src/sparkrun/orchestration/distribution.py
+++ b/src/sparkrun/orchestration/distribution.py
@@ -150,6 +150,11 @@ def _distribute_from_head(
     transfer counts) is visible in real time at INFO+ verbosity.  At default
     verbosity the output is captured silently and surfaced on failure.
 
+    Both are also run under the session guard
+    (:func:`~sparkrun.orchestration.ssh.wrap_with_session_guard`): these are the
+    long, expensive remote payloads, and a launch killed on the control node
+    must not leave a download or an rsync fan-out running on the head.
+
     Args:
         head: Head hostname (``hosts[0]``).
         hosts: Full cluster host list (head + workers).
@@ -181,6 +186,7 @@ def _distribute_from_head(
         timeout=timeout,
         dry_run=dry_run,
         quiet=_quiet,
+        session_guard=True,
     )
     if not ensure_result.success:
         logger.error("Failed to ensure %s on head %s (rc=%d)", resource_label, head, ensure_result.returncode)
@@ -207,6 +213,7 @@ def _distribute_from_head(
         timeout=timeout,
         dry_run=dry_run,
         quiet=_quiet,
+        session_guard=True,
     )
 
     if dist_result.success:

--- a/src/sparkrun/orchestration/hooks.py
+++ b/src/sparkrun/orchestration/hooks.py
@@ -12,7 +12,7 @@ import logging
 import subprocess
 from pathlib import Path
 
-from vpd.legacy.arguments import arg_substitute
+from sparkrun.utils.text import render_template
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,15 @@ def build_hook_context(
 def render_hook_command(cmd: str, context: dict[str, str]) -> str:
     """Render ``{key}`` placeholders in a hook command string.
 
-    Uses the same ``arg_substitute`` used for recipe command rendering.
+    Uses the same brace-masking renderer as recipe command rendering, so a
+    placeholder inside a JSON payload resolves here too — a hook like
+    ``curl -d '{"model":"{model}"}'`` otherwise reached the shell with a
+    literal ``{model}``, because vpd's regex matched from the opening brace
+    of the JSON object through the placeholder's closing brace and restored
+    the whole span verbatim.
+
+    Hook commands are not v1 recipe templates, so ``{{`` is left as two
+    literal braces rather than collapsed.
 
     Args:
         cmd: Command string with ``{key}`` placeholders.
@@ -89,12 +97,7 @@ def render_hook_command(cmd: str, context: dict[str, str]) -> str:
     Returns:
         Rendered command string.
     """
-    rendered = cmd
-    last = None
-    while last != rendered:
-        last = rendered
-        rendered = arg_substitute(rendered, context)
-    return rendered
+    return render_template(cmd, context)
 
 
 def render_hook_commands(

--- a/src/sparkrun/orchestration/hooks.py
+++ b/src/sparkrun/orchestration/hooks.py
@@ -87,8 +87,11 @@ def render_hook_command(cmd: str, context: dict[str, str]) -> str:
     of the JSON object through the placeholder's closing brace and restored
     the whole span verbatim.
 
-    Hook commands are not v1 recipe templates, so ``{{`` is left as two
-    literal braces rather than collapsed.
+    Unlike a recipe command, ``{{`` is left as two literal braces rather than
+    collapsed to one: a hook body is arbitrary shell, where a doubled brace is
+    plausibly meant literally (bash brace expansion, an ``awk`` program), and
+    nothing here needs the escape — a JSON payload can be written with plain
+    braces because the mask already keeps it away from vpd's regex.
 
     Args:
         cmd: Command string with ``{key}`` placeholders.

--- a/src/sparkrun/orchestration/primitives.py
+++ b/src/sparkrun/orchestration/primitives.py
@@ -175,6 +175,11 @@ def sync_resource_to_hosts(
 ) -> list[str]:
     """Run a sync script on all hosts in parallel and return failures.
 
+    The script runs under the session guard
+    (:func:`~sparkrun.orchestration.ssh.wrap_with_session_guard`): every caller
+    here is a model download or image pull, which must not keep running on the
+    hosts after the launch that started it was killed.
+
     Args:
         script: Pre-formatted bash script to execute on each host.
         hosts: Target hostnames or IPs.
@@ -192,6 +197,7 @@ def sync_resource_to_hosts(
         ssh_user=ssh_user,
         ssh_key=ssh_key,
         dry_run=dry_run,
+        session_guard=True,
     )
 
     failed = [r.host for r in results if not r.success]

--- a/src/sparkrun/orchestration/ssh.py
+++ b/src/sparkrun/orchestration/ssh.py
@@ -44,6 +44,66 @@ DEFAULT_MAX_PARALLEL_SSH = 20
 HEAD_DISTRIBUTE_MAX_PARALLEL = 4
 
 
+# Env kill-switch for the remote session guard (see
+# :func:`wrap_with_session_guard`).  The guard relies on ``ps`` and on sshd
+# exiting when the client goes away; set this to opt out on a host where that
+# doesn't hold, at the cost of orphaned work on a killed launch.
+NO_SESSION_GUARD_ENV = "SPARKRUN_NO_SESSION_GUARD"
+
+# Sentinel line in ``scripts/session_guard.sh`` replaced by the payload.
+_GUARD_PAYLOAD_SENTINEL = "__SPARKRUN_PAYLOAD__"
+
+
+def session_guard_disabled() -> bool:
+    """True when the session guard is switched off via the environment."""
+    return os.environ.get(NO_SESSION_GUARD_ENV, "").strip().lower() not in ("", "0", "false", "no")
+
+
+def wrap_with_session_guard(script: str) -> str:
+    """Wrap *script* so it dies with its SSH session.
+
+    Remote payloads run via ``ssh <host> bash -s``, i.e. **without a PTY**.  On
+    disconnect sshd's session process exits without signalling its child (the
+    SIGHUP-on-disconnect path is PTY-only), so a killed ``sparkrun`` on the
+    control node leaves the payload running on the remote host — invisible from
+    the control node, holding HF cache locks, consuming WAN, and stacking across
+    kill-and-retry cycles.
+
+    The wrapper backgrounds *script* in its own process group and polls its own
+    parent PID; when the session dies the shell is reparented (to init/systemd)
+    and the payload's whole process group is TERMed, then KILLed.  It is
+    transparent otherwise: stdout, stderr and the exit code pass through
+    unchanged.
+
+    Opt-in per call site (see the ``session_guard`` argument on
+    :func:`run_remote_script` and friends) — it is meant for long-running,
+    resource-consuming work (model downloads, image pulls, head→worker
+    fan-outs), not for short status probes where an orphan is harmless.
+
+    Returns *script* unchanged when :data:`NO_SESSION_GUARD_ENV` is set.
+    """
+    if session_guard_disabled():
+        logger.debug("Session guard disabled via %s", NO_SESSION_GUARD_ENV)
+        return script
+
+    from sparkrun.scripts import read_script
+
+    guard = read_script("session_guard.sh")
+    # Splice on the sentinel *line*, not a substring: the guard's own header
+    # comment names the token, and a substring replace would splice the payload
+    # into that comment instead.
+    lines = guard.splitlines()
+    try:
+        at = next(i for i, line in enumerate(lines) if line.strip() == _GUARD_PAYLOAD_SENTINEL)
+    except StopIteration:  # pragma: no cover — would mean a corrupt install
+        logger.error("session_guard.sh is missing its payload sentinel; running unguarded")
+        return script
+    # The payload is spliced in verbatim; the explicit newline keeps a payload
+    # without a trailing one from running into the subshell's closing paren.
+    lines[at : at + 1] = (script.rstrip("\n") + "\n").splitlines()
+    return "\n".join(lines) + "\n"
+
+
 def resolve_parallel_cap(n: int, cap: int | None = None) -> int:
     """Return the worker count for a fan-out over *n* items.
 
@@ -269,6 +329,7 @@ def run_remote_script(
     dry_run: bool = False,
     quiet: bool = False,
     allow_local: bool = False,
+    session_guard: bool = False,
 ) -> RemoteResult:
     """Execute a script on a remote host via stdin piping.
 
@@ -288,6 +349,10 @@ def run_remote_script(
         allow_local: Run the script directly (no SSH) when *host* is this
             machine — see :func:`run_remote_scripts_parallel` for why this
             is opt-in.
+        session_guard: Wrap the script so it dies with its SSH session — see
+            :func:`wrap_with_session_guard`.  Opt-in, for long-running work
+            that must not be orphaned by a killed launch.  Ignored on the
+            local-dispatch path, which has no SSH session to lose.
 
     Returns:
         RemoteResult with returncode, stdout, stderr.
@@ -300,6 +365,10 @@ def run_remote_script(
     if allow_local and should_run_locally(host, ssh_user):
         logger.debug("  Dispatching locally (no SSH) for: %s", host)
         return replace(run_local_script(script, timeout=timeout), host=host)
+
+    if session_guard:
+        script = wrap_with_session_guard(script)
+        script_lines = script.count("\n")
 
     cmd = build_ssh_cmd(host, ssh_user, ssh_key, ssh_options, connect_timeout)
     cmd.extend(["bash", "-s"])
@@ -330,6 +399,7 @@ def run_remote_script_streaming(
     timeout: int | None = None,
     dry_run: bool = False,
     quiet: bool = False,
+    session_guard: bool = False,
 ) -> RemoteResult:
     """Execute a script on a remote host with real-time stdout/stderr.
 
@@ -351,6 +421,8 @@ def run_remote_script_streaming(
         timeout: Overall execution timeout in seconds.
         dry_run: If True, log the script but don't execute.
         quiet: If True, capture output instead of streaming to terminal.
+        session_guard: Wrap the script so it dies with its SSH session — see
+            :func:`wrap_with_session_guard`.
 
     Returns:
         RemoteResult with returncode (stdout/stderr are empty when
@@ -359,6 +431,9 @@ def run_remote_script_streaming(
     if dry_run:
         logger.info("[dry-run] Would execute (streaming) on %s (%d bytes)", host, len(script))
         return RemoteResult(host=host, returncode=0, stdout="[dry-run]", stderr="")
+
+    if session_guard:
+        script = wrap_with_session_guard(script)
 
     cmd = build_ssh_cmd(host, ssh_user, ssh_key, ssh_options, connect_timeout)
     cmd.extend(["bash", "-s"])
@@ -660,6 +735,7 @@ def run_remote_scripts_parallel(
     quiet: bool = False,
     max_workers: int | None = None,
     allow_local: bool = False,
+    session_guard: bool = False,
 ) -> list[RemoteResult]:
     """Execute the same script on multiple hosts in parallel using threads.
 
@@ -683,6 +759,9 @@ def run_remote_scripts_parallel(
             (status discovery, hardware probes, teardown) pass ``True``
             so they work on a host without self-SSH configured.  Results
             are re-keyed to the caller's host string either way.
+        session_guard: Wrap the script so it dies with its SSH session — see
+            :func:`wrap_with_session_guard`.  Applies to the SSH-dispatched
+            hosts only; a locally-dispatched host has no session to lose.
 
     Returns:
         List of RemoteResult, one per host (order not guaranteed).
@@ -707,6 +786,7 @@ def run_remote_scripts_parallel(
             timeout=timeout,
             dry_run=dry_run,
             quiet=quiet,
+            session_guard=session_guard,
         )
 
     t0 = time.monotonic()

--- a/src/sparkrun/scripts/session_guard.sh
+++ b/src/sparkrun/scripts/session_guard.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# sparkrun session guard — terminate this host's work if the controlling SSH
+# session goes away, so a killed `sparkrun` on the control node cannot orphan a
+# multi-GB download / image pull / rsync fan-out here.
+#
+# Remote payloads run via `ssh <host> bash -s`, i.e. WITHOUT a PTY.  On
+# disconnect sshd's session process exits but sends no signal to its child (the
+# SIGHUP-on-disconnect path is PTY-only), so the payload is merely reparented
+# and keeps running, invisible to the control node.  This wrapper detects that
+# reparenting and kills the payload's whole process group.
+#
+# NOTE: consumed via Python — the payload sentinel line below is replaced by the
+# payload script (see ``orchestration.ssh.wrap_with_session_guard``).  The
+# sentinel is matched as a whole line, and must appear exactly once, so do not
+# repeat that token anywhere else in this file (including in a comment).
+#
+# Like model_distribute.sh this file must contain NO literal curly-brace
+# characters (shell functions are therefore avoided in favor of parenthesized
+# subshells), so that it stays safe to run through Python str.format().
+
+# Parent at start: the per-session sshd.  Empty when `ps` is unavailable, in
+# which case the guard stays inert rather than guessing (see below).
+__sr_ppid0="$(ps -o ppid= -p $$ 2>/dev/null | tr -d '[:space:]')"
+
+# `set -m` gives the payload its own process group, so the group kill below
+# reaches grandchildren (e.g. uvx -> hf download).  It is turned back OFF as the
+# first statement *inside* the payload subshell: with job control still on, a
+# payload that backgrounds its own jobs (model_distribute.sh, image_distribute.sh)
+# would put each one in a separate process group where the group kill can't
+# reach them.
+set -m
+(
+set +m
+__SPARKRUN_PAYLOAD__
+) &
+__sr_job=$!
+set +m
+
+# A signal delivered to this shell (e.g. sshd relaying one) tears the payload
+# down the same way.
+trap 'kill -TERM -$__sr_job 2>/dev/null; sleep 5; kill -KILL -$__sr_job 2>/dev/null; exit 143' HUP INT TERM
+
+__sr_watch=""
+if [ -n "$__sr_ppid0" ]; then
+    # Watchdog: poll our own parent.  When the ssh client dies, sshd exits and
+    # this shell is reparented (to init/systemd), which is the disconnect
+    # signal.  The watchdog deliberately prints NOTHING on that path — stderr
+    # is the dead channel by then, and a SIGPIPE there would kill the watchdog
+    # before it kills the payload.
+    (
+        while kill -0 "$__sr_job" 2>/dev/null; do
+            sleep 2
+            __sr_now="$(ps -o ppid= -p $$ 2>/dev/null | tr -d '[:space:]')"
+            if [ -n "$__sr_now" ] && [ "$__sr_now" != "$__sr_ppid0" ]; then
+                kill -TERM -$__sr_job 2>/dev/null
+                sleep 5
+                kill -KILL -$__sr_job 2>/dev/null
+                exit 0
+            fi
+        done
+    ) </dev/null >/dev/null 2>&1 &
+    __sr_watch=$!
+fi
+
+wait "$__sr_job"
+__sr_rc=$?
+if [ -n "$__sr_watch" ]; then
+    kill "$__sr_watch" 2>/dev/null
+fi
+exit "$__sr_rc"

--- a/src/sparkrun/utils/text.py
+++ b/src/sparkrun/utils/text.py
@@ -26,6 +26,21 @@ _PLACEHOLDER_SPAN_RE = re.compile(r"\{[^{}]*\}")
 _MAX_SUBSTITUTION_PASSES = 10
 
 
+def uses_brace_escapes(value: str) -> bool:
+    """Whether *value* is written in the doubled-brace escape convention.
+
+    ``{{`` is the marker, and it is a reliable one: a ``{`` immediately
+    followed by another ``{`` cannot occur in JSON (an object key must be a
+    string), so a doubled *opening* brace is only ever a deliberate escape.
+
+    A doubled *closing* brace carries no such signal — ``}}`` ends any nested
+    JSON object (``{"a":{"b":1}}``) just as often as it escapes one literal
+    brace — which is why the convention has to be read off the opening brace
+    and applied to the whole string, rather than decided per ``}}``.
+    """
+    return "{{" in value
+
+
 def mask_non_placeholder_braces(value: str, *, escapes: bool) -> str:
     """Hide every brace that is not part of a ``{key}`` placeholder.
 
@@ -37,17 +52,17 @@ def mask_non_placeholder_braces(value: str, *, escapes: bool) -> str:
 
     Scanning left to right, each position is one of:
 
-    - ``{{`` / ``}}`` — a brace escape.  With *escapes* (v1 recipes) it masks
-      to a **single** sentinel, so it restores as one literal brace; without,
-      it masks to **two**, so the doubled braces survive untouched.  Either way
-      the braces are invisible to vpd, so an escaped span can no longer eat the
-      placeholder inside it.
+    - ``{{`` / ``}}`` — a brace escape.  With *escapes* (recipe commands) it
+      masks to a **single** sentinel, so it restores as one literal brace;
+      without (hook commands), it masks to **two**, so the doubled braces
+      survive untouched.  Either way the braces are invisible to vpd, so an
+      escaped span can no longer eat the placeholder inside it.
     - ``{key}`` — a placeholder, passed through for vpd to resolve.
     - a lone ``{`` or ``}`` — literal, masked so it cannot open a bogus span.
 
     Args:
         value: Template string.
-        escapes: Treat ``{{``/``}}`` as v1 escapes that collapse to one brace.
+        escapes: Treat ``{{``/``}}`` as escapes that collapse to one brace.
 
     Returns:
         The masked string; pair with :func:`unmask_braces`.
@@ -103,7 +118,7 @@ def render_template(value: str, values: Any, *, escapes: bool = False, max_passe
         value: Template string.
         values: Anything with a one-argument ``.get(key)`` — a ``dict`` or a
             SAF ``Variables`` config chain.
-        escapes: Treat ``{{``/``}}`` as v1 escapes collapsing to one brace.
+        escapes: Treat ``{{``/``}}`` as escapes collapsing to one brace.
         max_passes: Substitution passes before giving up.
 
     Returns:

--- a/src/sparkrun/utils/text.py
+++ b/src/sparkrun/utils/text.py
@@ -2,6 +2,125 @@
 
 from __future__ import annotations
 
+import logging
+import re
+from typing import Any
+
+from vpd.legacy.arguments import arg_substitute
+
+logger = logging.getLogger(__name__)
+
+# Brace masking sentinels.  Control characters YAML 1.2 forbids in scalar
+# content, so they cannot collide with anything a recipe or an override value
+# can legitimately carry.
+_LBRACE_SENTINEL = "\x00"
+_RBRACE_SENTINEL = "\x01"
+
+# A ``{key}`` span.  ``[^{}]*`` is what makes this safe to run over JSON: a
+# brace whose span contains another brace (``{"a":{...``) cannot match, so it
+# is treated as a literal rather than as the start of a placeholder.
+_PLACEHOLDER_SPAN_RE = re.compile(r"\{[^{}]*\}")
+
+# Upper bound on substitution passes.  Legitimate nesting is a short chain
+# (``base_url`` -> ``port``); anything deeper than this is a cycle.
+_MAX_SUBSTITUTION_PASSES = 10
+
+
+def mask_non_placeholder_braces(value: str, *, escapes: bool) -> str:
+    """Hide every brace that is not part of a ``{key}`` placeholder.
+
+    vpd's placeholder regex is ``\\{(.*?)\\}``, which cannot tell a placeholder
+    from a brace that merely happens to sit in the text.  Any ``{`` opens a
+    non-greedy match that runs to the first ``}``, so a JSON-valued flag
+    swallows the placeholder nested inside it and the whole span is restored
+    verbatim.  Masking first leaves only real placeholders visible to vpd.
+
+    Scanning left to right, each position is one of:
+
+    - ``{{`` / ``}}`` — a brace escape.  With *escapes* (v1 recipes) it masks
+      to a **single** sentinel, so it restores as one literal brace; without,
+      it masks to **two**, so the doubled braces survive untouched.  Either way
+      the braces are invisible to vpd, so an escaped span can no longer eat the
+      placeholder inside it.
+    - ``{key}`` — a placeholder, passed through for vpd to resolve.
+    - a lone ``{`` or ``}`` — literal, masked so it cannot open a bogus span.
+
+    Args:
+        value: Template string.
+        escapes: Treat ``{{``/``}}`` as v1 escapes that collapse to one brace.
+
+    Returns:
+        The masked string; pair with :func:`unmask_braces`.
+    """
+    out: list[str] = []
+    i = 0
+    end = len(value)
+    while i < end:
+        ch = value[i]
+        if ch == "{":
+            if value.startswith("{{", i):
+                out.append(_LBRACE_SENTINEL if escapes else _LBRACE_SENTINEL * 2)
+                i += 2
+                continue
+            match = _PLACEHOLDER_SPAN_RE.match(value, i)
+            if match:
+                out.append(match.group())
+                i = match.end()
+                continue
+            out.append(_LBRACE_SENTINEL)
+        elif ch == "}":
+            if value.startswith("}}", i):
+                out.append(_RBRACE_SENTINEL if escapes else _RBRACE_SENTINEL * 2)
+                i += 2
+                continue
+            out.append(_RBRACE_SENTINEL)
+        else:
+            out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def unmask_braces(value: str) -> str:
+    """Restore :func:`mask_non_placeholder_braces` sentinels as literal braces."""
+    return value.replace(_LBRACE_SENTINEL, "{").replace(_RBRACE_SENTINEL, "}")
+
+
+def render_template(value: str, values: Any, *, escapes: bool = False, max_passes: int = _MAX_SUBSTITUTION_PASSES) -> str:
+    """Render ``{key}`` placeholders, iterating until the text stops changing.
+
+    Iterating is what makes nested references work — a default of
+    ``http://localhost:{port}`` needs a second pass to resolve ``{port}`` once
+    ``{base_url}`` has been pulled in.
+
+    The iteration is bounded.  An unbounded fixpoint loop never terminates for
+    a self-growing value (``a: "x{a}"`` renders ``x{a}`` -> ``xx{a}`` -> ...),
+    turning a malformed recipe into a hang with no output.  On hitting the
+    bound we log and return the last result, so the failure surfaces as a bad
+    command rather than a wedged process.  A value that resolves to itself
+    (``a: "{a}"``) is a fixpoint on the first pass and never reaches this.
+
+    Args:
+        value: Template string.
+        values: Anything with a one-argument ``.get(key)`` — a ``dict`` or a
+            SAF ``Variables`` config chain.
+        escapes: Treat ``{{``/``}}`` as v1 escapes collapsing to one brace.
+        max_passes: Substitution passes before giving up.
+
+    Returns:
+        The rendered string.
+    """
+    rendered = mask_non_placeholder_braces(value, escapes=escapes)
+    for _ in range(max_passes):
+        nxt = arg_substitute(rendered, values)
+        if nxt == rendered:
+            return unmask_braces(rendered)
+        rendered = nxt
+    logger.warning(
+        "Template did not stabilize after %d substitution passes — check for a placeholder whose value contains itself; using the last result",
+        max_passes,
+    )
+    return unmask_braces(rendered)
+
 
 def coerce_value(value: str):
     """Coerce a string value to int, float, or bool where possible."""

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -622,6 +622,153 @@ class TestEugrPrepareImage:
         assert result == "eugr/spark-vllm:latest"
 
 
+class TestEugrB12x:
+    """`--exp-b12x` / `--experimental-b12x` — build-and-copy.sh's b12x preset.
+
+    Upstream the flag swaps the vLLM fork/ref + Torch family and points
+    PREBUILT_RUNNER_IMAGE at ``eugr/spark-vllm-b12x:latest``, without setting
+    CUSTOM_BUILD_REQUESTED — so on its own it still *pulls*. sparkrun mirrors that:
+    the variant applies to both the pulled nightly and the local build tag, and the
+    flag is forwarded to the script like any other.
+    """
+
+    B12X_LATEST = "ghcr.io/spark-arena/dgx-vllm-eugr-nightly-b12x:latest"
+
+    @staticmethod
+    def _config(tmp_path):
+        config = mock.Mock()
+        config.cache_dir = tmp_path
+        config.get_defaults_builder = mock.Mock(return_value={})
+        return config
+
+    @pytest.mark.parametrize("flag", ["--exp-b12x", "--experimental-b12x"])
+    @pytest.mark.parametrize(
+        "sentinel_image",
+        [
+            "ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest",
+            "ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest",
+            "eugr/spark-vllm:latest",
+            "docker.io/eugr/spark-vllm:latest",
+        ],
+    )
+    def test_sentinel_maps_to_b12x_nightly(self, eugr_builder_with_repo, tmp_path, sentinel_image, flag):
+        """Both spellings redirect every sentinel to the b12x nightly — pulled, never built."""
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": sentinel_image,
+                "runtime_config": {"build_args": [flag]},
+            }
+        )
+
+        with mock.patch.object(builder, "ensure_repo") as mock_ensure:
+            with mock.patch("sparkrun.builders.eugr._run_build_capturing") as mock_build:
+                with mock.patch.object(builder, "_verify_image_imports") as mock_verify:
+                    result = builder.prepare_image(sentinel_image, recipe, ["10.0.0.1"], config=self._config(tmp_path))
+
+        assert result == self.B12X_LATEST
+        mock_ensure.assert_not_called()
+        mock_build.assert_not_called()
+        mock_verify.assert_not_called()
+
+    def test_missing_non_pullable_image_substitutes_b12x(self, eugr_builder_with_repo, tmp_path):
+        """The pull-first substitution for a missing eugr image honors the b12x selector."""
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": "vllm-node",
+                "runtime_config": {"build_args": ["--exp-b12x"]},
+            }
+        )
+
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo") as mock_ensure:
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing") as mock_build:
+                    result = builder.prepare_image("vllm-node", recipe, ["10.0.0.1"], config=self._config(tmp_path))
+
+        assert result == self.B12X_LATEST
+        mock_ensure.assert_not_called()
+        mock_build.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "extra_flag",
+        [
+            "--rebuild-vllm",
+            # Upstream rejects this pairing (b12x vLLM wheels aren't published);
+            # sparkrun forwards both flags and lets the script own that verdict.
+            "--use-wheels",
+        ],
+    )
+    def test_b12x_build_uses_b12x_local_tag_and_forwards_flag(self, eugr_builder_with_repo, tmp_path, extra_flag):
+        """With a custom build flag alongside it, b12x builds under its own local tag.
+
+        `--exp-b12x` is a real build-and-copy.sh flag — it must reach the script argv
+        (it selects the fork/ref the image is built from), and the result must not
+        overwrite the standard nightly's local tag.
+        """
+        builder, repo_dir = eugr_builder_with_repo
+        sentinel = "ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest"
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": sentinel,
+                "runtime_config": {"build_args": ["--exp-b12x", extra_flag]},
+            }
+        )
+
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo", return_value=repo_dir):
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing", return_value=(0, "")) as mock_build:
+                    with mock.patch.object(builder, "_can_skip_build", return_value=False):
+                        with mock.patch.object(builder, "_verify_image_imports"):
+                            with mock.patch.object(builder, "_save_build_metadata"):
+                                result = builder.prepare_image(sentinel, recipe, ["10.0.0.1"], config=self._config(tmp_path))
+
+        assert result == "sparkrun-eugr-vllm-b12x"
+        cmd = mock_build.call_args[0][0]
+        assert "--exp-b12x" in cmd
+        assert extra_flag in cmd
+        assert "sparkrun-eugr-vllm-b12x" in cmd
+
+    @pytest.mark.parametrize(
+        "b12x_image",
+        [
+            "ghcr.io/spark-arena/dgx-vllm-eugr-nightly-b12x:latest",
+            # build-and-copy.sh's PREBUILT_B12X_RUNNER_IMAGE, short and qualified.
+            "eugr/spark-vllm-b12x:latest",
+            "docker.io/eugr/spark-vllm-b12x:latest",
+        ],
+    )
+    def test_b12x_image_selects_the_variant_without_the_flag(self, eugr_builder_with_repo, tmp_path, b12x_image):
+        """Naming a b12x prebuilt image resolves to our b12x nightly, flag or not."""
+        builder, repo_dir = eugr_builder_with_repo
+        recipe = Recipe.from_dict(
+            {
+                "name": "test",
+                "model": "some/model",
+                "runtime": "eugr-vllm",
+                "container": b12x_image,
+            }
+        )
+
+        with mock.patch("sparkrun.containers.registry.image_exists_locally", return_value=False):
+            with mock.patch.object(builder, "ensure_repo") as mock_ensure:
+                with mock.patch("sparkrun.builders.eugr._run_build_capturing") as mock_build:
+                    result = builder.prepare_image(b12x_image, recipe, ["10.0.0.1"], config=self._config(tmp_path))
+
+        assert result == self.B12X_LATEST
+        mock_ensure.assert_not_called()
+        mock_build.assert_not_called()
+
+
 class TestEugrRebuild:
     """`builder_config.rebuild` — force a fresh image (rebuild or fresh pull)."""
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -135,6 +135,38 @@ class TestRenderHookCommand:
         result = render_hook_command("curl {base_url}/models", ctx)
         assert result == "curl http://10.0.0.1:8000/v1/models"
 
+    def test_render_placeholder_inside_json_payload(self):
+        """A placeholder inside a JSON body resolves.
+
+        The common post_exec shape — a warm-up ``curl`` that POSTs JSON.  vpd's
+        regex matched from the payload's opening brace through the
+        placeholder's closing brace and restored the span verbatim, so the hook
+        sent a literal ``{model}`` to the server.
+        """
+        ctx = {"base_url": "http://10.0.0.1:8000/v1", "model": "llama-7b"}
+        result = render_hook_command(
+            'curl {base_url}/chat/completions -d \'{"model":"{model}","stream":false}\'',
+            ctx,
+        )
+
+        assert result == 'curl http://10.0.0.1:8000/v1/chat/completions -d \'{"model":"llama-7b","stream":false}\''
+
+    def test_render_json_without_placeholders_untouched(self):
+        """A JSON payload with nothing to substitute passes through unchanged."""
+        cmd = "curl -d '{\"stream\": false}' http://h/x"
+
+        assert render_hook_command(cmd, {"model": "llama-7b"}) == cmd
+
+    def test_render_doubled_braces_preserved(self):
+        """Hook commands are not v1 templates — ``{{`` stays two braces."""
+        assert render_hook_command("echo '{{keep}}'", {"keep": "X"}) == "echo '{{keep}}'"
+
+    def test_render_terminates_on_self_growing_value(self):
+        """A self-referential context value must not hang the render."""
+        result = render_hook_command("echo {a}", {"a": "x{a}"})
+
+        assert result.endswith("{a}")
+
 
 # ---------------------------------------------------------------------------
 # render_hook_commands

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -158,7 +158,12 @@ class TestRenderHookCommand:
         assert render_hook_command(cmd, {"model": "llama-7b"}) == cmd
 
     def test_render_doubled_braces_preserved(self):
-        """Hook commands are not v1 templates — ``{{`` stays two braces."""
+        """Hooks keep ``{{`` as two braces even though recipe commands collapse it.
+
+        A hook body is arbitrary shell, where a doubled brace is plausibly
+        meant literally (brace expansion, an ``awk`` program), and the mask
+        already lets a JSON payload use plain braces.
+        """
         assert render_hook_command("echo '{{keep}}'", {"keep": "X"}) == "echo '{{keep}}'"
 
     def test_render_terminates_on_self_growing_value(self):

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -156,6 +156,68 @@ def test_v1_migration_preserves_non_string_defaults():
     assert r2.defaults["diffusion_config"] == '{"canvas_length": 256}'
 
 
+def test_defaults_brace_escapes_collapse_for_v2():
+    """The defaults collapse is not gated on recipe version either.
+
+    It used to live inside ``_resolve_v1_migration``, so a v2 recipe supplying
+    a JSON-valued flag as a *default* leaked ``{{...}}`` into the rendered
+    command — the same failure as the command template, one layer down.
+    """
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-defaults",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"spec": '{{"a":1}}', "port": 8000},
+            "command": "vllm serve m --spec '{spec}'",
+        }
+    )
+
+    assert recipe.defaults["spec"] == '{"a":1}'
+    assert recipe.defaults["port"] == 8000  # non-strings still pass through
+    assert "--spec '{\"a\":1}'" in recipe.render_command(recipe.build_config_chain({}))
+
+
+def test_defaults_plain_nested_json_is_not_collapsed():
+    """A default already written with plain braces is left alone.
+
+    ``.replace("}}", "}")`` fires on any doubled closer, so collapsing
+    unconditionally would drop the outer brace of nested JSON that was correct
+    to begin with.
+    """
+    for version in ("1", "2"):
+        recipe = Recipe.from_dict(
+            {
+                "name": f"v{version}-plain-defaults",
+                "model": "m",
+                "recipe_version": version,
+                "runtime": "vllm",
+                "defaults": {"spec": '{"a":{"b":1}}'},
+            }
+        )
+
+        assert recipe.defaults["spec"] == '{"a":{"b":1}}', version
+
+
+def test_defaults_brace_escapes_collapse_for_non_vllm_runtime():
+    """The collapse no longer depends on the runtime being vllm.
+
+    ``_resolve_v1_migration`` only reached the collapse when the runtime was
+    ``vllm`` or empty, so a v1 sglang recipe kept its doubled braces.
+    """
+    recipe = Recipe.from_dict(
+        {
+            "name": "v1-sglang",
+            "model": "m",
+            "recipe_version": "1",
+            "runtime": "sglang",
+            "defaults": {"spec": '{{"a":1}}'},
+        }
+    )
+
+    assert recipe.defaults["spec"] == '{"a":1}'
+
+
 def test_recipe_from_dict(sample_v2_recipe_data: dict[str, Any]):
     """Create a recipe from a dict and verify all fields are correctly set.
 
@@ -596,8 +658,7 @@ def test_render_command_v1_unknown_placeholder_is_left_verbatim():
 def test_render_command_v2_substitutes_placeholder_inside_bare_json():
     """A v2 recipe may write JSON with plain braces and a placeholder inside.
 
-    v2 has no ``{{`` escaping convention — ``RECIPES.md`` documents only
-    ``{key}`` — so a JSON-valued flag is written with single braces.  vpd's
+    Plain braces are the idiomatic v2 spelling — no escaping needed.  vpd's
     regex matches from the JSON's opening brace through the placeholder's
     closing brace, so the placeholder was left unsubstituted and the runtime
     received a literal ``{num_speculative_tokens}``.
@@ -615,6 +676,31 @@ def test_render_command_v2_substitutes_placeholder_inside_bare_json():
 
     assert '--speculative-config \'{"method":"mtp","n":2}\'' in rendered
     assert "{num_speculative_tokens}" not in rendered
+
+
+def test_render_command_nested_plain_json_survives_escape_capable_render():
+    """A trailing ``}}`` that merely closes nested JSON must not be collapsed.
+
+    This is why escape mode is detected from ``{{`` rather than forced on for
+    every recipe: ``'{"a":{"b":1}}'`` ends in ``}}`` exactly like an escaped
+    span does, so a blanket collapse silently eats the outer closing brace and
+    hands the runtime unparseable JSON.
+    """
+    for version in ("1", "2"):
+        recipe = Recipe.from_dict(
+            {
+                "name": f"v{version}-nested-plain",
+                "model": "m",
+                "recipe_version": version,
+                "runtime": "vllm",
+                "defaults": {"n": 1},
+                "command": 'vllm serve m --c \'{"a":{"b":{n}}}\'',
+            }
+        )
+        rendered = recipe.render_command(recipe.build_config_chain({}))
+
+        payload = next(tok for tok in shlex.split(rendered) if tok.startswith("{"))
+        assert json.loads(payload) == {"a": {"b": 1}}, version
 
 
 def test_render_command_v2_nested_bare_json_placeholder():
@@ -673,8 +759,12 @@ def test_render_command_terminates_on_self_growing_default(caplog):
     assert "did not stabilize" in caplog.text
 
 
-def test_render_command_does_not_collapse_braces_for_v2():
-    """v2 recipes are unaffected by the v1 brace-escape collapse."""
+def test_render_command_collapses_braces_for_v2():
+    """The ``{{``/``}}`` escape collapses for v2 too, not just v1.
+
+    Collapsing used to be gated on ``recipe_version == "1"``, so a v1 command
+    pasted into a v2 recipe emitted doubled braces to the runtime.
+    """
     recipe = Recipe.from_dict(
         {
             "name": "v2",
@@ -685,7 +775,102 @@ def test_render_command_does_not_collapse_braces_for_v2():
     )
     rendered = recipe.render_command(recipe.build_config_chain({}))
 
-    assert "{{literal}}" in rendered
+    assert "--x '{literal}'" in rendered
+    assert "{{" not in rendered
+
+
+def test_render_command_v2_escapes_log_deprecation_warning(caplog):
+    """Using the v1 doubled-brace escape outside v1 warns that v3 will drop it."""
+    import logging
+
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-escaped",
+            "model": "m",
+            "runtime": "vllm",
+            "command": "vllm serve m --x '{{\"a\":1}}'",
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="sparkrun.core.recipe"):
+        rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert "--x '{\"a\":1}'" in rendered
+    assert "doubled-brace escape" in caplog.text
+    assert "v3" in caplog.text
+
+
+def test_render_command_v1_escapes_do_not_warn(caplog):
+    """v1 is the convention's home — using it there is not deprecated."""
+    import logging
+
+    recipe = Recipe.from_dict(
+        {
+            "name": "v1-escaped",
+            "model": "m",
+            "recipe_version": "1",
+            "runtime": "vllm",
+            "command": "vllm serve m --x '{{\"a\":1}}'",
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="sparkrun.core.recipe"):
+        recipe.render_command(recipe.build_config_chain({}))
+
+    assert "doubled-brace escape" not in caplog.text
+
+
+def test_render_command_plain_json_does_not_warn(caplog):
+    """The idiomatic plain-brace spelling is not the escape convention."""
+    import logging
+
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-plain",
+            "model": "m",
+            "runtime": "vllm",
+            "command": 'vllm serve m --x \'{"a":{"b":1}}\'',
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="sparkrun.core.recipe"):
+        recipe.render_command(recipe.build_config_chain({}))
+
+    assert "doubled-brace escape" not in caplog.text
+
+
+def test_render_command_v2_pasted_v1_json_flags_parse():
+    """A v2 recipe carrying v1-style doubled-brace JSON flags renders valid JSON.
+
+    Regression for the arena ``deepseek-v4-flash-0731`` recipe: declared
+    ``recipe_version: "2"`` with its command copied from the v1 eugr recipe, so
+    every JSON-valued flag reached vLLM as ``'{{...}}'`` and
+    ``--compilation-config`` died with ``Invalid JSON: key must be a string``.
+    The failure surfaced only after the 167 GB model had downloaded.
+
+    The plain-brace flag in the same command must be unaffected — the two
+    spellings converge rather than one breaking the other.
+    """
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-pasted-v1",
+            "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+            "recipe_version": "2",
+            "runtime": "vllm",
+            "defaults": {"num_speculative_tokens": 5},
+            "command": (
+                "vllm serve m "
+                '--reasoning-config \'{"reasoning_parser":"deepseek_v4"}\' '
+                '--compilation-config \'{{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}}\' '
+                '--speculative-config \'{{"method":"dspark","num_speculative_tokens":{num_speculative_tokens}}}\''
+            ),
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    payloads = [json.loads(tok) for tok in shlex.split(rendered) if tok.startswith("{")]
+    assert payloads == [
+        {"reasoning_parser": "deepseek_v4"},
+        {"cudagraph_mode": "FULL_AND_PIECEWISE", "custom_ops": ["all"]},
+        {"method": "dspark", "num_speculative_tokens": 5},
+    ]
 
 
 def test_render_command_fixes_trailing_space_continuations():

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -593,6 +593,86 @@ def test_render_command_v1_unknown_placeholder_is_left_verbatim():
     assert "--x '{\"n\":{nope}}'" in rendered
 
 
+def test_render_command_v2_substitutes_placeholder_inside_bare_json():
+    """A v2 recipe may write JSON with plain braces and a placeholder inside.
+
+    v2 has no ``{{`` escaping convention — ``RECIPES.md`` documents only
+    ``{key}`` — so a JSON-valued flag is written with single braces.  vpd's
+    regex matches from the JSON's opening brace through the placeholder's
+    closing brace, so the placeholder was left unsubstituted and the runtime
+    received a literal ``{num_speculative_tokens}``.
+    """
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-json",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"port": 8000, "num_speculative_tokens": 2},
+            "command": 'vllm serve m --port {port} --speculative-config \'{"method":"mtp","n":{num_speculative_tokens}}\'',
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert '--speculative-config \'{"method":"mtp","n":2}\'' in rendered
+    assert "{num_speculative_tokens}" not in rendered
+
+
+def test_render_command_v2_nested_bare_json_placeholder():
+    """Nesting depth doesn't matter — only the placeholder is touched."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-nested",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"n": 1},
+            "command": 'vllm serve m --c \'{"a":{"b":{n}}}\'',
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert '--c \'{"a":{"b":1}}\'' in rendered
+
+
+def test_render_command_v2_json_without_placeholders_untouched():
+    """A v2 JSON blob that resolves to nothing passes through unchanged."""
+    recipe = Recipe.from_dict(
+        {
+            "name": "v2-plain-json",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"port": 8000},
+            "command": "vllm serve m --port {port} --c '{\"canvas_length\": 256}'",
+        }
+    )
+    rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert "--c '{\"canvas_length\": 256}'" in rendered
+
+
+def test_render_command_terminates_on_self_growing_default(caplog):
+    """A default whose value contains itself must not hang the render.
+
+    ``a: "x{a}"`` renders ``x{a}`` -> ``xx{a}`` -> ... and never reaches a
+    fixpoint, so an unbounded loop wedges the process with no output.
+    """
+    import logging
+
+    recipe = Recipe.from_dict(
+        {
+            "name": "cyclic",
+            "model": "m",
+            "runtime": "vllm",
+            "defaults": {"a": "x{a}"},
+            "command": "echo {a}",
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="sparkrun.utils.text"):
+        rendered = recipe.render_command(recipe.build_config_chain({}))
+
+    assert rendered.endswith("{a}")
+    assert "did not stabilize" in caplog.text
+
+
 def test_render_command_does_not_collapse_braces_for_v2():
     """v2 recipes are unaffected by the v1 brace-escape collapse."""
     recipe = Recipe.from_dict(

--- a/tests/test_resolve_long_term_image.py
+++ b/tests/test_resolve_long_term_image.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 
 from sparkrun.builders.base import BuilderPlugin
 from sparkrun.builders.eugr import (
     EugrBuilder,
     GHCR_EUGR_NIGHTLY,
+    GHCR_EUGR_NIGHTLY_B12X,
     GHCR_EUGR_NIGHTLY_TF5,
     GHCR_EUGR_PKG,
+    GHCR_EUGR_PKG_B12X,
     GHCR_EUGR_PKG_TF5,
 )
 from sparkrun.core.recipe import Recipe
@@ -85,6 +88,33 @@ class TestResolveGhcrTarget:
         builder = EugrBuilder()
         recipe = _make_recipe()
         ghcr, pkg = builder._resolve_ghcr_target("totally-custom-image", recipe)
+        assert ghcr is None
+        assert pkg is None
+
+    def test_b12x_build_args_resolve_b12x(self):
+        """The b12x selector identifies the variant even before the image is remapped."""
+        builder = EugrBuilder()
+        recipe = _make_recipe(runtime_config={"build_args": ["--exp-b12x"]})
+        ghcr, pkg = builder._resolve_ghcr_target("ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest", recipe)
+        assert ghcr == GHCR_EUGR_NIGHTLY_B12X
+        assert pkg == GHCR_EUGR_PKG_B12X
+
+    @pytest.mark.parametrize(
+        "image",
+        ["ghcr.io/spark-arena/dgx-vllm-eugr-nightly-b12x:latest", "sparkrun-eugr-vllm-b12x"],
+    )
+    def test_b12x_image_resolves_b12x(self, image):
+        builder = EugrBuilder()
+        recipe = _make_recipe()
+        ghcr, pkg = builder._resolve_ghcr_target(image, recipe)
+        assert ghcr == GHCR_EUGR_NIGHTLY_B12X
+        assert pkg == GHCR_EUGR_PKG_B12X
+
+    def test_b12x_with_custom_build_flag_is_unresolvable(self):
+        """b12x plus a custom build flag is a bespoke build — not a published variant."""
+        builder = EugrBuilder()
+        recipe = _make_recipe(runtime_config={"build_args": ["--exp-b12x", "--rebuild-vllm"]})
+        ghcr, pkg = builder._resolve_ghcr_target("sparkrun-eugr-vllm-b12x", recipe)
         assert ghcr is None
         assert pkg is None
 

--- a/tests/test_run_recipe_shim.py
+++ b/tests/test_run_recipe_shim.py
@@ -1,0 +1,325 @@
+"""Argv-mapping tests for the ``run-recipe.sh`` spark-vllm-docker shim.
+
+The shim exposes a hidden ``RUN_RECIPE_DEBUG=1`` hook that prints the assembled
+``sparkrun`` argv to stderr and exits 0 *without* invoking sparkrun, which is
+what lets us assert the legacy-option -> native-option mapping here without a
+cluster (or even a working sparkrun install).
+
+Assertions are ``endswith``-based because the runner prefix is environment
+dependent (``<repo>/.venv/bin/sparkrun`` in a dev checkout, plain ``sparkrun``
+on PATH, or ``uv tool run sparkrun`` as the last resort).
+
+The upstream tool these map onto is ``run-recipe.py`` in spark-vllm-docker; a
+pinned copy lives under ``reference_materials/spark-vllm-docker/``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SHIM = Path(__file__).resolve().parent.parent / "run-recipe.sh"
+
+RECIPE = "qwen3-1.7b-vllm"
+
+
+@pytest.fixture(scope="module")
+def stub_path(tmp_path_factory):
+    """A PATH entry holding a no-op ``sparkrun``.
+
+    Only used when the repo has no ``.venv`` (e.g. CI): it keeps
+    ``resolve_runner`` from falling through to its ``pip install uv``
+    bootstrap, which would hit the network.
+    """
+    bindir = tmp_path_factory.mktemp("stubbin")
+    stub = bindir / "sparkrun"
+    stub.write_text("#!/bin/sh\nexit 0\n")
+    stub.chmod(0o755)
+    return bindir
+
+
+def shim(*args, env=None):
+    """Run the shim under the debug hook; return (returncode, stderr)."""
+    e = dict(os.environ)
+    e["RUN_RECIPE_DEBUG"] = "1"
+    if env:
+        e.update(env)
+    p = subprocess.run(
+        [str(SHIM), *args],
+        capture_output=True,
+        text=True,
+        env=e,
+    )
+    return p.returncode, p.stderr
+
+
+def argv(*args, **kwargs):
+    """Run the shim and return the single assembled ``DEBUG argv:`` line."""
+    rc, err = shim(*args, **kwargs)
+    assert rc == 0, "shim exited %d:\n%s" % (rc, err)
+    lines = [ln for ln in err.splitlines() if ln.startswith("DEBUG argv:")]
+    assert len(lines) == 1, "expected exactly one DEBUG argv line, got:\n%s" % err
+    return lines[0][len("DEBUG argv:") :].strip()
+
+
+@pytest.fixture(autouse=True)
+def _path_with_stub(stub_path, monkeypatch):
+    monkeypatch.setenv("PATH", "%s%s%s" % (os.environ.get("PATH", ""), os.pathsep, stub_path))
+
+
+# ---------------------------------------------------------------------------
+# Baseline
+# ---------------------------------------------------------------------------
+
+
+def test_solo_defaults_tp1_and_foreground():
+    assert argv(RECIPE, "--solo").endswith("run %s --solo --tp 1 --foreground" % RECIPE)
+
+
+def test_explicit_tp_suppresses_the_solo_tp1_default():
+    """--solo only injects --tp 1 when the user did not pick a tp themselves."""
+    assert argv(RECIPE, "--solo", "--tp", "2").endswith("run %s --solo --tp 2 --foreground" % RECIPE)
+
+
+def test_daemon_drops_foreground():
+    assert argv(RECIPE, "--solo", "-d").endswith("run %s --solo --tp 1" % RECIPE)
+
+
+@pytest.mark.parametrize(
+    "legacy,native",
+    [
+        (["--port", "9000"], "--port 9000"),
+        (["--host", "0.0.0.0"], "-o host=0.0.0.0"),
+        (["--tp", "4"], "--tp 4"),
+        (["--tensor-parallel", "4"], "--tp 4"),
+        (["--gpu-mem", "0.8"], "--gpu-mem 0.8"),
+        (["--gpu-memory-utilization", "0.8"], "--gpu-mem 0.8"),
+        (["--max-model-len", "4096"], "--max-model-len 4096"),
+        (["-n", "h1,h2"], "--hosts h1,h2"),
+        (["--nodes", "h1,h2"], "--hosts h1,h2"),
+        (["-t", "img:tag"], "--image img:tag"),
+        (["--container", "img:tag"], "--image img:tag"),
+        (["--name", "vllm_node"], "--container-name vllm_node"),
+        (["--master-port", "29501"], "--init-port 29501"),
+        (["--head-port", "29501"], "--init-port 29501"),
+        (["-e", "HF_TOKEN=x"], "--executor-args -e HF_TOKEN=x"),
+        (["--nccl-debug", "INFO"], "--executor-args -e NCCL_DEBUG=INFO"),
+        (["--mem-limit-gb", "32"], "--memory-limit 32G"),
+        (["--shm-size-gb", "64"], "-o shm_size=64g"),
+        (["--mem-swap-limit-gb", "48"], "--executor-args --memory-swap 48g"),
+        (["--pids-limit", "4096"], "--executor-args --pids-limit 4096"),
+        (["--non-privileged"], "-o privileged=false"),
+        (["--dry-run"], "--dry-run"),
+    ],
+)
+def test_value_option_mapping(legacy, native):
+    assert argv(RECIPE, *legacy).endswith("run %s %s --foreground" % (RECIPE, native))
+
+
+def test_equals_form_is_accepted():
+    assert argv(RECIPE, "--port=9000").endswith("run %s --port 9000 --foreground" % RECIPE)
+
+
+# ---------------------------------------------------------------------------
+# -v/--volume  (upstream e987390)
+# ---------------------------------------------------------------------------
+
+
+def test_volume_maps_to_executor_args():
+    assert argv(RECIPE, "--solo", "-v", "/local/models:/models").endswith(
+        "run %s --solo --executor-args -v /local/models:/models --tp 1 --foreground" % RECIPE
+    )
+
+
+def test_volume_is_repeatable():
+    line = argv(RECIPE, "--solo", "-v", "/a:/b", "-v", "/c:/d")
+    assert "--executor-args -v /a:/b --executor-args -v /c:/d" in line
+
+
+def test_volume_long_and_equals_forms():
+    assert "--executor-args -v /a:/b" in argv(RECIPE, "--solo", "--volume", "/a:/b")
+    assert "--executor-args -v /a:/b" in argv(RECIPE, "--solo", "--volume=/a:/b")
+
+
+def test_volume_allowed_in_cluster_mode_unlike_publish():
+    """Upstream emits -v in both the solo and cluster branches; -p is solo-only."""
+    assert "--executor-args -v /a:/b" in argv(RECIPE, "-n", "h1,h2", "-v", "/a:/b")
+    rc, err = shim(RECIPE, "-n", "h1,h2", "-p", "8000:8000")
+    assert rc == 1
+    assert "only supported in solo mode" in err
+
+
+# ---------------------------------------------------------------------------
+# Ray selection — upstream: use_ray = args.ray and not is_solo
+# ---------------------------------------------------------------------------
+
+
+def test_no_ray_is_the_multi_node_default():
+    """Neither flag -> no backend override; sparkrun defaults to vllm-distributed."""
+    assert argv(RECIPE, "-n", "h1,h2").endswith("run %s --hosts h1,h2 --foreground" % RECIPE)
+
+
+def test_ray_opts_into_the_ray_backend():
+    assert "-o distributed_executor_backend=ray" in argv(RECIPE, "-n", "h1,h2", "--ray")
+
+
+def test_no_ray_is_accepted_for_compatibility():
+    assert "-o distributed_executor_backend=mp" in argv(RECIPE, "-n", "h1,h2", "--no-ray")
+
+
+@pytest.mark.parametrize("flag", ["--ray", "--no-ray"])
+@pytest.mark.parametrize("order", ["flag_first", "solo_first"])
+def test_solo_ignores_ray_flags_regardless_of_order(flag, order):
+    """Upstream silently drops the backend choice in solo mode rather than erroring.
+
+    Order matters as a regression guard: the flags are recorded during parsing
+    and resolved afterwards, precisely so a trailing --solo still suppresses
+    them.
+    """
+    args = [flag, "--solo"] if order == "flag_first" else ["--solo", flag]
+    rc, err = shim(RECIPE, *args)
+    assert rc == 0, err
+    assert "distributed_executor_backend" not in err
+    assert "ignored in solo mode" in err
+
+
+def test_ray_and_no_ray_are_mutually_exclusive():
+    rc, err = shim(RECIPE, "-n", "h1,h2", "--ray", "--no-ray")
+    assert rc == 1
+    assert "mutually exclusive" in err
+
+
+# ---------------------------------------------------------------------------
+# Unsupported / unknown options
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "opt",
+    [
+        "--apply-mod",
+        "--eth-if",
+        "--ib-if",
+        "--discover",
+        "--show-env",
+        "--build-only",
+        "--download-only",
+        "--force-build",
+        "--force-download",
+        "-j",
+        "--keep-entrypoint",
+        "--no-cache-dirs",
+        "--earlyoom",
+        "--earlyoom-args",
+    ],
+)
+def test_unsupported_options_exit_2_with_a_native_pointer(opt):
+    rc, err = shim(RECIPE, opt, "x")
+    assert rc == 2, err
+    assert "is not supported by" in err
+
+
+def test_unknown_option_is_rejected():
+    rc, err = shim(RECIPE, "--definitely-not-an-option")
+    assert rc == 1
+    assert "unknown option" in err
+
+
+def test_setup_is_a_noop_and_still_runs():
+    rc, err = shim(RECIPE, "--solo", "--setup")
+    assert rc == 0, err
+    assert "--setup is a no-op" in err
+
+
+def test_second_positional_is_rejected():
+    rc, err = shim(RECIPE, "extra-recipe")
+    assert rc == 1
+    assert "unexpected extra argument" in err
+
+
+def test_missing_recipe_is_rejected():
+    rc, err = shim("--solo")
+    assert rc == 1
+    assert "no recipe specified" in err
+
+
+def test_no_args_prints_usage():
+    rc, err = shim()
+    assert rc == 1
+    assert "Usage:" in err
+
+
+def test_help_exits_zero():
+    rc, err = shim("--help")
+    assert rc == 0
+    assert "Usage:" in err
+
+
+# ---------------------------------------------------------------------------
+# --list and --config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", ["--list", "-l"])
+def test_list_short_circuits_to_recipe_list(flag):
+    rc, err = shim(flag)
+    assert rc == 0, err
+    assert err.strip().endswith("recipe list")
+
+
+def test_list_wins_over_a_recipe_and_other_options():
+    rc, err = shim(RECIPE, "--solo", "--list")
+    assert rc == 0, err
+    assert err.strip().endswith("recipe list")
+
+
+def test_config_imports_a_cluster_and_retargets_the_run(tmp_path):
+    envf = tmp_path / "cluster.env"
+    envf.write_text("CLUSTER_NODES=10.0.0.1,10.0.0.2\n")
+    rc, err = shim(RECIPE, "--solo", "--config", str(envf))
+    assert rc == 0, err
+    assert "cluster import --from-spark-vllm-docker-env %s" % envf in err
+    # --cluster is prepended so it precedes the mapped run options.
+    assert "run %s --cluster <from-env> --solo --tp 1 --foreground" % RECIPE in err
+
+
+# ---------------------------------------------------------------------------
+# Engine passthrough after `--`
+# ---------------------------------------------------------------------------
+
+
+def test_passthrough_key_value_becomes_an_option_override():
+    line = argv(RECIPE, "--solo", "--", "--max-num-seqs", "64")
+    assert "-o max_num_seqs=64" in line
+
+
+def test_passthrough_equals_form():
+    line = argv(RECIPE, "--solo", "--", "--max-num-seqs=64")
+    assert "-o max_num_seqs=64" in line
+
+
+def test_passthrough_bare_flag_becomes_true():
+    line = argv(RECIPE, "--solo", "--", "--enforce-eager")
+    assert "-o enforce_eager=true" in line
+
+
+def test_passthrough_flag_followed_by_flag_does_not_consume_it():
+    line = argv(RECIPE, "--solo", "--", "--enforce-eager", "--trust-remote-code")
+    assert "-o enforce_eager=true" in line
+    assert "-o trust_remote_code=true" in line
+
+
+def test_passthrough_bare_token_is_warned_and_dropped():
+    rc, err = shim(RECIPE, "--solo", "--", "orphan")
+    assert rc == 0, err
+    assert "ignoring bare passthrough token 'orphan'" in err
+
+
+def test_passthrough_does_not_swallow_shim_options():
+    """Options before `--` are still mapped; only the tail is passthrough."""
+    line = argv(RECIPE, "--solo", "--port", "9000", "--", "--max-num-seqs", "64")
+    assert "--port 9000" in line
+    assert "-o max_num_seqs=64" in line

--- a/tests/test_session_guard.py
+++ b/tests/test_session_guard.py
@@ -1,0 +1,337 @@
+"""Tests for the remote session guard (issue #240).
+
+Remote payloads run via ``ssh <host> bash -s`` — without a PTY — so sshd sends
+no signal to its child on disconnect and a killed ``sparkrun`` on the control
+node would otherwise leave ``hf download`` / ``docker pull`` / rsync fan-outs
+running on the cluster.  See ``orchestration.ssh.wrap_with_session_guard``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import signal
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sparkrun.orchestration.ssh import (
+    NO_SESSION_GUARD_ENV,
+    RemoteResult,
+    run_remote_script,
+    run_remote_script_streaming,
+    run_remote_scripts_parallel,
+    session_guard_disabled,
+    wrap_with_session_guard,
+)
+
+GUARD_MARKER = "sparkrun session guard"
+
+needs_bash = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="requires a POSIX shell",
+)
+
+
+# ---------------------------------------------------------------------------
+# wrap_with_session_guard
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_embeds_payload_and_consumes_sentinel():
+    wrapped = wrap_with_session_guard("echo hello\n")
+
+    assert "echo hello" in wrapped
+    assert GUARD_MARKER in wrapped
+    # The sentinel must be substituted, not left behind as a stray command.
+    assert "__SPARKRUN_PAYLOAD__" not in wrapped
+
+
+def test_wrap_separates_payload_without_trailing_newline():
+    """A payload with no trailing newline must not run into the closing paren."""
+    wrapped = wrap_with_session_guard("echo hello")
+
+    assert "echo hello\n)" in wrapped
+
+
+def test_wrap_nests_rather_than_deduplicating():
+    """Wrapping twice nests, so each call site must wrap exactly once.
+
+    Enforced structurally: the only wrap points are the three dispatch
+    functions in ``orchestration.ssh``, and none of them calls another.
+    """
+    once = wrap_with_session_guard("echo hi")
+    twice = wrap_with_session_guard(once)
+
+    assert once.count(GUARD_MARKER) == 1
+    assert twice.count(GUARD_MARKER) == 2
+
+
+def test_guard_script_has_no_curly_braces():
+    """Repo convention: embedded scripts stay safe to run through str.format()."""
+    from sparkrun.scripts import read_script
+
+    guard = read_script("session_guard.sh")
+    assert "{" not in guard
+    assert "}" not in guard
+
+
+def test_kill_switch_returns_script_unchanged(monkeypatch):
+    monkeypatch.setenv(NO_SESSION_GUARD_ENV, "1")
+
+    assert session_guard_disabled() is True
+    assert wrap_with_session_guard("echo hello") == "echo hello"
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no"])
+def test_kill_switch_falsy_values_keep_guard_on(monkeypatch, value):
+    monkeypatch.setenv(NO_SESSION_GUARD_ENV, value)
+
+    assert session_guard_disabled() is False
+    assert GUARD_MARKER in wrap_with_session_guard("echo hello")
+
+
+# ---------------------------------------------------------------------------
+# Real-shell behaviour: the guard must be transparent
+# ---------------------------------------------------------------------------
+
+
+def _run_guarded(payload: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-s"],
+        input=wrap_with_session_guard(payload),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+@needs_bash
+def test_guard_passes_through_stdout_stderr_and_rc():
+    proc = _run_guarded("echo to-out\necho to-err >&2\n")
+
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == "to-out"
+    assert proc.stderr.strip() == "to-err"
+
+
+@needs_bash
+def test_guard_propagates_nonzero_rc():
+    proc = _run_guarded("echo failing\nexit 17\n")
+
+    assert proc.returncode == 17
+    assert proc.stdout.strip() == "failing"
+
+
+@needs_bash
+def test_guard_propagates_early_exit_zero():
+    """model_sync.sh's cache-hit fast path exits 0 from inside the payload."""
+    proc = _run_guarded('echo cached\nexit 0\necho "NOT REACHED"\n')
+
+    assert proc.returncode == 0
+    assert "NOT REACHED" not in proc.stdout
+
+
+@needs_bash
+def test_guard_preserves_payload_shell_options():
+    """`set -uo pipefail` inside the payload must not leak out, or vice versa."""
+    proc = _run_guarded("set -uo pipefail\necho ${MISSING_VAR:-default}\n")
+
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == "default"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch wiring
+# ---------------------------------------------------------------------------
+
+
+@patch("sparkrun.orchestration.ssh._run_subprocess")
+def test_run_remote_script_wraps_when_enabled(mock_run):
+    mock_run.return_value = RemoteResult(host="h1", returncode=0, stdout="", stderr="")
+
+    run_remote_script("h1", "echo payload", session_guard=True)
+
+    sent = mock_run.call_args[1]["input_data"]
+    assert GUARD_MARKER in sent
+    assert "echo payload" in sent
+
+
+@patch("sparkrun.orchestration.ssh._run_subprocess")
+def test_run_remote_script_unwrapped_by_default(mock_run):
+    mock_run.return_value = RemoteResult(host="h1", returncode=0, stdout="", stderr="")
+
+    run_remote_script("h1", "echo payload")
+
+    assert mock_run.call_args[1]["input_data"] == "echo payload"
+
+
+@patch("sparkrun.orchestration.ssh.run_local_script")
+@patch("sparkrun.orchestration.ssh.should_run_locally", return_value=True)
+def test_local_dispatch_is_never_wrapped(_mock_local, mock_run_local):
+    """A local run has no SSH session to lose — wrapping would be dead weight."""
+    mock_run_local.return_value = RemoteResult(host="localhost", returncode=0, stdout="", stderr="")
+
+    run_remote_script("localhost", "echo payload", allow_local=True, session_guard=True)
+
+    assert mock_run_local.call_args[0][0] == "echo payload"
+
+
+@patch("sparkrun.orchestration.ssh._run_subprocess")
+def test_dry_run_does_not_wrap(mock_run):
+    result = run_remote_script("h1", "echo payload", session_guard=True, dry_run=True)
+
+    assert result.stdout == "[dry-run]"
+    mock_run.assert_not_called()
+
+
+@patch("sparkrun.orchestration.ssh.subprocess.run")
+def test_streaming_wraps_when_enabled(mock_run):
+    mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+    run_remote_script_streaming("h1", "echo payload", session_guard=True, quiet=True)
+
+    sent = mock_run.call_args[1]["input"].decode()
+    assert GUARD_MARKER in sent
+    assert "echo payload" in sent
+
+
+@patch("sparkrun.orchestration.ssh.run_remote_script")
+def test_parallel_propagates_session_guard(mock_one):
+    mock_one.return_value = RemoteResult(host="h1", returncode=0, stdout="", stderr="")
+
+    run_remote_scripts_parallel(["h1", "h2"], "echo payload", session_guard=True)
+
+    assert all(call[1]["session_guard"] is True for call in mock_one.call_args_list)
+
+
+# ---------------------------------------------------------------------------
+# Call sites that must opt in
+# ---------------------------------------------------------------------------
+
+
+@patch("sparkrun.orchestration.primitives.run_remote_scripts_parallel")
+def test_sync_resource_to_hosts_opts_in(mock_parallel):
+    from sparkrun.orchestration.primitives import sync_resource_to_hosts
+
+    mock_parallel.return_value = [RemoteResult(host="h1", returncode=0, stdout="", stderr="")]
+
+    sync_resource_to_hosts("echo sync", ["h1"], "Model")
+
+    assert mock_parallel.call_args[1]["session_guard"] is True
+
+
+@patch("sparkrun.orchestration.ssh.run_remote_script_streaming")
+def test_distribute_from_head_opts_in_on_both_steps(mock_stream):
+    from sparkrun.orchestration.distribution import _distribute_from_head
+
+    mock_stream.return_value = RemoteResult(host="head", returncode=0, stdout="", stderr="")
+
+    _distribute_from_head(
+        head="head",
+        hosts=["head", "w1"],
+        ensure_script="echo ensure",
+        distribute_script="echo distribute",
+        resource_label="Model 'x'",
+    )
+
+    assert len(mock_stream.call_args_list) == 2
+    assert all(call[1]["session_guard"] is True for call in mock_stream.call_args_list)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: SIGTERM/SIGHUP unwind like Ctrl-C
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def restore_signal_handlers():
+    saved = {}
+    for name in ("SIGTERM", "SIGHUP"):
+        sig = getattr(signal, name, None)
+        if sig is not None:
+            saved[sig] = signal.getsignal(sig)
+    yield
+    for sig, handler in saved.items():
+        signal.signal(sig, handler)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics")
+def test_install_termination_handlers_installs_on_default(restore_signal_handlers):
+    from sparkrun.cli._common import _terminate_as_interrupt, install_termination_handlers
+
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    installed = install_termination_handlers()
+
+    assert int(signal.SIGTERM) in installed
+    assert signal.getsignal(signal.SIGTERM) is _terminate_as_interrupt
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics")
+def test_install_termination_handlers_does_not_clobber(restore_signal_handlers):
+    from sparkrun.cli._common import install_termination_handlers
+
+    sentinel = signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    try:
+        installed = install_termination_handlers()
+        assert int(signal.SIGTERM) not in installed
+        assert signal.getsignal(signal.SIGTERM) is signal.SIG_IGN
+    finally:
+        signal.signal(signal.SIGTERM, sentinel)
+
+
+def test_termination_handler_raises_keyboard_interrupt():
+    """KeyboardInterrupt is what subprocess.run's cleanup path kills ssh on."""
+    from sparkrun.cli._common import _terminate_as_interrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _terminate_as_interrupt(signal.SIGTERM, None)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics")
+@pytest.mark.skipif(shutil.which("pgrep") is None, reason="requires pgrep")
+def test_sigterm_reaps_the_subprocess_run_child():
+    """End-to-end for layer 2: SIGTERM to the parent must reap the child.
+
+    ``subprocess.run`` kills its child from the bare ``except`` in its cleanup
+    path — that is the mechanism the handler relies on to drop the SSH session
+    (and so trigger the remote guard on the far end).  ``sleep`` stands in for
+    the ``ssh`` client here.
+    """
+    import time
+
+    harness = (
+        "import subprocess, sys\n"
+        "from sparkrun.cli._common import install_termination_handlers\n"
+        "assert install_termination_handlers()\n"
+        "try:\n"
+        "    subprocess.run(['sleep', '120'])\n"
+        "except KeyboardInterrupt:\n"
+        "    sys.exit(143)\n"
+        "sys.exit(0)\n"
+    )
+    proc = subprocess.Popen([sys.executable, "-c", harness])
+    try:
+        children: list[str] = []
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not children:
+            children = subprocess.run(["pgrep", "-P", str(proc.pid)], capture_output=True, text=True).stdout.split()
+            if not children:
+                time.sleep(0.1)
+        assert children, "harness never spawned its `sleep` child"
+
+        proc.send_signal(signal.SIGTERM)
+        assert proc.wait(timeout=10) == 143, "SIGTERM did not unwind as KeyboardInterrupt"
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            alive = [pid for pid in children if subprocess.run(["kill", "-0", pid], capture_output=True).returncode == 0]
+            if not alive:
+                break
+            time.sleep(0.1)
+        assert not alive, "subprocess.run child survived SIGTERM: %s" % alive
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -1,0 +1,148 @@
+"""Tests for sparkrun.utils.text brace masking and template rendering.
+
+These lock down the scan rules shared by recipe command rendering and
+lifecycle-hook rendering: which braces are placeholders, which are literal,
+and how ``{{``/``}}`` behave in each mode.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from sparkrun.utils.text import mask_non_placeholder_braces, render_template, unmask_braces
+
+
+class TestMaskRoundTrip:
+    """mask -> unmask must be lossless apart from the intended escape collapse."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "no braces here",
+            "{key}",
+            '{"a": 1}',
+            '{"a":{"b":2}}',
+            "awk '{print $1}'",
+            "${HF_HOME}",
+            "{}",
+        ],
+    )
+    def test_plain_mode_is_lossless(self, text):
+        """Without escapes every brace comes back exactly as it went in."""
+        assert unmask_braces(mask_non_placeholder_braces(text, escapes=False)) == text
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("{{a}}", "{a}"),
+            ('{{"a": 1}}', '{"a": 1}'),
+            ('{{"a": {{"b": 1}}}}', '{"a": {"b": 1}}'),
+            ("{{{k}", "{{k}"),
+            ("{k}}}", "{k}}"),
+        ],
+    )
+    def test_escape_mode_collapses_doubled_braces(self, text, expected):
+        """With escapes a ``{{``/``}}`` pair restores as one literal brace."""
+        assert unmask_braces(mask_non_placeholder_braces(text, escapes=True)) == expected
+
+    def test_placeholders_survive_masking_verbatim(self):
+        """A ``{key}`` span is left untouched so vpd can still see it."""
+        masked = mask_non_placeholder_braces('{{"n":{tokens}}}', escapes=True)
+
+        assert "{tokens}" in masked
+        assert "{{" not in masked
+
+    def test_json_braces_are_hidden_from_substitution(self):
+        """Braces that merely surround JSON must not look like placeholders."""
+        masked = mask_non_placeholder_braces('{"a":{"b":{n}}}', escapes=False)
+
+        assert masked.count("{") == 1  # only the real placeholder
+        assert "{n}" in masked
+
+
+class TestRenderTemplate:
+    """The mask -> substitute -> unmask pipeline."""
+
+    def test_standalone_placeholders(self):
+        assert render_template("--host {host} --port {port}", {"host": "0.0.0.0", "port": 8000}) == "--host 0.0.0.0 --port 8000"
+
+    def test_unknown_key_left_verbatim(self):
+        """An unresolved placeholder is restored as-is (vpd behavior preserved)."""
+        assert render_template("--x {nope}", {"port": 8000}) == "--x {nope}"
+
+    def test_falsy_values_are_substituted(self):
+        assert render_template("{a}|{b}|{c}", {"a": 0, "b": False, "c": ""}) == "0|False|"
+
+    def test_placeholder_inside_bare_json(self):
+        """A placeholder nested in single-brace JSON resolves.
+
+        This is the v2/hook shape: no ``{{`` escaping, just JSON with a
+        placeholder inside it.  vpd alone matches from the JSON's opening brace
+        through the placeholder's closing brace and restores the span verbatim.
+        """
+        assert render_template('{"method":"mtp","n":{n}}', {"n": 2}) == '{"method":"mtp","n":2}'
+
+    def test_placeholder_inside_nested_bare_json(self):
+        assert render_template('{"a":{"b":{n}}}', {"n": 1}) == '{"a":{"b":1}}'
+
+    def test_placeholder_inside_escaped_json(self):
+        """The v1 shape: escapes collapse, inner placeholder resolves."""
+        rendered = render_template('{{"method":"mtp","n":{n}}}', {"n": 1}, escapes=True)
+
+        assert rendered == '{"method":"mtp","n":1}'
+
+    def test_doubled_braces_preserved_without_escapes(self):
+        """Without escape mode ``{{x}}`` keeps both braces and is not substituted."""
+        assert render_template("{{keep}}", {"keep": "X"}) == "{{keep}}"
+
+    def test_json_without_placeholders_untouched(self):
+        text = "--config '{\"canvas_length\": 256}'"
+
+        assert render_template(text, {"port": 8000}) == text
+
+    def test_awk_program_untouched(self):
+        text = "docker ps | awk '{print $1}'"
+
+        assert render_template(text, {"port": 8000}) == text
+
+    def test_shell_expansion_without_matching_key(self):
+        assert render_template("echo ${HF_HOME}", {"port": 8000}) == "echo ${HF_HOME}"
+
+    def test_nested_reference_resolves(self):
+        assert render_template("{base_url}", {"base_url": "http://h:{port}", "port": 8000}) == "http://h:8000"
+
+    def test_deep_chain_resolves(self):
+        assert render_template("{a}", {"a": "{b}", "b": "{c}", "c": "end"}) == "end"
+
+    def test_self_resolving_value_is_a_fixpoint(self):
+        """``a: "{a}"`` stabilizes on the first pass — not a cycle."""
+        assert render_template("{a}", {"a": "{a}"}) == "{a}"
+
+    def test_self_growing_value_terminates(self, caplog):
+        """``a: "x{a}"`` grows every pass; the loop must stop and say so.
+
+        Without the bound this never reaches a fixpoint and the render hangs
+        while the string grows without limit.
+        """
+        with caplog.at_level(logging.WARNING, logger="sparkrun.utils.text"):
+            rendered = render_template("{a}", {"a": "x{a}"})
+
+        assert rendered.endswith("{a}")
+        assert "did not stabilize" in caplog.text
+
+    def test_mutual_recursion_terminates(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="sparkrun.utils.text"):
+            render_template("{a}", {"a": "1{b}", "b": "2{a}"})
+
+        assert "did not stabilize" in caplog.text
+
+    def test_max_passes_is_configurable(self):
+        assert render_template("{a}", {"a": "x{a}"}, max_passes=3) == "xxx{a}"
+
+    def test_no_warning_for_ordinary_templates(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="sparkrun.utils.text"):
+            render_template("--port {port}", {"port": 8000})
+
+        assert caplog.text == ""

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -11,7 +11,38 @@ import logging
 
 import pytest
 
-from sparkrun.utils.text import mask_non_placeholder_braces, render_template, unmask_braces
+from sparkrun.utils.text import mask_non_placeholder_braces, render_template, unmask_braces, uses_brace_escapes
+
+
+class TestUsesBraceEscapes:
+    """The convention is read off ``{{``, which plain JSON cannot produce."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            '{{"a": 1}}',
+            '{{"method":"mtp","n":{n}}}',
+            "{{{k}",
+        ],
+    )
+    def test_doubled_open_is_the_marker(self, text):
+        assert uses_brace_escapes(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "no braces here",
+            "{key}",
+            '{"a": 1}',
+            # The whole point: a trailing '}}' is ordinary nested JSON, never
+            # on its own evidence of escaping.
+            '{"a":{"b":2}}',
+            '{"a":{"b":{"c":3}}}',
+            "awk '{print $1}'",
+        ],
+    )
+    def test_doubled_close_alone_is_not(self, text):
+        assert uses_brace_escapes(text) is False
 
 
 class TestMaskRoundTrip:
@@ -78,9 +109,9 @@ class TestRenderTemplate:
     def test_placeholder_inside_bare_json(self):
         """A placeholder nested in single-brace JSON resolves.
 
-        This is the v2/hook shape: no ``{{`` escaping, just JSON with a
-        placeholder inside it.  vpd alone matches from the JSON's opening brace
-        through the placeholder's closing brace and restores the span verbatim.
+        The unescaped shape: no ``{{``, just JSON with a placeholder inside it.
+        vpd alone matches from the JSON's opening brace through the
+        placeholder's closing brace and restores the span verbatim.
         """
         assert render_template('{"method":"mtp","n":{n}}', {"n": 2}) == '{"method":"mtp","n":2}'
 
@@ -88,7 +119,7 @@ class TestRenderTemplate:
         assert render_template('{"a":{"b":{n}}}', {"n": 1}) == '{"a":{"b":1}}'
 
     def test_placeholder_inside_escaped_json(self):
-        """The v1 shape: escapes collapse, inner placeholder resolves."""
+        """The escaped shape: escapes collapse, inner placeholder resolves."""
         rendered = render_template('{{"method":"mtp","n":{n}}}', {"n": 1}, escapes=True)
 
         assert rendered == '{"method":"mtp","n":1}'


### PR DESCRIPTION
This pull request introduces several enhancements and compatibility improvements to the `run-recipe.sh` shim and the eugr builder, focusing on better upstream alignment, new features, and improved user experience. The most important changes are grouped below.

---

**run-recipe.sh shim improvements:**

* Added support for `-v/--volume LOCAL:CONTAINER` (repeatable), which is mapped to `--executor-args "-v ..."`, aligning with spark-vllm-docker upstream and applying to both solo and multi-node runs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R40) [[2]](diffhunk://#diff-4b98bee26cf754e6fa44090bc30ab40cff80bc4b7df2e1a9acc2bd1bd11c0bdaL29-R33) [[3]](diffhunk://#diff-4b98bee26cf754e6fa44090bc30ab40cff80bc4b7df2e1a9acc2bd1bd11c0bdaR90) [[4]](diffhunk://#diff-4b98bee26cf754e6fa44090bc30ab40cff80bc4b7df2e1a9acc2bd1bd11c0bdaR223-R224)
* Changed handling of `--ray`/`--no-ray` combined with `--solo`: these flags now warn and are ignored instead of erroring, matching upstream behavior. The backend override is resolved after parsing, so a trailing `--solo` suppresses them. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R40) [[2]](diffhunk://#diff-4b98bee26cf754e6fa44090bc30ab40cff80bc4b7df2e1a9acc2bd1bd11c0bdaR235-R240) [[3]](diffhunk://#diff-4b98bee26cf754e6fa44090bc30ab40cff80bc4b7df2e1a9acc2bd1bd11c0bdaL330-R355)
* Improved error handling for `--earlyoom` and `--earlyoom-args`, which are now explicitly rejected with a standard "not supported" message, clarifying why they are unavailable. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R40) [[2]](diffhunk://#diff-4b98bee26cf754e6fa44090bc30ab40cff80bc4b7df2e1a9acc2bd1bd11c0bdaR263-R264)

**eugr builder enhancements (`src/sparkrun/builders/eugr.py`):**

* Added support for the `--exp-b12x` / `--experimental-b12x` preset, including new image/tag constants, logic to select the b12x variant for both pulling and building, and correct handling of build arguments and cache identity. Naming a b12x prebuilt image or using the flag selects the variant in the same way as upstream. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R40) [[2]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611R572-R588) [[3]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR35-R67) [[4]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR85-R110) [[5]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR124-R128) [[6]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eR441-R450) [[7]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL409-R472) [[8]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL457-R511) [[9]](diffhunk://#diff-1f6ee2e1564336638d43d6d692f2e65cc1de214c6d32cf69d42ac91e94df537eL495-R551)
* Updated documentation to describe the new preset, its behavior, and its effect on image selection and building. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R40) [[2]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611R572-R588)

**Testing:**

* Added `tests/test_run_recipe_shim.py` to provide argv-mapping coverage for the shim, driven through its `RUN_RECIPE_DEBUG=1` hook.

**Documentation and compatibility:**

* Updated `CHANGELOG.md` and `RECIPES.md` to reflect the new features and behavior changes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R40) [[2]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611R572-R588)
* Clarified in comments and help text how new and changed flags behave, including upstream compatibility notes. [[1]](diffhunk://#diff-4b98bee26cf754e6fa44090bc30ab40cff80bc4b7df2e1a9acc2bd1bd11c0bdaL29-R33) [[2]](diffhunk://#diff-4b98bee26cf754e6fa44090bc30ab40cff80bc4b7df2e1a9acc2bd1bd11c0bdaR90)

These changes ensure closer alignment with upstream behavior, introduce new useful features, and improve the clarity and robustness of both the user interface and internal logic.