### PR TITLE
fix(vram): size MLA KV caches from the compressed latent, add nvfp4_ds_mla

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -597,9 +597,13 @@ Before launching, sparkrun can pre-sync models and container images from the con
 - **VRAM estimation** (`models/vram.py`): Estimates VRAM usage based on model parameter count, dtype, and quantization.
   Supports HuggingFace model auto-detection to resolve parameter counts. KV cache sizing has two paths: the generic
   `2 * layers * kv_heads * head_dim * bytes` formula, and an **MLA** path for DeepSeek architectures, which cache one
-  compressed latent per token per layer. MLA is selected by `kv_lora_rank` in the HF config or by a fixed-slot KV
-  layout named in the recipe (`nvfp4_ds_mla` / `fp8_ds_mla`, sized from `_MLA_SLOT_BYTES` and DeepSeek V4's per-layer
-  `compress_ratios`). The MLA latent cache is **replicated across TP ranks**, so only pipeline parallelism divides it.
+  compressed latent per token per layer. MLA is selected by `kv_lora_rank` / `qk_rope_head_dim` in the HF config or by
+  a fixed-slot KV layout named in the recipe (`nvfp4_ds_mla` / `fp8_ds_mla`, sized from `_MLA_SLOT_BYTES` and DeepSeek
+  V4's per-layer `compress_ratios`). `mla_latent_dim()` normalizes the two config shapes — V2/V3 name the latent and
+  cache the RoPE tail on top of it, V4 folds both into `head_dim` — to the NoPE width, so the tail is counted once.
+  The MLA latent cache is **replicated across TP ranks**, so only pipeline parallelism divides it.
+  `Recipe.estimate_vram()` writes every detected field back into `metadata`, which is what lets later calls skip the
+  HF fetch — so anything read on the way in must also be written back, or it is silently lost on the second call.
 
 ### Kernel Tuning (`tuning/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,7 +595,11 @@ Before launching, sparkrun can pre-sync models and container images from the con
   `docker save | ssh docker load` (`containers/distribute.py`, `containers/sync.py`). Checks image IDs to skip hosts
   that already have the correct image.
 - **VRAM estimation** (`models/vram.py`): Estimates VRAM usage based on model parameter count, dtype, and quantization.
-  Supports HuggingFace model auto-detection to resolve parameter counts.
+  Supports HuggingFace model auto-detection to resolve parameter counts. KV cache sizing has two paths: the generic
+  `2 * layers * kv_heads * head_dim * bytes` formula, and an **MLA** path for DeepSeek architectures, which cache one
+  compressed latent per token per layer. MLA is selected by `kv_lora_rank` in the HF config or by a fixed-slot KV
+  layout named in the recipe (`nvfp4_ds_mla` / `fp8_ds_mla`, sized from `_MLA_SLOT_BYTES` and DeepSeek V4's per-layer
+  `compress_ratios`). The MLA latent cache is **replicated across TP ranks**, so only pipeline parallelism divides it.
 
 ### Kernel Tuning (`tuning/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,6 +604,10 @@ Before launching, sparkrun can pre-sync models and container images from the con
   The MLA latent cache is **replicated across TP ranks**, so only pipeline parallelism divides it.
   `Recipe.estimate_vram()` writes every detected field back into `metadata`, which is what lets later calls skip the
   HF fetch — so anything read on the way in must also be written back, or it is silently lost on the second call.
+  `kv_cache_dtype` is resolved CLI → metadata → HF quant config → `defaults.kv_cache_dtype` → `--kv-cache-dtype`
+  parsed from the `command:` template (last resort, with a warning). When no dtype is resolved, the estimator
+  computes with `bfloat16` but leaves `VRAMEstimate.kv_dtype` as `None` so the CLI formatter can show
+  `bfloat16 (default)` rather than silently reporting a guessed value.
 
 ### Kernel Tuning (`tuning/`)
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -128,10 +128,16 @@ magnitude. sparkrun detects MLA from the HuggingFace config (`qk_rope_head_dim`,
 
 | Field               | Meaning                                                                                  |
 |---------------------|------------------------------------------------------------------------------------------|
-| `kv_lora_rank`      | Compressed-latent dimension. Its presence switches KV sizing to the MLA path.             |
+| `kv_lora_rank`      | Compressed-latent width, **excluding** the RoPE tail. Its presence switches KV sizing to the MLA path. |
 | `qk_rope_head_dim`  | RoPE tail cached alongside the latent.                                                    |
 | `compress_ratios`   | DeepSeek V4 per-layer cache compression; layers at ratio ≤ 1 are sliding-window layers.   |
 | `model_type`        | Selects the packed slot layout (e.g. `deepseek_v4`).                                      |
+| `index_head_dim`    | Sparse-attention indexer width. Not sized; its presence marks the estimate as a floor.     |
+
+The two generations spell the latent differently, and sparkrun normalizes them: V2/V3 name `kv_lora_rank` and cache
+the RoPE tail *in addition* to it (512 + 64 = 576 elements), while V4 has no `kv_lora_rank` and folds both into
+`head_dim` (512 total, of which 64 is the tail). Auto-detection reports the **NoPE width** for both — 512 for V3, 448
+for V4 — so the tail is added exactly once. Pin `kv_lora_rank` by hand only if you are giving the NoPE width.
 
 Runtimes that pack the latent, its block scales and the RoPE tail into a fixed-width uint8 slot are named through
 `kv_dtype` / `defaults.kv_cache_dtype`: `fp8_ds_mla` and `nvfp4_ds_mla` (656 bytes per token per layer; 584 on
@@ -141,8 +147,9 @@ Two consequences worth knowing when reading an estimate:
 
 - **The latent cache is replicated on every tensor-parallel rank** — it has no head dimension to shard — so raising
   `--tp` does not shrink it. Pipeline parallelism still splits it by layer.
-- For DeepSeek V4 the estimate covers the **latent cache only**. The sliding-window and sparse-indexer caches are
-  excluded and reported as a warning.
+- For sparse-attention models the estimate covers the **latent cache only**, so treat it as a floor. DeepSeek V4
+  also keeps a sliding-window cache and V3.2 a sparse-indexer cache (roughly 132 bytes per token per layer); neither
+  is sized. Whichever apply are named in a warning on the estimate.
 
 Use `kv_vram_per_token` to override the whole calculation if a runtime's real footprint differs.
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -119,6 +119,13 @@ sparkrun auto-detects `model_params`, `model_dtype`, `num_layers`, `num_kv_heads
 contains `kv_cache_quant_algo`, it is used to set `kv_dtype` if not already specified. Metadata values always take
 precedence over auto-detected values.
 
+The `kv_cache_dtype` is resolved in priority order: CLI override → `metadata.kv_dtype` → HuggingFace quant config →
+`defaults.kv_cache_dtype` → `--kv-cache-dtype` parsed from the `command:` template (last resort, with a warning).
+When the dtype is resolved from the command template, it is written back to `metadata.kv_dtype` so subsequent
+estimates are stable. When no dtype is resolved at all, the estimator defaults to `bfloat16` for computation but
+leaves `VRAMEstimate.kv_dtype` as `None` so the CLI can display `bfloat16 (default)` rather than silently reporting
+a guessed value.
+
 #### Multi-head Latent Attention (DeepSeek)
 
 MLA models cache one *compressed latent* per token per layer instead of a K and V entry per attention head, so the

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -151,13 +151,18 @@ Two consequences worth knowing when reading an estimate:
   also keeps a sliding-window cache and V3.2 a sparse-indexer cache (roughly 132 bytes per token per layer); neither
   is sized. Whichever apply are named in a warning on the estimate.
 
-Use `kv_vram_per_token` to override the whole calculation if a runtime's real footprint differs.
+Use `kv_vram_per_token` to override the whole calculation if a runtime's real footprint differs. Note it follows
+the same sharding rule: on an MLA model the override is divided by pipeline parallelism only, not by `--tp`, so
+the figure you supply is one rank's replicated latent cache rather than a cluster-wide total.
 
-> **Pinning architecture metadata on an MLA model.** Setting `num_layers`, `num_kv_heads` and `head_dim` in
-> `metadata` suppresses the HuggingFace config fetch, so MLA can no longer be auto-detected and the estimate falls
-> back to the generic formula — for DeepSeek-V3 that reads 122 GB instead of 2.1 GB at 32k context. Pin
-> `qk_rope_head_dim` (and `kv_lora_rank`, unless `head_dim` already holds the latent) alongside them, or name an
-> `*_ds_mla` layout in `kv_dtype`; any one of those signals is enough.
+> **Pinning architecture metadata on an MLA model.** Pinning `num_layers`, `num_kv_heads` and `head_dim` *together
+> with* `model_dtype` (or `model_vram`) suppresses the HuggingFace config fetch — all of them are needed; pinning the
+> three architecture fields alone still leaves `model_dtype` missing, which keeps detection running. Once the fetch is
+> suppressed, MLA can no longer be auto-detected and the estimate falls back to the generic formula: for DeepSeek-V3,
+> 122 GB instead of 2.1 GB at 32k context. Pin `qk_rope_head_dim` (and `kv_lora_rank`, unless `head_dim` already holds
+> the whole cached width) alongside them, or name an `*_ds_mla` layout in `kv_dtype`; any one of those signals is
+> enough. Pinning `qk_rope_head_dim` on its own is accepted but warns, since it cannot distinguish a compressed-latent
+> cache from an ordinary one.
 
 ### Benchmark
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -103,7 +103,7 @@ metadata:
   category: agent
   model_params: 8B           # or 8000000000
   model_dtype: bfloat16      # float32, float16, bfloat16, int8, fp8, int4, awq4, gptq, nvfp4, q4_k_m, q8_0, ...
-  kv_dtype: fp8_e5m2         # KV cache dtype (default: bfloat16)
+  kv_dtype: fp8_e5m2         # KV cache dtype (default: bfloat16); also accepts nvfp4_ds_mla / fp8_ds_mla
   num_layers: 32
   num_kv_heads: 8
   head_dim: 128
@@ -118,6 +118,39 @@ sparkrun auto-detects `model_params`, `model_dtype`, `num_layers`, `num_kv_heads
 `hf_quant_config.json` (modelopt supplement, e.g. NVIDIA NVFP4 models) are checked. When `hf_quant_config.json`
 contains `kv_cache_quant_algo`, it is used to set `kv_dtype` if not already specified. Metadata values always take
 precedence over auto-detected values.
+
+#### Multi-head Latent Attention (DeepSeek)
+
+MLA models cache one *compressed latent* per token per layer instead of a K and V entry per attention head, so the
+generic `2 * num_layers * num_kv_heads * head_dim * bytes` sizing overestimates their KV cache by one to two orders of
+magnitude. sparkrun detects MLA from the HuggingFace config (`qk_rope_head_dim`, plus `kv_lora_rank` on V2/V3 or
+`head_dim` on V4) and sizes the latent cache instead. Auto-detected fields, all overridable in `metadata`:
+
+| Field               | Meaning                                                                                  |
+|---------------------|------------------------------------------------------------------------------------------|
+| `kv_lora_rank`      | Compressed-latent dimension. Its presence switches KV sizing to the MLA path.             |
+| `qk_rope_head_dim`  | RoPE tail cached alongside the latent.                                                    |
+| `compress_ratios`   | DeepSeek V4 per-layer cache compression; layers at ratio ≤ 1 are sliding-window layers.   |
+| `model_type`        | Selects the packed slot layout (e.g. `deepseek_v4`).                                      |
+
+Runtimes that pack the latent, its block scales and the RoPE tail into a fixed-width uint8 slot are named through
+`kv_dtype` / `defaults.kv_cache_dtype`: `fp8_ds_mla` and `nvfp4_ds_mla` (656 bytes per token per layer; 584 on
+DeepSeek V4). Naming one of these is on its own enough to select MLA sizing.
+
+Two consequences worth knowing when reading an estimate:
+
+- **The latent cache is replicated on every tensor-parallel rank** — it has no head dimension to shard — so raising
+  `--tp` does not shrink it. Pipeline parallelism still splits it by layer.
+- For DeepSeek V4 the estimate covers the **latent cache only**. The sliding-window and sparse-indexer caches are
+  excluded and reported as a warning.
+
+Use `kv_vram_per_token` to override the whole calculation if a runtime's real footprint differs.
+
+> **Pinning architecture metadata on an MLA model.** Setting `num_layers`, `num_kv_heads` and `head_dim` in
+> `metadata` suppresses the HuggingFace config fetch, so MLA can no longer be auto-detected and the estimate falls
+> back to the generic formula — for DeepSeek-V3 that reads 122 GB instead of 2.1 GB at 32k context. Pin
+> `qk_rope_head_dim` (and `kv_lora_rank`, unless `head_dim` already holds the latent) alongside them, or name an
+> `*_ds_mla` layout in `kv_dtype`; any one of those signals is enough.
 
 ### Benchmark
 

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -31,6 +31,10 @@ logger = logging.getLogger(__name__)
 _TRAILING_SPACE_CONTINUATION_RE = re.compile(r"\\ +\n")
 
 _RAY_BACKEND_RE = re.compile(r"--distributed-executor-backend\s+ray\b")
+# --kv-cache-dtype (vllm/sglang/atlas: --kv-cache-dtype) or tokenary (--kvcache-dtype),
+# space- or =-separated. Captured so a recipe that sets the flag only inside the
+# free-form command: template is still picked up by the VRAM estimator (issue #248).
+_KV_CACHE_DTYPE_FLAG_RE = re.compile(r"--kv-?cache-dtype[=\s]+(\S+)", re.IGNORECASE)
 _CMD_VLLM_RE = re.compile(r"^vllm\s+serve\b")
 _CMD_SGLANG_RE = re.compile(r"^(?:sglang\s+serve|python3?\s+-m\s+sglang\.launch_server)\b")
 _CMD_LLAMA_CPP_RE = re.compile(r"^llama-server\b")
@@ -308,6 +312,28 @@ def _sort_dict_by_patterns(data: dict[str, Any], patterns: list[str]) -> dict[st
         ordered[k] = data[k]
 
     return ordered
+
+
+def extract_kv_cache_dtype_from_command(command: str | None) -> str | None:
+    """Extract a ``--kv-cache-dtype`` value from a free-form command template.
+
+    Recipes sometimes set the KV cache dtype only inside ``command:`` rather
+    than in ``defaults.kv_cache_dtype`` or ``metadata.kv_dtype``.  Without
+    parsing it, the VRAM estimator silently falls back to ``bfloat16`` and
+    (for MLA models using ``fp8_ds_mla`` / ``nvfp4_ds_mla``) sizes the KV cache
+    with the wrong formula — a ~10x over-estimate (issue #248).
+
+    Returns the first match's value (``"auto"`` treated as absent), or ``None``.
+    """
+    if not command:
+        return None
+    m = _KV_CACHE_DTYPE_FLAG_RE.search(command)
+    if not m:
+        return None
+    value = m.group(1)
+    if value.lower() in ("auto", ""):
+        return None
+    return value
 
 
 def _resolve_runtime_from_command_hint(recipe: Recipe) -> None:
@@ -1415,6 +1441,19 @@ class Recipe:
             if kv_cache_default and str(kv_cache_default) != "auto":
                 kv_dtype = str(kv_cache_default)
 
+        # Last resort: parse --kv-cache-dtype out of the free-form command
+        # template.  Recipes that set the flag only in command: (rather than
+        # in defaults) would otherwise silently fall back to bfloat16 — for
+        # MLA models using fp8_ds_mla / nvfp4_ds_mla that's a ~10x KV-cache
+        # over-estimate (issue #248).  Warn so the user knows the estimate
+        # depends on a command-template parse and is encouraged to pin the
+        # value in defaults/metadata instead.
+        _kv_from_command: str | None = None
+        if not kv_dtype:
+            _kv_from_command = extract_kv_cache_dtype_from_command(self.command)
+            if _kv_from_command:
+                kv_dtype = _kv_from_command
+
         # GPU memory utilization (runtime budget fraction)
         gpu_mem_val = config.get("gpu_memory_utilization")
         gpu_memory_utilization = float(gpu_mem_val) if gpu_mem_val is not None else None
@@ -1439,6 +1478,11 @@ class Recipe:
             model_type=str(model_type) if model_type else None,
             index_head_dim=int(index_head_dim) if index_head_dim is not None else None,
         )
+        if _kv_from_command:
+            result.warnings.append(
+                "kv_cache_dtype %r inferred from command: template; pin it in "
+                "defaults.kv_cache_dtype or metadata.kv_dtype for a stable estimate" % _kv_from_command
+            )
 
         # Write back auto-detected values so downstream consumers
         # (e.g. benchmark result export) can use them without re-fetching.

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -1127,6 +1127,26 @@ class Recipe:
             # a per-element dtype, so they have no bytes_per_element entry.
             if kd is not None and kv_bytes_per_element(str(kd)) is None and not is_mla_kv_layout(str(kd)):
                 issues.append("metadata.kv_dtype %r is not a recognized dtype" % kd)
+            # MLA architecture fields. These are documented as user-overridable
+            # and are coerced with int() in estimate_vram, so an unchecked bad
+            # value surfaces as a traceback from `recipe show --json` — or, on
+            # the launch path, as a debug-level log and a silently dropped
+            # memory claim, which skips the fit check altogether.
+            for _key in ("kv_lora_rank", "qk_rope_head_dim", "index_head_dim"):
+                _val = self.metadata.get(_key)
+                if _val is None:
+                    continue
+                if isinstance(_val, bool) or not isinstance(_val, int) or _val <= 0:
+                    issues.append("metadata.%s %r must be a positive integer" % (_key, _val))
+            cr = self.metadata.get("compress_ratios")
+            if cr is not None:
+                if not isinstance(cr, list) or not cr:
+                    issues.append("metadata.compress_ratios %r must be a non-empty list of integers" % cr)
+                elif any(isinstance(r, bool) or not isinstance(r, int) for r in cr):
+                    issues.append("metadata.compress_ratios must contain only integers")
+            mt = self.metadata.get("model_type")
+            if mt is not None and not isinstance(mt, str):
+                issues.append("metadata.model_type %r must be a string" % mt)
             mq = self.metadata.get("quantization")
             if mq is not None:
                 _KNOWN_QUANT_METHODS = {
@@ -1209,6 +1229,7 @@ class Recipe:
             fetch_model_config,
             fetch_safetensors_params,
             fetch_safetensors_size,
+            is_mla_kv_layout,
             parse_param_count,
         )
         from sparkrun.models.quantization import (
@@ -1226,7 +1247,16 @@ class Recipe:
         model_dtype = normalize_dtype(str(_raw_dtype)) if _raw_dtype else None
         model_params_raw = self.metadata.get("model_params")
         _raw_kv = self.metadata.get("kv_dtype")
-        kv_dtype = normalize_dtype(str(_raw_kv)) if _raw_kv else None
+        # An explicit CLI kv_cache_dtype override always wins over a metadata
+        # value, which may be an auto-write from a previous estimate on this
+        # object.  Without this, a value frozen into metadata on call one
+        # shadows a different override passed on call two — a frozen MLA slot
+        # layout vs generic KV dtype is a ~10x switch.
+        _cli_kv = (cli_overrides or {}).get("kv_cache_dtype")
+        if _cli_kv and str(_cli_kv) not in ("auto", ""):
+            kv_dtype = str(_cli_kv)
+        else:
+            kv_dtype = normalize_dtype(str(_raw_kv)) if _raw_kv else None
         num_layers = self.metadata.get("num_layers")
         num_kv_heads = self.metadata.get("num_kv_heads")
         head_dim = self.metadata.get("head_dim")
@@ -1242,67 +1272,84 @@ class Recipe:
         _storage_dtype: str | None = None  # raw torch_dtype before quant override
         effective_recipe_quant: str | None = None  # recipe-level quantization override
 
-        # Auto-detect from HF if fields are missing and model is specified
-        if auto_detect and self.model:
-            needs_detection = (model_vram is None and (not model_dtype or model_params_raw is None)) or (
-                kv_vram_per_token is None and (not num_layers or not num_kv_heads or not head_dim)
+        # Auto-detect from HF if fields are missing and model is specified.
+        needs_detection = (model_vram is None and (not model_dtype or model_params_raw is None)) or (
+            kv_vram_per_token is None and (not num_layers or not num_kv_heads or not head_dim)
+        )
+        # Even with kv_vram_per_token pinned we must still learn whether the
+        # model is MLA.  The override replaces the KV *sizing* (the user
+        # supplies the exact bytes-per-token), but the *sharding rule* only
+        # depends on the architecture: an MLA latent is replicated across TP
+        # ranks (divided by PP only), an ordinary KV cache shards by TP*PP.
+        # Defaulting to the ordinary rule silently TP-divides the override of a
+        # DeepSeek model, which under-claims memory and lets the scheduler
+        # over-commit a placement.  This cannot be short-circuited by pinned
+        # architecture: pinning num_layers/num_kv_heads/head_dim is exactly how
+        # a user suppresses detection, and they may not have pinned the MLA
+        # markers while delegating KV sizing.  Detection is cheap and
+        # write-back stops it recurring, so always run it here.
+        needs_detection = needs_detection or (
+            kv_vram_per_token is not None
+            and not is_mla_kv_layout(str(kv_dtype or ""))
+            and not (kv_lora_rank or qk_rope_head_dim)
+            and not self.metadata.get("model_type")
+        )
+        if auto_detect and self.model and needs_detection:
+            hf_config = fetch_model_config(self.model, revision=self.model_revision, cache_dir=cache_dir)
+            hf_quant_config = fetch_hf_quant_config(self.model, revision=self.model_revision, cache_dir=cache_dir)
+
+            # Resolve quantization from all sources (works even without hf_config for GGUF)
+            recipe_quant_meta = self.metadata.get("quantization")
+            recipe_quant_default = config.get("quantization")
+            effective_recipe_quant = recipe_quant_meta or (str(recipe_quant_default) if recipe_quant_default else None)
+            quant_info = resolve_quantization(
+                hf_config=hf_config,
+                hf_quant_config=hf_quant_config,
+                recipe_quant=effective_recipe_quant,
+                model_id=self.model,
             )
-            if needs_detection:
-                hf_config = fetch_model_config(self.model, revision=self.model_revision, cache_dir=cache_dir)
-                hf_quant_config = fetch_hf_quant_config(self.model, revision=self.model_revision, cache_dir=cache_dir)
 
-                # Resolve quantization from all sources (works even without hf_config for GGUF)
-                recipe_quant_meta = self.metadata.get("quantization")
-                recipe_quant_default = config.get("quantization")
-                effective_recipe_quant = recipe_quant_meta or (str(recipe_quant_default) if recipe_quant_default else None)
-                quant_info = resolve_quantization(
-                    hf_config=hf_config,
-                    hf_quant_config=hf_quant_config,
-                    recipe_quant=effective_recipe_quant,
-                    model_id=self.model,
-                )
+            if hf_config:
+                hf_info = extract_model_info(hf_config)
 
-                if hf_config:
-                    hf_info = extract_model_info(hf_config)
+                # use quant_config to capture on disk storage as quantized if it exists
+                # but otherwise fall back to the model dtype
+                _storage_dtype = hf_info.get("quant_dtype") or hf_info.get("model_dtype")
 
-                    # use quant_config to capture on disk storage as quantized if it exists
-                    # but otherwise fall back to the model dtype
-                    _storage_dtype = hf_info.get("quant_dtype") or hf_info.get("model_dtype")
-
-                    # Fill in missing fields (metadata takes precedence)
-                    if not model_dtype:
-                        if quant_info:
-                            model_dtype = quant_info.weight_dtype
-                        else:
-                            model_dtype = _storage_dtype
-                    if not num_layers:
-                        num_layers = hf_info.get("num_layers")
-                    if not num_kv_heads:
-                        num_kv_heads = hf_info.get("num_kv_heads")
-                    if not head_dim:
-                        head_dim = hf_info.get("head_dim")
-
-                    # MLA architectures (DeepSeek V2/V3/V4): the KV cache holds
-                    # a compressed latent per token per layer, so it is sized
-                    # from these rather than num_kv_heads * head_dim.
-                    if not kv_lora_rank:
-                        kv_lora_rank = hf_info.get("kv_lora_rank")
-                    if not qk_rope_head_dim:
-                        qk_rope_head_dim = hf_info.get("qk_rope_head_dim")
-                    if not compress_ratios:
-                        compress_ratios = hf_info.get("compress_ratios")
-                    if not model_type:
-                        model_type = hf_info.get("model_type")
-                    if not index_head_dim:
-                        index_head_dim = hf_info.get("index_head_dim")
-
-                    # Use kv_cache_quant from hf_quant_config to inform kv_dtype
-                    if not kv_dtype and quant_info and quant_info.kv_cache_quant:
-                        kv_dtype = quant_info.kv_cache_quant
-                else:
-                    # No HF config (e.g. GGUF models) — still use quant_info if available
-                    if not model_dtype and quant_info:
+                # Fill in missing fields (metadata takes precedence)
+                if not model_dtype:
+                    if quant_info:
                         model_dtype = quant_info.weight_dtype
+                    else:
+                        model_dtype = _storage_dtype
+                if not num_layers:
+                    num_layers = hf_info.get("num_layers")
+                if not num_kv_heads:
+                    num_kv_heads = hf_info.get("num_kv_heads")
+                if not head_dim:
+                    head_dim = hf_info.get("head_dim")
+
+                # MLA architectures (DeepSeek V2/V3/V4): the KV cache holds
+                # a compressed latent per token per layer, so it is sized
+                # from these rather than num_kv_heads * head_dim.
+                if not kv_lora_rank:
+                    kv_lora_rank = hf_info.get("kv_lora_rank")
+                if not qk_rope_head_dim:
+                    qk_rope_head_dim = hf_info.get("qk_rope_head_dim")
+                if not compress_ratios:
+                    compress_ratios = hf_info.get("compress_ratios")
+                if not model_type:
+                    model_type = hf_info.get("model_type")
+                if not index_head_dim:
+                    index_head_dim = hf_info.get("index_head_dim")
+
+                # Use kv_cache_quant from hf_quant_config to inform kv_dtype
+                if not kv_dtype and quant_info and quant_info.kv_cache_quant:
+                    kv_dtype = quant_info.kv_cache_quant
+            else:
+                # No HF config (e.g. GGUF models) — still use quant_info if available
+                if not model_dtype and quant_info:
+                    model_dtype = quant_info.weight_dtype
 
         # Parse model_params
         model_params = parse_param_count(model_params_raw) if model_params_raw is not None else None
@@ -1362,7 +1409,7 @@ class Recipe:
         pp_val = config.get("pipeline_parallel")
         pipeline_parallel = int(pp_val) if pp_val is not None else 1
 
-        # Check for kv_cache_dtype in defaults (runtime-specific)
+        # Check for kv_cache_dtype in defaults (runtime-specific).
         if not kv_dtype:
             kv_cache_default = config.get("kv_cache_dtype")
             if kv_cache_default and str(kv_cache_default) != "auto":
@@ -1417,7 +1464,12 @@ class Recipe:
             self.metadata["quantization"] = quant_info.method
         if quant_info and quant_info.bits and "quant_bits" not in self.metadata:
             self.metadata["quant_bits"] = quant_info.bits
-        if kv_dtype:
+        # Persist the resolved dtype so benchmark export and telemetry (which
+        # read only metadata) record the KV cache configuration that actually
+        # ran.  The read side now prefers a fresh cli override over this
+        # metadata value, so persisting it cannot shadow a later override the
+        # way it did before.
+        if kv_dtype and "kv_dtype" not in self.metadata:
             self.metadata["kv_dtype"] = normalize_dtype(str(kv_dtype))
         # MLA architecture fields.  A non-MLA model leaves these unset on every
         # call, which re-derives the same (correct) non-MLA verdict.

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -1114,7 +1114,7 @@ class Recipe:
 
         # Validate metadata if present
         if self.metadata:
-            from sparkrun.models.vram import parse_param_count, bytes_per_element
+            from sparkrun.models.vram import parse_param_count, bytes_per_element, is_mla_kv_layout, kv_bytes_per_element
 
             mp = self.metadata.get("model_params")
             if mp is not None and parse_param_count(mp) is None:
@@ -1123,7 +1123,9 @@ class Recipe:
             if md is not None and bytes_per_element(str(md)) is None:
                 issues.append("metadata.model_dtype %r is not a recognized dtype" % md)
             kd = self.metadata.get("kv_dtype")
-            if kd is not None and bytes_per_element(str(kd)) is None:
+            # MLA layouts (nvfp4_ds_mla, fp8_ds_mla) are packed uint8 slots, not
+            # a per-element dtype, so they have no bytes_per_element entry.
+            if kd is not None and kv_bytes_per_element(str(kd)) is None and not is_mla_kv_layout(str(kd)):
                 issues.append("metadata.kv_dtype %r is not a recognized dtype" % kd)
             mq = self.metadata.get("quantization")
             if mq is not None:
@@ -1230,6 +1232,11 @@ class Recipe:
         head_dim = self.metadata.get("head_dim")
         model_vram = self.metadata.get("model_vram")
         kv_vram_per_token = self.metadata.get("kv_vram_per_token")
+        # MLA architecture fields — auto-detected below, overridable in metadata.
+        kv_lora_rank = self.metadata.get("kv_lora_rank")
+        qk_rope_head_dim = self.metadata.get("qk_rope_head_dim")
+        compress_ratios = self.metadata.get("compress_ratios")
+        model_type = self.metadata.get("model_type")
         quant_info: QuantizationInfo | None = None
         _storage_dtype: str | None = None  # raw torch_dtype before quant override
         effective_recipe_quant: str | None = None  # recipe-level quantization override
@@ -1273,6 +1280,18 @@ class Recipe:
                         num_kv_heads = hf_info.get("num_kv_heads")
                     if not head_dim:
                         head_dim = hf_info.get("head_dim")
+
+                    # MLA architectures (DeepSeek V2/V3/V4): the KV cache holds
+                    # a compressed latent per token per layer, so it is sized
+                    # from these rather than num_kv_heads * head_dim.
+                    if not kv_lora_rank:
+                        kv_lora_rank = hf_info.get("kv_lora_rank")
+                    if not qk_rope_head_dim:
+                        qk_rope_head_dim = hf_info.get("qk_rope_head_dim")
+                    if not compress_ratios:
+                        compress_ratios = hf_info.get("compress_ratios")
+                    if not model_type:
+                        model_type = hf_info.get("model_type")
 
                     # Use kv_cache_quant from hf_quant_config to inform kv_dtype
                     if not kv_dtype and quant_info and quant_info.kv_cache_quant:
@@ -1364,6 +1383,10 @@ class Recipe:
             kv_vram_per_token=float(kv_vram_per_token) if kv_vram_per_token is not None else None,
             gpu_memory_utilization=gpu_memory_utilization,
             total_gpu_memory_gb=total_gpu_memory_gb,
+            kv_lora_rank=int(kv_lora_rank) if kv_lora_rank is not None else None,
+            qk_rope_head_dim=int(qk_rope_head_dim) if qk_rope_head_dim is not None else None,
+            compress_ratios=[int(r) for r in compress_ratios] if compress_ratios else None,
+            model_type=str(model_type) if model_type else None,
         )
 
         # Write back auto-detected values so downstream consumers

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -1237,6 +1237,7 @@ class Recipe:
         qk_rope_head_dim = self.metadata.get("qk_rope_head_dim")
         compress_ratios = self.metadata.get("compress_ratios")
         model_type = self.metadata.get("model_type")
+        index_head_dim = self.metadata.get("index_head_dim")
         quant_info: QuantizationInfo | None = None
         _storage_dtype: str | None = None  # raw torch_dtype before quant override
         effective_recipe_quant: str | None = None  # recipe-level quantization override
@@ -1292,6 +1293,8 @@ class Recipe:
                         compress_ratios = hf_info.get("compress_ratios")
                     if not model_type:
                         model_type = hf_info.get("model_type")
+                    if not index_head_dim:
+                        index_head_dim = hf_info.get("index_head_dim")
 
                     # Use kv_cache_quant from hf_quant_config to inform kv_dtype
                     if not kv_dtype and quant_info and quant_info.kv_cache_quant:
@@ -1387,10 +1390,19 @@ class Recipe:
             qk_rope_head_dim=int(qk_rope_head_dim) if qk_rope_head_dim is not None else None,
             compress_ratios=[int(r) for r in compress_ratios] if compress_ratios else None,
             model_type=str(model_type) if model_type else None,
+            index_head_dim=int(index_head_dim) if index_head_dim is not None else None,
         )
 
         # Write back auto-detected values so downstream consumers
         # (e.g. benchmark result export) can use them without re-fetching.
+        #
+        # This must stay complete: the written-back architecture fields satisfy
+        # ``needs_detection`` above, so anything omitted here is lost on the
+        # second call.  A single ``sparkrun run`` estimates three times on one
+        # Recipe (host resolution, the displayed banner, then the scheduling
+        # pass inside ``api.run``), and the last one feeds the placement's
+        # ``ResourceRequest`` — so a partial write-back silently reverts the
+        # estimate on the path that decides where ranks land.
         if model_dtype:
             self.metadata["model_dtype"] = normalize_dtype(str(model_dtype))
         if num_layers is not None and "num_layers" not in self.metadata:
@@ -1407,6 +1419,18 @@ class Recipe:
             self.metadata["quant_bits"] = quant_info.bits
         if kv_dtype:
             self.metadata["kv_dtype"] = normalize_dtype(str(kv_dtype))
+        # MLA architecture fields.  A non-MLA model leaves these unset on every
+        # call, which re-derives the same (correct) non-MLA verdict.
+        if kv_lora_rank is not None and "kv_lora_rank" not in self.metadata:
+            self.metadata["kv_lora_rank"] = int(kv_lora_rank)
+        if qk_rope_head_dim is not None and "qk_rope_head_dim" not in self.metadata:
+            self.metadata["qk_rope_head_dim"] = int(qk_rope_head_dim)
+        if compress_ratios and "compress_ratios" not in self.metadata:
+            self.metadata["compress_ratios"] = [int(r) for r in compress_ratios]
+        if model_type and "model_type" not in self.metadata:
+            self.metadata["model_type"] = str(model_type)
+        if index_head_dim is not None and "index_head_dim" not in self.metadata:
+            self.metadata["index_head_dim"] = int(index_head_dim)
 
         return result
 

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -91,13 +91,21 @@ _KV_DTYPE_BYTES: dict[str, float] = {
 #
 # Keyed by KV cache dtype, then by ``model_type`` (``None`` = the fallback for
 # any MLA model that isn't special-cased).
+# Both figures are verifiable in upstream vLLM (`vllm/v1/kv_cache_interface.py`,
+# `MLAAttentionSpec.real_page_size_bytes`); only the `nvfp4_ds_mla` *spelling*
+# is fork-only, shipping in the DGX Spark overlay (Anemll/dspark-vllm-gx10).
 _MLA_SLOT_BYTES: dict[str, dict[str | None, int]] = {
     # V3.2 sparse MLA: kv_lora_rank 512 in fp8 (512 B) + 4 fp32 block scales
     # (16 B) + qk_rope_head_dim 64 in bfloat16 (128 B) = 656 B.
-    # DeepSeek V4 pads to the 584 B sparse-MLA envelope instead.
+    # DeepSeek V4 instead packs 448 B NoPE + 128 B RoPE + 8 B fp8 scale = 584 B.
     "fp8_ds_mla": {None: 656, "deepseek_v4": 584},
-    # NVFP4 latent + fp8 block scales.  V4 reuses the same 584 B envelope as
-    # fp8_ds_mla (the padding, not the element width, sets the slot size).
+    # V4 reuses that same 584 B envelope for the NVFP4 variant — the padding,
+    # not the element width, sets the slot size.
+    #
+    # The non-V4 fallback is deliberately the *fp8* 656 B figure, not a true
+    # NVFP4 one (which would be nearer 416-448 B): no non-V4 model ships this
+    # layout, so rather than invent a number we over-estimate, which refuses a
+    # borderline placement instead of OOMing it. Revisit if one appears.
     "nvfp4_ds_mla": {None: 656, "deepseek_v4": 584},
 }
 
@@ -223,6 +231,31 @@ def is_mla_kv_layout(kv_dtype: str) -> bool:
     return kv_dtype.lower().strip().replace("-", "_") in _MLA_SLOT_BYTES
 
 
+# HuggingFace ``model_type`` values that delegate to the MLA estimator.
+# These are architecture family names, not domain strings: 'deepseek_v3' means
+# DeepSeek-V3 does Multi-head Latent Attention.  Matching on *prefix* deliberately
+# so a future deepseek_v5 / deepseek_v6 keeps working without a code change.
+_MLA_MODEL_TYPE_PREFIXES = ("deepseek_v", "deepseek2", "kimiko")
+
+
+def _is_mla_model_type(model_type: str | None) -> bool:
+    """Whether *model_type* names an MLA-family architecture.
+
+    ``model_type`` on its own is not a KV provenance guarantee — nothing says a
+    model named ``deepseek_*`` *must* run MLA, and a backend could run it with
+    full attention.  But it is a strong prior: every shipping DeepSeek/Kimi
+    config intends MLA, and the packed-slot estimators for those families exist
+    precisely because they cache a latent.  Used to let a user who pins
+    ``metadata.model_type`` get a consistent MLA verdict even when the latent
+    markers are not pinned alongside it (the ``kv_vram_per_token`` sharding
+    path).
+    """
+    if not model_type:
+        return False
+    t = model_type.lower()
+    return any(t.startswith(p) for p in _MLA_MODEL_TYPE_PREFIXES)
+
+
 def mla_latent_dim(*, kv_lora_rank: int | None = None, head_dim: int | None = None, qk_rope_head_dim: int | None = None) -> int | None:
     """Resolve the non-RoPE part of an MLA model's cached width.
 
@@ -250,6 +283,45 @@ def mla_latent_dim(*, kv_lora_rank: int | None = None, head_dim: int | None = No
     if qk_rope_head_dim and head_dim > qk_rope_head_dim:
         return int(head_dim) - int(qk_rope_head_dim)
     return int(head_dim)
+
+
+def reconcile_compress_ratios(compress_ratios: Sequence[int] | None, num_layers: int | None) -> tuple[Sequence[int] | None, str | None]:
+    """Trim a ``compress_ratios`` list to the model's layer count.
+
+    Upstream vLLM consults ``compress_ratios[layer_id]`` only for
+    ``layer_id < num_hidden_layers`` — DeepSeek-V4-Flash ships 46 entries for
+    43 layers, the extra ones covering MTP / non-standard layers.  Summing the
+    whole list would count caches that are never allocated.
+
+    Returns:
+        ``(ratios, note)`` — the ratios to size from, and a human-readable note
+        when the mismatch is one worth surfacing.  A trailing tail of ``<= 1``
+        entries (the normal V4 shape) changes nothing and is dropped silently;
+        a *short* list, or a trimmed tail that held real compressed layers,
+        would change the estimate and is reported.
+    """
+    if not compress_ratios or not num_layers:
+        return compress_ratios, None
+
+    count = len(compress_ratios)
+    if count == num_layers:
+        return compress_ratios, None
+    if count < num_layers:
+        return compress_ratios, "compress_ratios lists %d layers but the model has %d; the remainder is unsized" % (count, num_layers)
+
+    trimmed = compress_ratios[:num_layers]
+    dropped = [r for r in compress_ratios[num_layers:] if r and r > 1]
+    if dropped:
+        return (
+            trimmed,
+            "compress_ratios lists %d layers but the model has %d; %d compressed layer(s) beyond the layer count were ignored"
+            % (
+                count,
+                num_layers,
+                len(dropped),
+            ),
+        )
+    return trimmed, None
 
 
 def mla_kv_bytes_per_token(
@@ -299,8 +371,9 @@ def mla_kv_bytes_per_token(
             return None
         per_layer = (kv_lora_rank + (qk_rope_head_dim or 0)) * bpe
 
-    if compress_ratios:
-        total = sum(per_layer / r for r in compress_ratios if r and r > 1)
+    ratios, _note = reconcile_compress_ratios(compress_ratios, num_layers)
+    if ratios:
+        total = sum(per_layer / r for r in ratios if r and r > 1)
         # Every entry was <= 1, so no layer contributes a latent cache.  That
         # is 0 bytes, not "0 GB of KV needed" — a zero estimate passes every
         # fit check, so the workload would be placed with no KV headroom and
@@ -706,7 +779,24 @@ def _extract_from_config(cfg: dict[str, Any]) -> dict[str, Any]:
     if "index_head_dim" in cfg:
         info["index_head_dim"] = cfg["index_head_dim"]
 
+    # Extracted here rather than only at the top level so a multimodal wrapper's
+    # *text* model_type is reachable — it is the one that selects the KV slot
+    # layout, and it lives in the nested config alongside the MLA markers.
+    if cfg.get("model_type"):
+        info["model_type"] = cfg["model_type"]
+
     return info
+
+
+# Architecture keys that make an estimate possible at all.  Their absence is
+# what sends :func:`extract_model_info` looking in a nested sub-config.
+_CORE_ARCH_KEYS = frozenset({"model_dtype", "num_layers", "num_kv_heads", "head_dim"})
+
+# MLA markers.  Kept separate from the core set because a top-level config can
+# be complete for the core keys yet carry no MLA fields at all — which is both
+# how an ordinary model looks and how a multimodal wrapper around an MLA text
+# model looks.  Only the nested config can tell them apart.
+_MLA_ARCH_KEYS = frozenset({"kv_lora_rank", "qk_rope_head_dim", "compress_ratios", "index_head_dim"})
 
 
 def extract_model_info(hf_config: dict[str, Any]) -> dict[str, Any]:
@@ -724,15 +814,15 @@ def extract_model_info(hf_config: dict[str, Any]) -> dict[str, Any]:
     """
     info = _extract_from_config(hf_config)
 
-    model_type = hf_config.get("model_type")
-    if model_type:
-        info["model_type"] = model_type
-
-    # For multimodal / composite models the text architecture lives in a
-    # nested sub-config.  Check common nesting keys when the top-level
-    # extraction is missing architecture fields.
-    _NEEDED = {"model_dtype", "num_layers", "num_kv_heads", "head_dim"}
-    if not _NEEDED.issubset(info.keys()):
+    # For multimodal / composite models the text architecture lives in a nested
+    # sub-config.  Consult it when the top level is missing core architecture
+    # fields *or* carries no MLA markers — a wrapper around an MLA text model
+    # can be complete for the core keys while hiding every MLA field below, and
+    # gating on the core keys alone would silently size it as ordinary
+    # attention (a ~14x overestimate that refuses placements).
+    needs_core = not _CORE_ARCH_KEYS.issubset(info.keys())
+    needs_mla = _MLA_ARCH_KEYS.isdisjoint(info.keys())
+    if needs_core or needs_mla:
         for nested_key in ("text_config", "llm_config", "language_config"):
             nested = hf_config.get(nested_key)
             if isinstance(nested, dict):
@@ -741,7 +831,15 @@ def extract_model_info(hf_config: dict[str, Any]) -> dict[str, Any]:
                 for k, v in nested_info.items():
                     if k not in info:
                         info[k] = v
+                # The KV slot layout is a property of the *text* model, so when
+                # the MLA markers came from the nested config its model_type
+                # outranks the wrapper's (deepseek_v4, not deepseek_vl_v2).
+                if nested_info.get("model_type") and not _MLA_ARCH_KEYS.isdisjoint(nested_info.keys()):
+                    info["model_type"] = nested_info["model_type"]
                 break  # only use the first matching nested config
+
+    if not info.get("model_type") and hf_config.get("model_type"):
+        info["model_type"] = hf_config["model_type"]
 
     # Extract quantization dtype from quantization_config if present.
     # This is more accurate than torch_dtype for quantized models (e.g.
@@ -792,7 +890,9 @@ def estimate_vram(
         tensor_parallel: Tensor parallelism degree.
         pipeline_parallel: Pipeline parallelism degree.
         model_vram: Direct override for model weight VRAM in GB (not scaled by TP/PP).
-        kv_vram_per_token: Direct override for KV cache in GB per token (scaled by max_model_len and TP*PP).
+        kv_vram_per_token: Direct override for KV cache in GB per token (scaled by max_model_len,
+            then divided by TP*PP — or by PP alone under MLA, whose latent cache every TP rank
+            holds a full copy of).
         gpu_memory_utilization: Fraction of GPU memory the runtime is allowed to use (e.g. 0.9).
         total_gpu_memory_gb: Per-GPU memory of the *target* accelerator (e.g. 48 for an
             RTX A6000). Defaults to the DGX Spark figure when unset, preserving the
@@ -836,17 +936,58 @@ def estimate_vram(
     kv_cache_total_gb: float | None = None
 
     # MLA models cache one compressed latent per token per layer.  Detected
-    # either from the architecture (kv_lora_rank / qk_rope_head_dim) or from an
-    # MLA-specific KV layout named by the recipe (fp8_ds_mla / nvfp4_ds_mla).
-    is_mla = bool(kv_lora_rank or qk_rope_head_dim) or is_mla_kv_layout(kv_dtype)
+    # either from the architecture (kv_lora_rank / qk_rope_head_dim), from an
+    # MLA-specific KV layout named by the recipe (fp8_ds_mla / nvfp4_ds_mla),
+    # or from a model_type that *means* MLA (deepseek_v2/v3/v4, kimi_k2, ...).
+    # Consulting model_type matters for the kv_vram_per_token path: the override
+    # delegates KV *sizing* to the user, but the *sharding rule* still needs the
+    # architecture — and a user who pins model_type: deepseek_v4 is declaring
+    # it, so the client and the sizing decision must agree.
+    is_mla = bool(kv_lora_rank or qk_rope_head_dim) or is_mla_kv_layout(kv_dtype) or _is_mla_model_type(model_type)
 
     # Same normalization _extract_from_config applies, so a recipe that pins
     # head_dim + qk_rope_head_dim in metadata gets MLA sizing without naming
     # kv_lora_rank separately — and gets the same width either way.
     mla_latent = mla_latent_dim(kv_lora_rank=kv_lora_rank, head_dim=head_dim, qk_rope_head_dim=qk_rope_head_dim)
 
+    # `qk_rope_head_dim` on its own is a weak signal.  Auto-detection always
+    # resolves a latent alongside it (every shipping DeepSeek/Kimi config names
+    # kv_lora_rank, or is V4-shaped), so this only arises from hand-pinned
+    # metadata — and there it is worth flagging, because sizing a non-MLA model
+    # this way drops the 2 * num_kv_heads factor and *under*-estimates, which
+    # OOMs at runtime rather than refusing the placement.
+    if is_mla and not kv_lora_rank and qk_rope_head_dim and not is_mla_kv_layout(kv_dtype):
+        warnings.append(
+            "MLA sizing inferred from qk_rope_head_dim alone, using head_dim as the cached width; "
+            "pin metadata.kv_lora_rank (or kv_vram_per_token) if this model does not use a compressed KV cache"
+        )
+    # The mirror image: kv_lora_rank on its own silently drops the RoPE tail.
+    # The generic path sizes (kv_lora_rank + qk_rope_head_dim) elements, so
+    # omitting the tail reads `kv_lora_rank * bytes` — an ~11% under-estimate
+    # for DeepSeek-V3 (62,464 vs 70,272), again in the OOM direction.  Same
+    # reachability: auto-detection always pairs the fields, so this is a
+    # hand-pinned-metadata footgun.
+    elif is_mla and kv_lora_rank and not qk_rope_head_dim and not is_mla_kv_layout(kv_dtype):
+        warnings.append(
+            "MLA sizing inferred from kv_lora_rank alone; the RoPE tail (qk_rope_head_dim) is not counted. "
+            "Pin metadata.qk_rope_head_dim if this model caches the tail alongside the latent"
+        )
+    # An MLA KV layout is authoritative on its own — but if the model shows no
+    # architectural MLA marker at all, it is being forced onto a non-MLA model,
+    # which sizes the latent instead of the real heads and *under*-estimates by
+    # ~170x (Qwen3-32B: 656 B/layer/token vs ~113 KB).  Reachable only by an
+    # explicit `kv_dtype: nvfp4_ds_mla` on such a model; worth a loud warning.
+    elif is_mla and is_mla_kv_layout(kv_dtype) and not (kv_lora_rank or qk_rope_head_dim):
+        warnings.append(
+            "KV layout %r forces MLA sizing but the model has no MLA architecture markers; "
+            "this under-estimates a non-MLA model. Pin metadata.kv_lora_rank or remove the layout" % kv_dtype
+        )
+
     if kv_vram_per_token is not None:
-        # Direct override: user provides GB per token
+        # Direct override: user provides GB per token.  Note this still goes
+        # through the MLA sharding rule below — an override on an MLA model is
+        # divided by PP only, not TP*PP, since the figure describes one rank's
+        # replicated latent cache rather than a shardable whole.
         kv_cache_per_token_bytes = kv_vram_per_token * (1024**3)  # convert to bytes for display
         if max_model_len:
             kv_cache_total_gb = kv_vram_per_token * max_model_len
@@ -866,6 +1007,8 @@ def estimate_vram(
             # layer count, or a compress_ratios list with nothing above 1.
             if compress_ratios and not any(r and r > 1 for r in compress_ratios):
                 reason = "no compress_ratios entry above 1, so no layer holds a latent cache"
+            elif compress_ratios and num_layers and len(compress_ratios) < num_layers and any(r and r > 1 for r in compress_ratios):
+                reason = "compress_ratios lists %d layers but the model has %d" % (len(compress_ratios), num_layers)
             elif not is_mla_kv_layout(kv_dtype) and not mla_latent:
                 reason = "no kv_lora_rank/head_dim to size the compressed latent from"
             elif not is_mla_kv_layout(kv_dtype) and kv_bytes_per_element(kv_dtype) is None:
@@ -882,6 +1025,9 @@ def estimate_vram(
             # is understood as a floor.  Keying this on compress_ratios alone
             # would silently skip DeepSeek V3.2, which has a sparse indexer but
             # no per-layer compression.
+            _ratios, ratio_note = reconcile_compress_ratios(compress_ratios, num_layers)
+            if ratio_note:
+                warnings.append(ratio_note)
             excluded = []
             if compress_ratios and any(not r or r <= 1 for r in compress_ratios):
                 excluded.append("sliding-window")

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -882,7 +882,10 @@ def estimate_vram(
     Args:
         model_params: Total parameter count.
         model_dtype: Weight dtype (e.g. "float16", "int4", "fp8").
-        kv_dtype: KV cache dtype (default: "bfloat16").
+        kv_dtype: KV cache dtype. ``None`` means "unset" — the estimator falls
+            back to ``"bfloat16"`` for computation but leaves ``VRAMEstimate.kv_dtype``
+            as ``None`` so display code can distinguish an explicit dtype from a
+            defaulted one (issue #248).
         num_layers: Number of transformer layers.
         num_kv_heads: Number of KV attention heads.
         head_dim: Dimension per attention head.
@@ -910,7 +913,13 @@ def estimate_vram(
         VRAMEstimate with per-GPU totals and any warnings.
     """
     warnings: list[str] = []
-    kv_dtype = kv_dtype or "bfloat16"
+    # Apply the bfloat16 fallback only at computation sites, not on the value
+    # returned in VRAMEstimate.kv_dtype.  Keeping the original (possibly None)
+    # lets the CLI formatter distinguish an explicit dtype from a defaulted one
+    # and show "bfloat16 (default)" — without this, the fallback was baked into
+    # est.kv_dtype itself and the display code's (default) branch never fired
+    # (issue #248).
+    kv_dtype_effective = kv_dtype or "bfloat16"
     tp = max(tensor_parallel, 1)
     pp = max(pipeline_parallel, 1)
     shard_factor = tp * pp
@@ -943,7 +952,7 @@ def estimate_vram(
     # delegates KV *sizing* to the user, but the *sharding rule* still needs the
     # architecture — and a user who pins model_type: deepseek_v4 is declaring
     # it, so the client and the sizing decision must agree.
-    is_mla = bool(kv_lora_rank or qk_rope_head_dim) or is_mla_kv_layout(kv_dtype) or _is_mla_model_type(model_type)
+    is_mla = bool(kv_lora_rank or qk_rope_head_dim) or is_mla_kv_layout(kv_dtype_effective) or _is_mla_model_type(model_type)
 
     # Same normalization _extract_from_config applies, so a recipe that pins
     # head_dim + qk_rope_head_dim in metadata gets MLA sizing without naming
@@ -956,7 +965,7 @@ def estimate_vram(
     # metadata — and there it is worth flagging, because sizing a non-MLA model
     # this way drops the 2 * num_kv_heads factor and *under*-estimates, which
     # OOMs at runtime rather than refusing the placement.
-    if is_mla and not kv_lora_rank and qk_rope_head_dim and not is_mla_kv_layout(kv_dtype):
+    if is_mla and not kv_lora_rank and qk_rope_head_dim and not is_mla_kv_layout(kv_dtype_effective):
         warnings.append(
             "MLA sizing inferred from qk_rope_head_dim alone, using head_dim as the cached width; "
             "pin metadata.kv_lora_rank (or kv_vram_per_token) if this model does not use a compressed KV cache"
@@ -967,7 +976,7 @@ def estimate_vram(
     # for DeepSeek-V3 (62,464 vs 70,272), again in the OOM direction.  Same
     # reachability: auto-detection always pairs the fields, so this is a
     # hand-pinned-metadata footgun.
-    elif is_mla and kv_lora_rank and not qk_rope_head_dim and not is_mla_kv_layout(kv_dtype):
+    elif is_mla and kv_lora_rank and not qk_rope_head_dim and not is_mla_kv_layout(kv_dtype_effective):
         warnings.append(
             "MLA sizing inferred from kv_lora_rank alone; the RoPE tail (qk_rope_head_dim) is not counted. "
             "Pin metadata.qk_rope_head_dim if this model caches the tail alongside the latent"
@@ -977,10 +986,10 @@ def estimate_vram(
     # which sizes the latent instead of the real heads and *under*-estimates by
     # ~170x (Qwen3-32B: 656 B/layer/token vs ~113 KB).  Reachable only by an
     # explicit `kv_dtype: nvfp4_ds_mla` on such a model; worth a loud warning.
-    elif is_mla and is_mla_kv_layout(kv_dtype) and not (kv_lora_rank or qk_rope_head_dim):
+    elif is_mla and is_mla_kv_layout(kv_dtype_effective) and not (kv_lora_rank or qk_rope_head_dim):
         warnings.append(
             "KV layout %r forces MLA sizing but the model has no MLA architecture markers; "
-            "this under-estimates a non-MLA model. Pin metadata.kv_lora_rank or remove the layout" % kv_dtype
+            "this under-estimates a non-MLA model. Pin metadata.kv_lora_rank or remove the layout" % kv_dtype_effective
         )
 
     if kv_vram_per_token is not None:
@@ -993,7 +1002,7 @@ def estimate_vram(
             kv_cache_total_gb = kv_vram_per_token * max_model_len
     elif is_mla:
         kv_cache_per_token_bytes = mla_kv_bytes_per_token(
-            kv_dtype=kv_dtype,
+            kv_dtype=kv_dtype_effective,
             num_layers=num_layers,
             kv_lora_rank=mla_latent,
             qk_rope_head_dim=qk_rope_head_dim,
@@ -1009,10 +1018,10 @@ def estimate_vram(
                 reason = "no compress_ratios entry above 1, so no layer holds a latent cache"
             elif compress_ratios and num_layers and len(compress_ratios) < num_layers and any(r and r > 1 for r in compress_ratios):
                 reason = "compress_ratios lists %d layers but the model has %d" % (len(compress_ratios), num_layers)
-            elif not is_mla_kv_layout(kv_dtype) and not mla_latent:
+            elif not is_mla_kv_layout(kv_dtype_effective) and not mla_latent:
                 reason = "no kv_lora_rank/head_dim to size the compressed latent from"
-            elif not is_mla_kv_layout(kv_dtype) and kv_bytes_per_element(kv_dtype) is None:
-                reason = "unknown KV cache dtype %r" % kv_dtype
+            elif not is_mla_kv_layout(kv_dtype_effective) and kv_bytes_per_element(kv_dtype_effective) is None:
+                reason = "unknown KV cache dtype %r" % kv_dtype_effective
             elif not num_layers:
                 reason = "num_layers unavailable"
             else:
@@ -1039,14 +1048,14 @@ def estimate_vram(
                     % (" and ".join(excluded), "s are" if len(excluded) > 1 else " is")
                 )
     elif num_layers and num_kv_heads and head_dim:
-        kv_bpe = kv_bytes_per_element(kv_dtype)
+        kv_bpe = kv_bytes_per_element(kv_dtype_effective)
         if kv_bpe is not None:
             # Per token: 2 (K+V) * num_layers * num_kv_heads * head_dim * bytes
             kv_cache_per_token_bytes = 2.0 * num_layers * num_kv_heads * head_dim * kv_bpe
             if max_model_len:
                 kv_cache_total_gb = kv_cache_per_token_bytes * max_model_len / (1024**3)
         else:
-            warnings.append("Unknown KV cache dtype %r" % kv_dtype)
+            warnings.append("Unknown KV cache dtype %r" % kv_dtype_effective)
     else:
         missing = []
         if not num_layers:

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -71,6 +72,35 @@ _DTYPE_BYTES: dict[str, float] = {
     "tq2_0": 0.3125,
 }
 
+# Bytes per element for dtypes whose *KV cache* packing differs from their
+# weight packing.  Consulted by :func:`kv_bytes_per_element` before
+# :data:`_DTYPE_BYTES`.
+#
+# NVFP4 KV cache stores fp8 block scales alongside the fp4 data (one scale
+# per 16 elements), so the packed last dimension is
+# ``head_size // 2 + head_size // 16`` — 0.5625 bytes per element, not 0.5.
+_KV_DTYPE_BYTES: dict[str, float] = {
+    "nvfp4": 0.5625,
+    "w4a16_nvfp4": 0.5625,
+}
+
+# Fixed-width KV slot layouts used by DeepSeek Multi-head Latent Attention
+# runtimes.  These backends pack the compressed latent, its block scales and
+# the RoPE tail into one padded uint8 slot per token per layer, so the
+# footprint is a constant rather than ``2 * heads * head_dim * bytes``.
+#
+# Keyed by KV cache dtype, then by ``model_type`` (``None`` = the fallback for
+# any MLA model that isn't special-cased).
+_MLA_SLOT_BYTES: dict[str, dict[str | None, int]] = {
+    # V3.2 sparse MLA: kv_lora_rank 512 in fp8 (512 B) + 4 fp32 block scales
+    # (16 B) + qk_rope_head_dim 64 in bfloat16 (128 B) = 656 B.
+    # DeepSeek V4 pads to the 584 B sparse-MLA envelope instead.
+    "fp8_ds_mla": {None: 656, "deepseek_v4": 584},
+    # NVFP4 latent + fp8 block scales.  V4 reuses the same 584 B envelope as
+    # fp8_ds_mla (the padding, not the element width, sets the slot size).
+    "nvfp4_ds_mla": {None: 656, "deepseek_v4": 584},
+}
+
 # Shorthand suffixes for parameter counts
 _PARAM_SUFFIXES = {
     "T": 1_000_000_000_000,
@@ -113,6 +143,18 @@ class VRAMEstimate:
     num_layers: int | None = None
     num_kv_heads: int | None = None
     head_dim: int | None = None
+
+    # Multi-head Latent Attention
+    mla: bool = False
+    """Whether the KV cache was sized as an MLA compressed latent cache."""
+
+    kv_cache_replicated: bool = False
+    """Whether the KV cache is duplicated on every tensor-parallel rank.
+
+    True for MLA: the compressed latent has no head dimension to shard, so each
+    TP rank holds the full cache and ``tensor_parallel`` does not reduce the
+    per-GPU KV footprint (pipeline parallelism still splits it by layer).
+    """
 
     # GPU memory budget fields
     gpu_memory_utilization: float | None = None
@@ -163,6 +205,76 @@ def normalize_dtype(dtype: str) -> str:
 def bytes_per_element(dtype: str) -> float | None:
     """Return bytes per element for a dtype string, or None if unknown."""
     return _DTYPE_BYTES.get(dtype.lower().strip().replace("-", "_"))
+
+
+def kv_bytes_per_element(dtype: str) -> float | None:
+    """Return bytes per KV-cache element for a dtype string, or None if unknown.
+
+    Same as :func:`bytes_per_element` except for dtypes whose KV cache packing
+    carries extra per-block scale bytes (see :data:`_KV_DTYPE_BYTES`).
+    """
+    key = dtype.lower().strip().replace("-", "_")
+    override = _KV_DTYPE_BYTES.get(key)
+    return override if override is not None else _DTYPE_BYTES.get(key)
+
+
+def is_mla_kv_layout(kv_dtype: str) -> bool:
+    """Whether *kv_dtype* names one of the fixed-width DeepSeek MLA KV layouts."""
+    return kv_dtype.lower().strip().replace("-", "_") in _MLA_SLOT_BYTES
+
+
+def mla_kv_bytes_per_token(
+    *,
+    kv_dtype: str,
+    num_layers: int | None = None,
+    kv_lora_rank: int | None = None,
+    qk_rope_head_dim: int | None = None,
+    compress_ratios: Sequence[int] | None = None,
+    model_type: str | None = None,
+) -> float | None:
+    """Bytes of KV cache per token for a Multi-head Latent Attention model.
+
+    MLA stores one *compressed latent* per token per layer instead of a K and V
+    entry per attention head, so the generic
+    ``2 * num_layers * num_kv_heads * head_dim * bytes`` formula overestimates
+    it by one to two orders of magnitude.
+
+    Two sizings are supported:
+
+    - **Fixed-slot layouts** (``fp8_ds_mla`` / ``nvfp4_ds_mla``): the backend
+      packs the latent, its block scales and the RoPE tail into a padded uint8
+      slot of constant width — see :data:`_MLA_SLOT_BYTES`.
+    - **Everything else**: ``(kv_lora_rank + qk_rope_head_dim)`` elements per
+      layer at the KV dtype's element width.
+
+    ``compress_ratios`` is DeepSeek V4's per-layer cache compression (from the
+    HF config key of the same name).  A layer with ratio ``r > 1`` stores one
+    slot per ``r`` tokens; layers with ratio ``<= 1`` are sliding-window layers
+    whose cache is bounded by ``sliding_window`` rather than ``max_model_len``,
+    so they contribute nothing at this scale and are excluded.
+
+    Returns:
+        Bytes per token summed over all layers, or ``None`` when neither
+        sizing has enough information.
+    """
+    key = kv_dtype.lower().strip().replace("-", "_")
+
+    slots = _MLA_SLOT_BYTES.get(key)
+    if slots is not None:
+        per_layer: float = slots.get(model_type, slots[None])
+    else:
+        if not kv_lora_rank:
+            return None
+        bpe = kv_bytes_per_element(key)
+        if bpe is None:
+            return None
+        per_layer = (kv_lora_rank + (qk_rope_head_dim or 0)) * bpe
+
+    if compress_ratios:
+        return sum(per_layer / r for r in compress_ratios if r and r > 1)
+    if not num_layers:
+        return None
+    return per_layer * num_layers
 
 
 def parse_param_count(value: int | float | str) -> int | None:
@@ -533,6 +645,22 @@ def _extract_from_config(cfg: dict[str, Any]) -> dict[str, Any]:
                 info["head_dim"] = cfg["hidden_size"] // cfg[key]
                 break
 
+    # Multi-head Latent Attention (DeepSeek V2/V3/V4).  ``qk_rope_head_dim`` is
+    # the marker: these models cache one compressed latent per token per layer,
+    # so the KV cache must be sized from the latent dim rather than from
+    # num_kv_heads * head_dim.  V2/V3 name the latent ``kv_lora_rank``; V4
+    # carries it in ``head_dim`` instead.
+    if "qk_rope_head_dim" in cfg:
+        info["qk_rope_head_dim"] = cfg["qk_rope_head_dim"]
+        latent = cfg.get("kv_lora_rank") or info.get("head_dim")
+        if latent:
+            info["kv_lora_rank"] = latent
+
+    # DeepSeek V4 per-layer KV cache compression.
+    ratios = cfg.get("compress_ratios")
+    if isinstance(ratios, list):
+        info["compress_ratios"] = ratios
+
     return info
 
 
@@ -545,9 +673,15 @@ def extract_model_info(hf_config: dict[str, Any]) -> dict[str, Any]:
     as a fallback when top-level extraction yields incomplete results.
 
     Returns:
-        Dict with keys: model_dtype, num_layers, num_kv_heads, head_dim (present only if found).
+        Dict with keys: model_dtype, num_layers, num_kv_heads, head_dim,
+        model_type, and — for MLA architectures — kv_lora_rank,
+        qk_rope_head_dim, compress_ratios (present only if found).
     """
     info = _extract_from_config(hf_config)
+
+    model_type = hf_config.get("model_type")
+    if model_type:
+        info["model_type"] = model_type
 
     # For multimodal / composite models the text architecture lives in a
     # nested sub-config.  Check common nesting keys when the top-level
@@ -594,6 +728,10 @@ def estimate_vram(
     kv_vram_per_token: float | None = None,
     gpu_memory_utilization: float | None = None,
     total_gpu_memory_gb: float | None = None,
+    kv_lora_rank: int | None = None,
+    qk_rope_head_dim: int | None = None,
+    compress_ratios: Sequence[int] | None = None,
+    model_type: str | None = None,
 ) -> VRAMEstimate:
     """Estimate VRAM usage for an inference workload.
 
@@ -613,6 +751,12 @@ def estimate_vram(
         total_gpu_memory_gb: Per-GPU memory of the *target* accelerator (e.g. 48 for an
             RTX A6000). Defaults to the DGX Spark figure when unset, preserving the
             legacy single-platform estimate.
+        kv_lora_rank: MLA compressed-latent dimension. Its presence (or an MLA KV
+            layout in ``kv_dtype``) switches KV sizing to the MLA path.
+        qk_rope_head_dim: MLA RoPE tail dimension, cached alongside the latent.
+        compress_ratios: DeepSeek V4 per-layer KV cache compression ratios.
+        model_type: HuggingFace ``model_type``; selects the MLA slot layout
+            (e.g. ``deepseek_v4``).
 
     Returns:
         VRAMEstimate with per-GPU totals and any warnings.
@@ -643,13 +787,42 @@ def estimate_vram(
     kv_cache_per_token_bytes: float | None = None
     kv_cache_total_gb: float | None = None
 
+    # MLA models cache one compressed latent per token per layer.  Detected
+    # either from the architecture (kv_lora_rank / qk_rope_head_dim) or from an
+    # MLA-specific KV layout named by the recipe (fp8_ds_mla / nvfp4_ds_mla).
+    is_mla = bool(kv_lora_rank or qk_rope_head_dim) or is_mla_kv_layout(kv_dtype)
+
+    # Mirrors _extract_from_config: V2/V3 name the latent kv_lora_rank, V4
+    # carries it in head_dim.  Lets a recipe that pins head_dim + qk_rope_head_dim
+    # in metadata get MLA sizing without naming kv_lora_rank separately.
+    mla_latent = kv_lora_rank or (head_dim if qk_rope_head_dim else None)
+
     if kv_vram_per_token is not None:
         # Direct override: user provides GB per token
         kv_cache_per_token_bytes = kv_vram_per_token * (1024**3)  # convert to bytes for display
         if max_model_len:
             kv_cache_total_gb = kv_vram_per_token * max_model_len
+    elif is_mla:
+        kv_cache_per_token_bytes = mla_kv_bytes_per_token(
+            kv_dtype=kv_dtype,
+            num_layers=num_layers,
+            kv_lora_rank=mla_latent,
+            qk_rope_head_dim=qk_rope_head_dim,
+            compress_ratios=compress_ratios,
+            model_type=model_type,
+        )
+        if kv_cache_per_token_bytes is None:
+            is_mla = False
+            warnings.append("Cannot size MLA KV cache for dtype %r; KV cache estimate unavailable" % kv_dtype)
+        else:
+            if max_model_len:
+                kv_cache_total_gb = kv_cache_per_token_bytes * max_model_len / (1024**3)
+            if compress_ratios:
+                warnings.append(
+                    "MLA estimate covers the compressed latent cache only; sliding-window and sparse-indexer caches are not included"
+                )
     elif num_layers and num_kv_heads and head_dim:
-        kv_bpe = bytes_per_element(kv_dtype)
+        kv_bpe = kv_bytes_per_element(kv_dtype)
         if kv_bpe is not None:
             # Per token: 2 (K+V) * num_layers * num_kv_heads * head_dim * bytes
             kv_cache_per_token_bytes = 2.0 * num_layers * num_kv_heads * head_dim * kv_bpe
@@ -671,8 +844,11 @@ def estimate_vram(
     # Model weights split across TP * PP GPUs
     per_gpu_weights_gb = model_weights_gb / shard_factor
 
-    # KV heads also split across TP * PP GPUs
-    per_gpu_kv_gb = (kv_cache_total_gb / shard_factor) if kv_cache_total_gb else 0.0
+    # KV heads also split across TP * PP GPUs — except under MLA, where the
+    # compressed latent has no head dimension to shard and every TP rank keeps
+    # a full copy.  Pipeline parallelism still splits it by layer.
+    kv_shard_factor = pp if is_mla else shard_factor
+    per_gpu_kv_gb = (kv_cache_total_gb / kv_shard_factor) if kv_cache_total_gb else 0.0
 
     total_per_gpu_gb = per_gpu_weights_gb + per_gpu_kv_gb
 
@@ -701,7 +877,7 @@ def estimate_vram(
 
         # Estimate max context tokens that fit in available KV space
         if kv_cache_per_token_bytes and kv_cache_per_token_bytes > 0:
-            per_gpu_kv_per_token_gb = (kv_cache_per_token_bytes / shard_factor) / (1024**3)
+            per_gpu_kv_per_token_gb = (kv_cache_per_token_bytes / kv_shard_factor) / (1024**3)
             if per_gpu_kv_per_token_gb > 0:
                 max_context_tokens = int(available_kv_gb / per_gpu_kv_per_token_gb)
 
@@ -723,6 +899,8 @@ def estimate_vram(
         num_layers=num_layers,
         num_kv_heads=num_kv_heads,
         head_dim=head_dim,
+        mla=is_mla,
+        kv_cache_replicated=is_mla,
         gpu_memory_utilization=gpu_memory_utilization,
         total_gpu_memory_gb=_total_gpu_gb,
         usable_gpu_memory_gb=usable_gpu_memory_gb,

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -223,6 +223,35 @@ def is_mla_kv_layout(kv_dtype: str) -> bool:
     return kv_dtype.lower().strip().replace("-", "_") in _MLA_SLOT_BYTES
 
 
+def mla_latent_dim(*, kv_lora_rank: int | None = None, head_dim: int | None = None, qk_rope_head_dim: int | None = None) -> int | None:
+    """Resolve the non-RoPE part of an MLA model's cached width.
+
+    The two DeepSeek generations spell the same quantity differently, and the
+    difference is easy to double-count:
+
+    - **V2/V3** name the latent ``kv_lora_rank`` and cache ``qk_rope_head_dim``
+      *in addition* to it — 512 + 64 = 576 elements for DeepSeek-V3.
+    - **V4** has no ``kv_lora_rank``.  Its ``head_dim`` is the *whole* cached
+      width, with the RoPE tail carved out of it: upstream vLLM computes
+      ``nope_head_dim = head_dim - qk_rope_head_dim`` (512 − 64 = 448) and
+      documents the slot as "448B NoPE + 128B RoPE + 8B fp8 scale = 584B".
+
+    Returning the NoPE width for both shapes lets callers add the tail exactly
+    once, so V4 sizes to ``head_dim`` rather than ``head_dim + qk_rope_head_dim``.
+
+    Returns:
+        The NoPE width in elements, or ``None`` when it can't be resolved.
+    """
+    if kv_lora_rank:
+        return int(kv_lora_rank)
+    if not head_dim:
+        return None
+    # V4 shape: head_dim already contains the tail, so carve it back out.
+    if qk_rope_head_dim and head_dim > qk_rope_head_dim:
+        return int(head_dim) - int(qk_rope_head_dim)
+    return int(head_dim)
+
+
 def mla_kv_bytes_per_token(
     *,
     kv_dtype: str,
@@ -271,7 +300,12 @@ def mla_kv_bytes_per_token(
         per_layer = (kv_lora_rank + (qk_rope_head_dim or 0)) * bpe
 
     if compress_ratios:
-        return sum(per_layer / r for r in compress_ratios if r and r > 1)
+        total = sum(per_layer / r for r in compress_ratios if r and r > 1)
+        # Every entry was <= 1, so no layer contributes a latent cache.  That
+        # is 0 bytes, not "0 GB of KV needed" — a zero estimate passes every
+        # fit check, so the workload would be placed with no KV headroom and
+        # OOM at runtime.  Report it as unsizable and let the caller warn.
+        return total or None
     if not num_layers:
         return None
     return per_layer * num_layers
@@ -649,10 +683,15 @@ def _extract_from_config(cfg: dict[str, Any]) -> dict[str, Any]:
     # the marker: these models cache one compressed latent per token per layer,
     # so the KV cache must be sized from the latent dim rather than from
     # num_kv_heads * head_dim.  V2/V3 name the latent ``kv_lora_rank``; V4
-    # carries it in ``head_dim`` instead.
+    # folds it into ``head_dim`` together with the RoPE tail — see
+    # :func:`mla_latent_dim`, which normalizes both shapes to the NoPE width.
     if "qk_rope_head_dim" in cfg:
         info["qk_rope_head_dim"] = cfg["qk_rope_head_dim"]
-        latent = cfg.get("kv_lora_rank") or info.get("head_dim")
+        latent = mla_latent_dim(
+            kv_lora_rank=cfg.get("kv_lora_rank"),
+            head_dim=info.get("head_dim"),
+            qk_rope_head_dim=cfg["qk_rope_head_dim"],
+        )
         if latent:
             info["kv_lora_rank"] = latent
 
@@ -660,6 +699,12 @@ def _extract_from_config(cfg: dict[str, Any]) -> dict[str, Any]:
     ratios = cfg.get("compress_ratios")
     if isinstance(ratios, list):
         info["compress_ratios"] = ratios
+
+    # DeepSeek sparse attention (V3.2 / V4) keeps a second, separate indexer
+    # cache alongside the latent.  We don't size it, but its presence is what
+    # makes the estimate a floor rather than a total.
+    if "index_head_dim" in cfg:
+        info["index_head_dim"] = cfg["index_head_dim"]
 
     return info
 
@@ -732,6 +777,7 @@ def estimate_vram(
     qk_rope_head_dim: int | None = None,
     compress_ratios: Sequence[int] | None = None,
     model_type: str | None = None,
+    index_head_dim: int | None = None,
 ) -> VRAMEstimate:
     """Estimate VRAM usage for an inference workload.
 
@@ -757,6 +803,8 @@ def estimate_vram(
         compress_ratios: DeepSeek V4 per-layer KV cache compression ratios.
         model_type: HuggingFace ``model_type``; selects the MLA slot layout
             (e.g. ``deepseek_v4``).
+        index_head_dim: DeepSeek sparse-attention indexer width. Not sized, but
+            its presence means the MLA estimate is a floor, which is warned about.
 
     Returns:
         VRAMEstimate with per-GPU totals and any warnings.
@@ -792,10 +840,10 @@ def estimate_vram(
     # MLA-specific KV layout named by the recipe (fp8_ds_mla / nvfp4_ds_mla).
     is_mla = bool(kv_lora_rank or qk_rope_head_dim) or is_mla_kv_layout(kv_dtype)
 
-    # Mirrors _extract_from_config: V2/V3 name the latent kv_lora_rank, V4
-    # carries it in head_dim.  Lets a recipe that pins head_dim + qk_rope_head_dim
-    # in metadata get MLA sizing without naming kv_lora_rank separately.
-    mla_latent = kv_lora_rank or (head_dim if qk_rope_head_dim else None)
+    # Same normalization _extract_from_config applies, so a recipe that pins
+    # head_dim + qk_rope_head_dim in metadata gets MLA sizing without naming
+    # kv_lora_rank separately — and gets the same width either way.
+    mla_latent = mla_latent_dim(kv_lora_rank=kv_lora_rank, head_dim=head_dim, qk_rope_head_dim=qk_rope_head_dim)
 
     if kv_vram_per_token is not None:
         # Direct override: user provides GB per token
@@ -813,13 +861,36 @@ def estimate_vram(
         )
         if kv_cache_per_token_bytes is None:
             is_mla = False
-            warnings.append("Cannot size MLA KV cache for dtype %r; KV cache estimate unavailable" % kv_dtype)
+            # Name the actual reason: blaming the dtype unconditionally is
+            # misleading when the real gap is a missing latent dim, a missing
+            # layer count, or a compress_ratios list with nothing above 1.
+            if compress_ratios and not any(r and r > 1 for r in compress_ratios):
+                reason = "no compress_ratios entry above 1, so no layer holds a latent cache"
+            elif not is_mla_kv_layout(kv_dtype) and not mla_latent:
+                reason = "no kv_lora_rank/head_dim to size the compressed latent from"
+            elif not is_mla_kv_layout(kv_dtype) and kv_bytes_per_element(kv_dtype) is None:
+                reason = "unknown KV cache dtype %r" % kv_dtype
+            elif not num_layers:
+                reason = "num_layers unavailable"
+            else:
+                reason = "insufficient architecture info"
+            warnings.append("Cannot size MLA KV cache (%s); KV cache estimate unavailable" % reason)
         else:
             if max_model_len:
                 kv_cache_total_gb = kv_cache_per_token_bytes * max_model_len / (1024**3)
-            if compress_ratios:
+            # Name the auxiliary caches this estimate leaves out, so the number
+            # is understood as a floor.  Keying this on compress_ratios alone
+            # would silently skip DeepSeek V3.2, which has a sparse indexer but
+            # no per-layer compression.
+            excluded = []
+            if compress_ratios and any(not r or r <= 1 for r in compress_ratios):
+                excluded.append("sliding-window")
+            if index_head_dim:
+                excluded.append("sparse-indexer")
+            if excluded:
                 warnings.append(
-                    "MLA estimate covers the compressed latent cache only; sliding-window and sparse-indexer caches are not included"
+                    "MLA estimate covers the compressed latent cache only; the %s cache%s not included"
+                    % (" and ".join(excluded), "s are" if len(excluded) > 1 else " is")
                 )
     elif num_layers and num_kv_heads and head_dim:
         kv_bpe = kv_bytes_per_element(kv_dtype)

--- a/src/sparkrun/utils/cli_formatters.py
+++ b/src/sparkrun/utils/cli_formatters.py
@@ -309,11 +309,16 @@ def display_vram_estimate(
     if est.model_params:
         click.echo(f"  Model params:     {est.model_params:,}")
     click.echo(f"  KV cache dtype:   {est.kv_dtype or 'bfloat16 (default)'}")
-    if all([est.num_layers, est.num_kv_heads, est.head_dim]):
+    if est.mla:
+        click.echo("  Architecture:     MLA (compressed latent KV cache)")
+    elif all([est.num_layers, est.num_kv_heads, est.head_dim]):
         click.echo(f"  Architecture:     {est.num_layers} layers, {est.num_kv_heads} KV heads, {est.head_dim} head_dim")
     click.echo(f"  Model weights:    {est.model_weights_gb:.2f} GB")
     if est.kv_cache_total_gb is not None:
-        click.echo(f"  KV cache:         {est.kv_cache_total_gb:.2f} GB (max_model_len={est.max_model_len:,})")
+        # MLA's latent cache has no head dimension to shard, so it is duplicated
+        # on every TP rank — worth saying, since raising --tp won't shrink it.
+        replicated = " — replicated per rank" if est.kv_cache_replicated and est.tensor_parallel > 1 else ""
+        click.echo(f"  KV cache:         {est.kv_cache_total_gb:.2f} GB (max_model_len={est.max_model_len:,}){replicated}")
     click.echo(f"  Tensor parallel:  {est.tensor_parallel}")
     if est.pipeline_parallel > 1:
         click.echo(f"  Pipeline parallel: {est.pipeline_parallel}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,3 +297,30 @@ def log_sources_spy(monkeypatch):
 
     monkeypatch.setattr("sparkrun.orchestration.logs.print_log_sources", _capture)
     return calls
+
+
+@pytest.fixture
+def deepseek_v4_config() -> dict[str, Any]:
+    """Return an abridged DeepSeek-V4-Flash-0731 ``config.json``.
+
+    Carries the fields the VRAM estimator reads for a Multi-head Latent
+    Attention model: ``head_dim`` holds the compressed latent (V2/V3 name it
+    ``kv_lora_rank`` instead), and ``compress_ratios`` gives 21 layers at ratio
+    4 and 20 at ratio 128.  The ratio-0 layers are sliding-window and hold no
+    latent cache.
+
+    Returns:
+        Dictionary of HuggingFace config fields.
+    """
+    return {
+        "model_type": "deepseek_v4",
+        "torch_dtype": "bfloat16",
+        "num_hidden_layers": 43,
+        "num_attention_heads": 64,
+        "num_key_value_heads": 1,
+        "hidden_size": 4096,
+        "head_dim": 512,
+        "qk_rope_head_dim": 64,
+        "sliding_window": 128,
+        "compress_ratios": [0, 0] + [4, 128] * 20 + [4, 0, 0, 0],
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,4 +323,61 @@ def deepseek_v4_config() -> dict[str, Any]:
         "qk_rope_head_dim": 64,
         "sliding_window": 128,
         "compress_ratios": [0, 0] + [4, 128] * 20 + [4, 0, 0, 0],
+        # Sparse attention: a second cache the estimator does not size.
+        "index_head_dim": 128,
+        "index_topk": 512,
+    }
+
+
+@pytest.fixture
+def deepseek_v3_config() -> dict[str, Any]:
+    """Return an abridged DeepSeek-V3 ``config.json``.
+
+    The other MLA shape: V2/V3 name the compressed latent ``kv_lora_rank``
+    explicitly and cache ``qk_rope_head_dim`` *in addition* to it, so the KV
+    width is ``512 + 64`` elements.  There is no top-level ``head_dim`` — it is
+    derived as ``hidden_size // num_attention_heads`` — and no
+    ``compress_ratios``.
+
+    Returns:
+        Dictionary of HuggingFace config fields.
+    """
+    return {
+        "model_type": "deepseek_v3",
+        "torch_dtype": "bfloat16",
+        "num_hidden_layers": 61,
+        "num_attention_heads": 128,
+        "num_key_value_heads": 128,
+        "hidden_size": 7168,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "qk_nope_head_dim": 128,
+        "v_head_dim": 128,
+    }
+
+
+@pytest.fixture
+def deepseek_v32_config() -> dict[str, Any]:
+    """Return an abridged DeepSeek-V3.2-Exp ``config.json``.
+
+    The shape that exposed the auxiliary-cache warning gap: sparse attention
+    (``index_head_dim``) with **no** ``compress_ratios``, so a warning keyed on
+    per-layer compression alone would never fire for it — even though its
+    indexer cache is a full KV peer worth roughly 132 B per token per layer.
+
+    Returns:
+        Dictionary of HuggingFace config fields.
+    """
+    return {
+        "model_type": "deepseek_v32",
+        "torch_dtype": "bfloat16",
+        "num_hidden_layers": 61,
+        "num_attention_heads": 128,
+        "num_key_value_heads": 128,
+        "hidden_size": 7168,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "index_head_dim": 128,
+        "index_n_heads": 64,
+        "index_topk": 2048,
     }

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1003,6 +1003,25 @@ def test_recipe_get_default():
     assert recipe.get_default("nonexistent", "fallback") == "fallback"
 
 
+def test_extract_kv_cache_dtype_from_command():
+    """The command-template parser picks up --kv-cache-dtype in space and equals forms."""
+    from sparkrun.core.recipe import extract_kv_cache_dtype_from_command
+
+    # Space-separated
+    assert extract_kv_cache_dtype_from_command("vllm serve {model} --kv-cache-dtype fp8_ds_mla --port 8000") == "fp8_ds_mla"
+    # Equals-separated
+    assert extract_kv_cache_dtype_from_command("vllm serve {model} --kv-cache-dtype=fp8 --port 8000") == "fp8"
+    # tokenary's --kvcache-dtype (no dash between kv and cache)
+    assert extract_kv_cache_dtype_from_command("tokenary --m {model} --kvcache-dtype nvfp4") == "nvfp4"
+    # auto is treated as absent
+    assert extract_kv_cache_dtype_from_command("vllm serve {model} --kv-cache-dtype auto") is None
+    # No flag present
+    assert extract_kv_cache_dtype_from_command("vllm serve {model} --port 8000") is None
+    # None / empty
+    assert extract_kv_cache_dtype_from_command(None) is None
+    assert extract_kv_cache_dtype_from_command("") is None
+
+
 def test_recipe_load_nonexistent_file():
     """Verify that Recipe.load() raises RecipeError for non-existent files.
 
@@ -1405,6 +1424,127 @@ class TestRecipeMetadata:
         )
         est = recipe.estimate_vram(auto_detect=False)
         assert est.kv_dtype == "fp8"
+
+    def test_estimate_vram_kv_dtype_from_command_template(self):
+        """--kv-cache-dtype in command: is parsed when no defaults/metadata value exists.
+
+        Issue #248: the flag was silently ignored, falling back to bfloat16 and
+        doubling the KV cache estimate for MLA models using fp8_ds_mla.
+        """
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "test-model",
+                "metadata": {
+                    "model_params": "7B",
+                    "model_dtype": "float16",
+                    "num_layers": 32,
+                    "num_kv_heads": 32,
+                    "head_dim": 128,
+                },
+                "defaults": {"max_model_len": 4096},
+                "command": "vllm serve {model} --kv-cache-dtype fp8 --max-model-len {max_model_len}",
+            }
+        )
+        est = recipe.estimate_vram(auto_detect=False)
+        assert est.kv_dtype == "fp8"
+        # The estimate should match an explicit fp8 kv_dtype
+        assert est.kv_cache_per_token_bytes == pytest.approx(2.0 * 32 * 32 * 128 * 1)
+        # A warning should fire so the user knows it was inferred from the template
+        assert any("inferred from command" in w for w in est.warnings)
+
+    def test_estimate_vram_kv_dtype_from_command_equals_form(self):
+        """--kv-cache-dtype=fp8 (equals form) is also parsed from command:."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "test-model",
+                "metadata": {
+                    "model_params": "7B",
+                    "model_dtype": "float16",
+                    "num_layers": 32,
+                    "num_kv_heads": 32,
+                    "head_dim": 128,
+                },
+                "defaults": {"max_model_len": 4096},
+                "command": "vllm serve {model} --kv-cache-dtype=fp8 --max-model-len {max_model_len}",
+            }
+        )
+        est = recipe.estimate_vram(auto_detect=False)
+        assert est.kv_dtype == "fp8"
+
+    def test_estimate_vram_kv_dtype_command_ignored_when_defaults_present(self):
+        """When defaults.kv_cache_dtype is set, command: parsing is skipped (no warning)."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "test-model",
+                "metadata": {
+                    "model_params": "7B",
+                    "model_dtype": "float16",
+                    "num_layers": 32,
+                    "num_kv_heads": 32,
+                    "head_dim": 128,
+                },
+                "defaults": {"max_model_len": 4096, "kv_cache_dtype": "fp8"},
+                "command": "vllm serve {model} --kv-cache-dtype bfloat16",
+            }
+        )
+        est = recipe.estimate_vram(auto_detect=False)
+        # defaults wins over command:
+        assert est.kv_dtype == "fp8"
+        # no "inferred from command" warning since defaults provided the value
+        assert not any("inferred from command" in w for w in est.warnings)
+
+    def test_estimate_vram_kv_dtype_command_auto_is_ignored(self):
+        """--kv-cache-dtype auto in command: is treated as absent (no dtype inferred)."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "test-model",
+                "metadata": {
+                    "model_params": "7B",
+                    "model_dtype": "float16",
+                    "num_layers": 32,
+                    "num_kv_heads": 32,
+                    "head_dim": 128,
+                },
+                "defaults": {"max_model_len": 4096},
+                "command": "vllm serve {model} --kv-cache-dtype auto --max-model-len {max_model_len}",
+            }
+        )
+        est = recipe.estimate_vram(auto_detect=False)
+        # auto is treated as absent — est.kv_dtype stays None (defaulted to bfloat16)
+        assert est.kv_dtype is None
+        # no "inferred from command" warning
+        assert not any("inferred from command" in w for w in est.warnings)
+
+    def test_estimate_vram_kv_dtype_from_command_writeback_idempotent(self):
+        """The command-inferred dtype is written back to metadata so the second call doesn't re-parse."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "test-model",
+                "metadata": {
+                    "model_params": "7B",
+                    "model_dtype": "float16",
+                    "num_layers": 32,
+                    "num_kv_heads": 32,
+                    "head_dim": 128,
+                },
+                "defaults": {"max_model_len": 4096},
+                "command": "vllm serve {model} --kv-cache-dtype fp8 --max-model-len {max_model_len}",
+            }
+        )
+        est1 = recipe.estimate_vram(auto_detect=False)
+        assert est1.kv_dtype == "fp8"
+        assert any("inferred from command" in w for w in est1.warnings)
+        # metadata was written back
+        assert recipe.metadata["kv_dtype"] == "fp8"
+        # second call: metadata provides the value, no command parsing, no warning
+        est2 = recipe.estimate_vram(auto_detect=False)
+        assert est2.kv_dtype == "fp8"
+        assert not any("inferred from command" in w for w in est2.warnings)
 
     def test_estimate_vram_nvfp4_ds_mla_from_defaults(self, deepseek_v4_config):
         """kv_cache_dtype: nvfp4_ds_mla plus an auto-detected MLA config sizes the latent cache.

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -3257,9 +3257,10 @@ class TestEstimateVramIdempotency:
         return (est.mla, est.kv_cache_per_token_bytes, est.kv_cache_total_gb, est.total_per_gpu_gb)
 
     def test_fixed_slot_mla_is_stable(self, deepseek_v4_config):
-        """V4 + nvfp4_ds_mla: kv_dtype survives the write-back, but model_type and
-        compress_ratios did not — so a regression here keeps mla=True while
-        silently falling back to 43 x 656 B/token."""
+        """V4 + nvfp4_ds_mla on defaults: model_type and compress_ratios come from
+        detection; without the full write-back a repeat call keeps mla=True but
+        silently falls back to 43 x 656 B/token (model_type/compress_ratios
+        lost). The estimate must be identical on every call."""
         recipe = Recipe.from_dict(
             {
                 "name": "Test",
@@ -3354,3 +3355,332 @@ class TestEstimateVramIdempotency:
         # deepseek_v32 is not in the V4 slot table, so it takes the 656 B fallback.
         assert {self._signature(e) for e in results} == {self._signature(results[0])}
         assert results[0].kv_cache_per_token_bytes == pytest.approx(656 * 5.40625)
+
+
+class TestMlaMetadataValidation:
+    """The MLA fields are documented as user-overridable, so they must validate.
+
+    `estimate_vram` coerces them with `int()`. Unchecked, a bad value is a raw
+    traceback out of `recipe show --json`, and on the launch path it is caught,
+    logged at debug, and the memory claim is dropped — silently skipping the
+    fit check for that run.
+    """
+
+    @staticmethod
+    def _issues(metadata):
+        recipe = Recipe.from_dict({"name": "Test", "model": "test-model", "metadata": metadata})
+        return [i for i in recipe.validate() if "metadata." in i]
+
+    @pytest.mark.parametrize(
+        ("metadata", "expected_key"),
+        [
+            pytest.param({"compress_ratios": 4}, "compress_ratios", id="ratios-scalar"),
+            pytest.param({"compress_ratios": "4,128"}, "compress_ratios", id="ratios-string"),
+            pytest.param({"compress_ratios": []}, "compress_ratios", id="ratios-empty"),
+            pytest.param({"compress_ratios": [4, "128"]}, "compress_ratios", id="ratios-mixed"),
+            pytest.param({"kv_lora_rank": "big"}, "kv_lora_rank", id="latent-string"),
+            pytest.param({"kv_lora_rank": -1}, "kv_lora_rank", id="latent-negative"),
+            pytest.param({"qk_rope_head_dim": 0}, "qk_rope_head_dim", id="rope-zero"),
+            pytest.param({"index_head_dim": 1.5}, "index_head_dim", id="index-float"),
+            pytest.param({"model_type": 4}, "model_type", id="model-type-int"),
+        ],
+    )
+    def test_rejects_malformed_values(self, metadata, expected_key):
+        issues = self._issues(metadata)
+        assert any(expected_key in i for i in issues), issues
+
+    def test_accepts_well_formed_values(self):
+        assert (
+            self._issues(
+                {
+                    "kv_lora_rank": 448,
+                    "qk_rope_head_dim": 64,
+                    "index_head_dim": 128,
+                    "model_type": "deepseek_v4",
+                    "compress_ratios": [0, 0, 4, 128],
+                }
+            )
+            == []
+        )
+
+    def test_bools_are_not_integers(self):
+        """`True` is an int in Python; it is not a valid dimension."""
+        assert self._issues({"kv_lora_rank": True})
+        assert self._issues({"compress_ratios": [True, 4]})
+
+    def test_absent_fields_are_fine(self):
+        assert self._issues({}) == []
+
+    def test_validation_catches_what_would_otherwise_traceback(self):
+        """The same value that validate() now rejects used to reach int()."""
+        recipe = Recipe.from_dict({"name": "Test", "model": "m", "metadata": {"compress_ratios": 4}})
+        assert recipe.validate()
+        with pytest.raises(TypeError):
+            recipe.estimate_vram(auto_detect=False)
+
+
+class TestOverrideDoesNotSuppressMlaDetection:
+    """Pinning kv_vram_per_token replaces KV *sizing*, not the *sharding rule*.
+
+    The override delegates the bytes-per-token to the user, but the sharding
+    rule still depends on the architecture: an MLA latent is replicated across
+    TP ranks (divided by PP only), an ordinary KV cache shards by TP*PP. If
+    pinning the override also suppressed HF detection, a DeepSeek model would
+    silently default to the ordinary rule and TP-divide the override — an
+    under-claim that lets the scheduler over-commit (OOM) a placement.
+    """
+
+    def _run(self, recipe, hf_config):
+        with (
+            mock.patch("sparkrun.models.vram.fetch_model_config", return_value=hf_config) as fetch,
+            mock.patch("sparkrun.models.quantization.fetch_hf_quant_config", return_value=None),
+            mock.patch("sparkrun.models.vram.fetch_safetensors_size", return_value=None),
+            mock.patch("sparkrun.models.vram.fetch_safetensors_params", return_value=None),
+        ):
+            est = recipe.estimate_vram()
+        return est, fetch.call_count
+
+    def test_mla_override_is_pp_divided_not_tp(self, deepseek_v4_config):
+        """The override on a DeepSeek V4 model must be /pp, not /(tp*pp)."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {"model_vram": 340.0, "kv_vram_per_token": 1e-5},
+                "defaults": {"max_model_len": 100000, "tensor_parallel": 4, "pipeline_parallel": 2},
+            }
+        )
+        est, fetches = self._run(recipe, deepseek_v4_config)
+        per_gpu_kv = est.total_per_gpu_gb - est.model_weights_gb / 8
+        # KV override = 1e-5 * 100000 = 1.0 GB; /pp(2) = 0.5, not /(tp*pp)=0.125
+        assert est.mla
+        assert est.kv_cache_replicated
+        assert per_gpu_kv == pytest.approx(0.5)
+        assert fetches == 1
+
+    def test_detection_runs_despite_pinned_architecture(self, deepseek_v4_config):
+        """Pinning num_layers/num_kv_heads/head_dim must not suppress MLA detection here."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {
+                    "model_vram": 340.0,
+                    "kv_vram_per_token": 1e-5,
+                    "num_layers": 43,
+                    "num_kv_heads": 1,
+                    "head_dim": 512,
+                },
+                "defaults": {"max_model_len": 100000, "tensor_parallel": 4, "pipeline_parallel": 2},
+            }
+        )
+        est, fetches = self._run(recipe, deepseek_v4_config)
+        assert est.mla and est.kv_cache_replicated
+        assert fetches == 1
+
+    def test_pinned_mla_markers_skip_the_fetch(self, deepseek_v4_config):
+        """Explicit MLA markers are enough; do not re-fetch."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {"model_vram": 340.0, "kv_vram_per_token": 1e-5, "kv_lora_rank": 448, "qk_rope_head_dim": 64},
+                "defaults": {"max_model_len": 100000, "tensor_parallel": 4, "pipeline_parallel": 2},
+            }
+        )
+        _, fetches = self._run(recipe, deepseek_v4_config)
+        assert fetches == 0
+
+    def test_non_mla_override_fetches_once_then_is_stable(self):
+        hf = {
+            "model_type": "qwen3",
+            "torch_dtype": "bfloat16",
+            "num_hidden_layers": 64,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 8,
+            "hidden_size": 5120,
+            "head_dim": 128,
+        }
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "Qwen/Qwen3-32B",
+                "metadata": {"model_vram": 60.0, "kv_vram_per_token": 1e-5},
+                "defaults": {"max_model_len": 100000, "tensor_parallel": 2},
+            }
+        )
+        first, n1 = self._run(recipe, hf)
+        second, n2 = self._run(recipe, hf)
+        assert not first.mla
+        assert n1 == 1 and n2 == 0  # model_type written back stops the refetch
+        assert first.total_per_gpu_gb == second.total_per_gpu_gb
+
+
+class TestPinnedModelTypeIsMla:
+    """A pinned model_type that *means* MLA must render a real MLA verdict.
+
+    The kv_vram_per_token detection clause short-circuits on a pinned
+    model_type; that is only safe if the sizing path agrees that an MLA
+    model_type is MLA. Without this, pinning model_type: deepseek_v4 +
+    kv_vram_per_token + architecture (but no latent markers) skipped detection,
+    is_mla resolved False, and the override was divided by TP*PP instead of PP —
+    the exact mis-sharding R2-P2 set out to remove.
+    """
+
+    def _run(self, recipe, hf_config):
+        with (
+            mock.patch("sparkrun.models.vram.fetch_model_config", return_value=hf_config) as fetch,
+            mock.patch("sparkrun.models.quantization.fetch_hf_quant_config", return_value=None),
+            mock.patch("sparkrun.models.vram.fetch_safetensors_size", return_value=None),
+            mock.patch("sparkrun.models.vram.fetch_safetensors_params", return_value=None),
+        ):
+            est = recipe.estimate_vram()
+        return est, fetch.call_count
+
+    def test_pinned_mla_model_type_shards_pp_only(self, deepseek_v4_config):
+        """model_type: deepseek_v4 + override -> PP division, no HF fetch needed."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {
+                    "model_vram": 340.0,
+                    "kv_vram_per_token": 1e-5,
+                    "model_type": "deepseek_v4",
+                    "num_layers": 43,
+                    "num_kv_heads": 1,
+                    "head_dim": 512,
+                },
+                "defaults": {"max_model_len": 100000, "tensor_parallel": 4, "pipeline_parallel": 2},
+            }
+        )
+        est, fetches = self._run(recipe, deepseek_v4_config)
+        per_gpu_kv = est.total_per_gpu_gb - est.model_weights_gb / 8
+        assert est.mla and est.kv_cache_replicated
+        assert per_gpu_kv == pytest.approx(0.5)  # PP-only, not TP*PP (0.125)
+        assert fetches == 0
+
+    def test_pinned_non_mla_model_type_shards_tp_pp(self):
+        """A genuinely non-MLA model_type keeps the ordinary rule."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "Qwen/Qwen3-32B",
+                "metadata": {"model_vram": 60.0, "kv_vram_per_token": 1e-5, "model_type": "qwen3"},
+                "defaults": {"max_model_len": 100000, "tensor_parallel": 4, "pipeline_parallel": 2},
+            }
+        )
+        est, _ = self._run(
+            recipe,
+            {
+                "model_type": "qwen3",
+                "torch_dtype": "bfloat16",
+                "num_hidden_layers": 64,
+                "num_attention_heads": 64,
+                "num_key_value_heads": 8,
+                "hidden_size": 5120,
+                "head_dim": 128,
+            },
+        )
+        assert not est.mla
+        per_gpu_kv = est.total_per_gpu_gb - est.model_weights_gb / 8
+        assert per_gpu_kv == pytest.approx(1e-5 * 100000 / 8)  # /(tp*pp)
+
+    def test_auto_detected_mla_model_type_still_works(self, deepseek_v4_config):
+        """No pinned model_type -> detection runs and fills it in."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {"model_vram": 340.0, "kv_vram_per_token": 1e-5},
+                "defaults": {"max_model_len": 100000, "tensor_parallel": 4, "pipeline_parallel": 2},
+            }
+        )
+        est, fetches = self._run(recipe, deepseek_v4_config)
+        assert est.mla and est.kv_cache_replicated
+        assert fetches == 1
+
+
+class TestConfigChainKvDtypeIsExported:
+    """A kv_cache_dtype from defaults/cli must reach metadata for export.
+
+    benchmark export and telemetry read only recipe.metadata["kv_dtype"], and
+    the exporter's docstring promises "values written back by Recipe.
+    estimate_vram" — so dropping config-chain dtypes from the write-back made
+    the exported record omit the KV dtype the run actually used.
+    """
+
+    def test_defaults_kv_cache_dtype_is_persisted(self):
+        hf = {
+            "model_type": "qwen3",
+            "torch_dtype": "bfloat16",
+            "num_hidden_layers": 64,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 8,
+            "hidden_size": 5120,
+            "head_dim": 128,
+        }
+        recipe = Recipe.from_dict(
+            {"name": "Test", "model": "Qwen/Qwen3-32B", "metadata": {"model_vram": 60.0}, "defaults": {"kv_cache_dtype": "fp8_e5m2"}}
+        )
+        with (
+            mock.patch("sparkrun.models.vram.fetch_model_config", return_value=hf),
+            mock.patch("sparkrun.models.quantization.fetch_hf_quant_config", return_value=None),
+        ):
+            est = recipe.estimate_vram()
+        assert est.kv_dtype == "fp8_e5m2"
+        assert recipe.metadata.get("kv_dtype") == "fp8_e5m2"
+
+    def test_cli_override_wins_over_auto_written_metadata(self, deepseek_v4_config):
+        """The anti-shadowing read: a fresh cli override beats a frozen metadata value."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {"model_vram": 340.0},
+                "defaults": {"max_model_len": 32768},
+            }
+        )
+
+        def est(**overrides):
+            with (
+                mock.patch("sparkrun.models.vram.fetch_model_config", return_value=deepseek_v4_config),
+                mock.patch("sparkrun.models.quantization.fetch_hf_quant_config", return_value=None),
+                mock.patch("sparkrun.models.vram.fetch_safetensors_size", return_value=None),
+                mock.patch("sparkrun.models.vram.fetch_safetensors_params", return_value=None),
+            ):
+                return recipe.estimate_vram(cli_overrides=overrides or None)
+
+        first = est(kv_cache_dtype="nvfp4_ds_mla")
+        second = est(kv_cache_dtype="bfloat16")
+        assert first.kv_dtype == "nvfp4_ds_mla"
+        assert second.kv_dtype == "bfloat16"
+        assert second.kv_cache_per_token_bytes == pytest.approx(5536.0)
+
+    def test_metadata_pin_beats_defaults(self):
+        """An explicit metadata kv_dtype outranks a defaults value."""
+        hf = {
+            "model_type": "qwen3",
+            "torch_dtype": "bfloat16",
+            "num_hidden_layers": 64,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 8,
+            "hidden_size": 5120,
+            "head_dim": 128,
+        }
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "Qwen/Qwen3-32B",
+                "metadata": {"model_vram": 60.0, "kv_dtype": "fp8"},
+                "defaults": {"kv_cache_dtype": "bfloat16"},
+            }
+        )
+        with (
+            mock.patch("sparkrun.models.vram.fetch_model_config", return_value=hf),
+            mock.patch("sparkrun.models.quantization.fetch_hf_quant_config", return_value=None),
+            mock.patch("sparkrun.models.vram.fetch_safetensors_size", return_value=None),
+            mock.patch("sparkrun.models.vram.fetch_safetensors_params", return_value=None),
+        ):
+            est = recipe.estimate_vram()
+        assert est.kv_dtype == "fp8"

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -3228,3 +3228,129 @@ class TestRecipeSerialization:
         restored = Recipe._deserialize(original.__getstate__())
         restored.resolve({"distributed_executor_backend": "ray"})
         assert restored.runtime == "vllm-ray"
+
+
+class TestEstimateVramIdempotency:
+    """`Recipe.estimate_vram()` must return the same answer on every call.
+
+    The method writes auto-detected architecture back into ``self.metadata`` so
+    later calls skip the HuggingFace fetch.  Any field read on the way in but
+    not written back is silently lost on call two — and a single ``sparkrun
+    run`` estimates three times on one Recipe (host resolution, the displayed
+    banner, then the scheduling pass inside ``api.run`` that builds the
+    placement's ``ResourceRequest``).
+    """
+
+    def _estimate_repeatedly(self, recipe, hf_config, times=3):
+        """Call estimate_vram *times* on one object; return results + fetch count."""
+        with (
+            mock.patch("sparkrun.models.vram.fetch_model_config", return_value=hf_config) as fetch,
+            mock.patch("sparkrun.models.quantization.fetch_hf_quant_config", return_value=None),
+            mock.patch("sparkrun.models.vram.fetch_safetensors_size", return_value=None),
+            mock.patch("sparkrun.models.vram.fetch_safetensors_params", return_value=None),
+        ):
+            results = [recipe.estimate_vram() for _ in range(times)]
+        return results, fetch.call_count
+
+    @staticmethod
+    def _signature(est):
+        return (est.mla, est.kv_cache_per_token_bytes, est.kv_cache_total_gb, est.total_per_gpu_gb)
+
+    def test_fixed_slot_mla_is_stable(self, deepseek_v4_config):
+        """V4 + nvfp4_ds_mla: kv_dtype survives the write-back, but model_type and
+        compress_ratios did not — so a regression here keeps mla=True while
+        silently falling back to 43 x 656 B/token."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {"model_vram": 340.0},
+                "defaults": {"max_model_len": 1048576, "kv_cache_dtype": "nvfp4_ds_mla", "tensor_parallel": 2},
+            }
+        )
+        results, fetches = self._estimate_repeatedly(recipe, deepseek_v4_config)
+
+        assert all(e.mla for e in results)
+        assert {self._signature(e) for e in results} == {self._signature(results[0])}
+        assert results[0].kv_cache_per_token_bytes == pytest.approx(3157.25)
+        # The write-back exists to avoid re-fetching; it must still do that.
+        assert fetches == 1
+
+    def test_generic_dtype_mla_is_stable(self, deepseek_v3_config):
+        """DeepSeek-V3 with an ordinary KV dtype: losing kv_lora_rank drops MLA
+        entirely and reverts to the 2 * layers * kv_heads * head_dim formula."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V3",
+                "metadata": {"model_vram": 350.0},
+                "defaults": {"max_model_len": 32768, "tensor_parallel": 4},
+            }
+        )
+        results, fetches = self._estimate_repeatedly(recipe, deepseek_v3_config)
+
+        assert all(e.mla for e in results)
+        assert {self._signature(e) for e in results} == {self._signature(results[0])}
+        assert results[0].kv_cache_per_token_bytes == 70_272
+        assert fetches == 1
+
+    def test_non_mla_model_is_stable(self):
+        """A model with no MLA markers re-derives the same non-MLA verdict."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "Qwen/Qwen3-32B",
+                "metadata": {"model_vram": 60.0},
+                "defaults": {"max_model_len": 32768, "tensor_parallel": 2},
+            }
+        )
+        hf_config = {
+            "model_type": "qwen3",
+            "torch_dtype": "bfloat16",
+            "num_hidden_layers": 64,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 8,
+            "hidden_size": 5120,
+            "head_dim": 128,
+        }
+        results, fetches = self._estimate_repeatedly(recipe, hf_config)
+
+        assert not any(e.mla for e in results)
+        assert {self._signature(e) for e in results} == {self._signature(results[0])}
+        assert fetches == 1
+
+    def test_mla_fields_are_written_back(self, deepseek_v4_config):
+        """The four MLA fields must land in metadata, like the other detected ones."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {"model_vram": 340.0},
+                "defaults": {"max_model_len": 1048576, "kv_cache_dtype": "nvfp4_ds_mla"},
+            }
+        )
+        self._estimate_repeatedly(recipe, deepseek_v4_config, times=1)
+
+        # V4's NoPE width: head_dim (512) minus the RoPE tail (64).
+        assert recipe.metadata["kv_lora_rank"] == 448
+        assert recipe.metadata["qk_rope_head_dim"] == 64
+        assert recipe.metadata["model_type"] == "deepseek_v4"
+        assert recipe.metadata["compress_ratios"] == deepseek_v4_config["compress_ratios"]
+        assert recipe.metadata["index_head_dim"] == 128
+
+    def test_metadata_overrides_are_not_clobbered(self, deepseek_v4_config):
+        """An explicit metadata value outranks the detected one, on every call."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {"model_vram": 340.0, "model_type": "deepseek_v32"},
+                "defaults": {"max_model_len": 1048576, "kv_cache_dtype": "nvfp4_ds_mla"},
+            }
+        )
+        results, _ = self._estimate_repeatedly(recipe, deepseek_v4_config)
+
+        assert recipe.metadata["model_type"] == "deepseek_v32"
+        # deepseek_v32 is not in the V4 slot table, so it takes the 656 B fallback.
+        assert {self._signature(e) for e in results} == {self._signature(results[0])}
+        assert results[0].kv_cache_per_token_bytes == pytest.approx(656 * 5.40625)

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1406,14 +1406,12 @@ class TestRecipeMetadata:
         est = recipe.estimate_vram(auto_detect=False)
         assert est.kv_dtype == "fp8"
 
-    def test_estimate_vram_nvfp4_ds_mla_from_defaults(self):
+    def test_estimate_vram_nvfp4_ds_mla_from_defaults(self, deepseek_v4_config):
         """kv_cache_dtype: nvfp4_ds_mla plus an auto-detected MLA config sizes the latent cache.
 
         The generic 2 * layers * kv_heads * head_dim formula reads 86 GB for this
         model at 1M context, which would refuse any placement; MLA reads ~3 GB.
         """
-        from tests.test_vram import DEEPSEEK_V4_CONFIG
-
         recipe = Recipe.from_dict(
             {
                 "name": "Test",
@@ -1423,7 +1421,7 @@ class TestRecipeMetadata:
             }
         )
         with (
-            mock.patch("sparkrun.models.vram.fetch_model_config", return_value=DEEPSEEK_V4_CONFIG),
+            mock.patch("sparkrun.models.vram.fetch_model_config", return_value=deepseek_v4_config),
             mock.patch("sparkrun.models.quantization.fetch_hf_quant_config", return_value=None),
         ):
             est = recipe.estimate_vram()

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -6,6 +6,7 @@ import json
 import shlex
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 import pytest
 import yaml
@@ -1211,6 +1212,18 @@ class TestRecipeMetadata:
         issues = recipe.validate()
         assert any("kv_dtype" in i for i in issues)
 
+    @pytest.mark.parametrize("kv_dtype", ["nvfp4_ds_mla", "fp8_ds_mla", "nvfp4"])
+    def test_validate_accepts_mla_kv_layouts(self, kv_dtype):
+        """MLA layouts are packed uint8 slots, not per-element dtypes, but are valid."""
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "test-model",
+                "metadata": {"kv_dtype": kv_dtype},
+            }
+        )
+        assert not any("kv_dtype" in i for i in recipe.validate())
+
     def test_validate_good_metadata(self):
         """Test that valid metadata passes validation without issues."""
         recipe = Recipe.from_dict(
@@ -1392,6 +1405,35 @@ class TestRecipeMetadata:
         )
         est = recipe.estimate_vram(auto_detect=False)
         assert est.kv_dtype == "fp8"
+
+    def test_estimate_vram_nvfp4_ds_mla_from_defaults(self):
+        """kv_cache_dtype: nvfp4_ds_mla plus an auto-detected MLA config sizes the latent cache.
+
+        The generic 2 * layers * kv_heads * head_dim formula reads 86 GB for this
+        model at 1M context, which would refuse any placement; MLA reads ~3 GB.
+        """
+        from tests.test_vram import DEEPSEEK_V4_CONFIG
+
+        recipe = Recipe.from_dict(
+            {
+                "name": "Test",
+                "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                "metadata": {"model_vram": 340.0},
+                "defaults": {"max_model_len": 1048576, "kv_cache_dtype": "nvfp4_ds_mla", "tensor_parallel": 2},
+            }
+        )
+        with (
+            mock.patch("sparkrun.models.vram.fetch_model_config", return_value=DEEPSEEK_V4_CONFIG),
+            mock.patch("sparkrun.models.quantization.fetch_hf_quant_config", return_value=None),
+        ):
+            est = recipe.estimate_vram()
+
+        assert est.mla
+        assert est.kv_dtype == "nvfp4_ds_mla"
+        assert est.kv_cache_per_token_bytes == pytest.approx(3157.25)
+        assert est.kv_cache_total_gb == pytest.approx(3.08, abs=0.01)
+        # Weights shard across the 2 ranks; the MLA latent cache does not.
+        assert est.total_per_gpu_gb == pytest.approx(340.0 / 2 + est.kv_cache_total_gb)
 
     def test_estimate_vram_gpu_memory_utilization(self):
         """Test that gpu_memory_utilization from defaults flows through."""

--- a/tests/test_vram.py
+++ b/tests/test_vram.py
@@ -16,6 +16,7 @@ from sparkrun.models.vram import (
     is_mla_kv_layout,
     kv_bytes_per_element,
     mla_kv_bytes_per_token,
+    mla_latent_dim,
     parse_param_count,
 )
 
@@ -1076,8 +1077,12 @@ class TestExtractModelInfoMla:
         info = extract_model_info(deepseek_v4_config)
         assert info["model_type"] == "deepseek_v4"
         assert info["qk_rope_head_dim"] == 64
-        # V4 carries the latent dim in head_dim rather than kv_lora_rank.
-        assert info["kv_lora_rank"] == 512
+        # V4 has no kv_lora_rank: head_dim (512) is the whole cached width with
+        # the RoPE tail carved out of it, so the NoPE part is 512 - 64 = 448.
+        assert info["kv_lora_rank"] == 448
+        # The contract that matters: NoPE + RoPE reconstructs head_dim exactly,
+        # so the tail is counted once.
+        assert info["kv_lora_rank"] + info["qk_rope_head_dim"] == deepseek_v4_config["head_dim"]
         assert info["compress_ratios"][:4] == [0, 0, 4, 128]
 
     def test_deepseek_v3_uses_kv_lora_rank(self):
@@ -1104,7 +1109,11 @@ class TestMlaDetectionSignals:
     """Each independent signal that should select MLA sizing."""
 
     def test_qk_rope_head_dim_with_pinned_head_dim(self):
-        """A recipe pinning head_dim + qk_rope_head_dim skips HF detection but still gets MLA sizing."""
+        """A recipe pinning head_dim + qk_rope_head_dim skips HF detection but still gets MLA sizing.
+
+        V4 shape: head_dim is the full cached width, so the per-layer footprint
+        is ``head_dim * bytes`` — the RoPE tail must not be added on top.
+        """
         est = estimate_vram(
             model_vram=340.0,
             num_layers=43,
@@ -1114,7 +1123,7 @@ class TestMlaDetectionSignals:
             max_model_len=32768,
         )
         assert est.mla
-        assert est.kv_cache_per_token_bytes == 43 * (512 + 64) * 2.0
+        assert est.kv_cache_per_token_bytes == 43 * 512 * 2.0
 
     def test_kv_lora_rank_alone(self):
         est = estimate_vram(model_vram=340.0, num_layers=61, kv_lora_rank=512, qk_rope_head_dim=64, max_model_len=32768)
@@ -1128,3 +1137,190 @@ class TestMlaDetectionSignals:
         assert not est.mla
         assert not est.kv_cache_replicated
         assert est.kv_cache_per_token_bytes == 2.0 * 64 * 8 * 128 * 2.0
+
+
+class TestMlaLatentDim:
+    """The V2/V3 vs V4 asymmetry that makes the RoPE tail easy to double-count.
+
+    Upstream vLLM sizes V4's MLA cache from ``head_dim`` directly (documented as
+    "448B NoPE + 128B RoPE + 8B fp8 scale = 584B"), but sizes V3.2's from
+    ``kv_lora_rank + qk_rope_head_dim`` (head_size=576).  Normalizing both to
+    the NoPE width lets one formula add the tail exactly once.
+    """
+
+    def test_v3_shape_uses_kv_lora_rank_verbatim(self):
+        """V2/V3 cache the RoPE tail *in addition* to the named latent."""
+        assert mla_latent_dim(kv_lora_rank=512, qk_rope_head_dim=64) == 512
+
+    def test_v4_shape_carves_the_tail_out_of_head_dim(self):
+        """V4 has no kv_lora_rank; head_dim is the whole width."""
+        assert mla_latent_dim(head_dim=512, qk_rope_head_dim=64) == 448
+
+    def test_explicit_kv_lora_rank_wins_over_head_dim(self):
+        """When a config carries both, the named latent is authoritative."""
+        assert mla_latent_dim(kv_lora_rank=512, head_dim=56, qk_rope_head_dim=64) == 512
+
+    def test_degenerate_head_dim_is_not_carved(self):
+        """A head_dim at or below the tail width would go zero/negative."""
+        assert mla_latent_dim(head_dim=64, qk_rope_head_dim=64) == 64
+        assert mla_latent_dim(head_dim=32, qk_rope_head_dim=64) == 32
+
+    def test_unresolvable(self):
+        assert mla_latent_dim(qk_rope_head_dim=64) is None
+        assert mla_latent_dim() is None
+
+    def test_v4_width_matches_upstream_slot_geometry(self, deepseek_v4_config):
+        """End-to-end: the generic-dtype V4 estimate must equal head_dim * bytes.
+
+        Upstream's fp8 slot decomposes as 448 NoPE + 64 RoPE = 512 elements, so
+        a bf16 KV cache is 512 * 2 = 1024 B per token per layer before
+        compression.  Summed over the compressed layers that is 5,536 B/token —
+        adding the tail twice gives 6,228 (+12.5%).
+        """
+        info = extract_model_info(deepseek_v4_config)
+        got = mla_kv_bytes_per_token(
+            kv_dtype="bfloat16",
+            num_layers=info["num_layers"],
+            kv_lora_rank=info["kv_lora_rank"],
+            qk_rope_head_dim=info["qk_rope_head_dim"],
+            compress_ratios=info["compress_ratios"],
+            model_type=info["model_type"],
+        )
+        multiplier = 21 / 4 + 20 / 128  # 5.40625
+        assert got == pytest.approx(512 * 2.0 * multiplier)
+        assert got == pytest.approx(5536.0)
+
+    def test_fixed_slot_path_is_unaffected_by_the_latent(self, deepseek_v4_config):
+        """*_ds_mla short-circuits on the slot table before the latent is read."""
+        kwargs = dict(
+            num_layers=43,
+            compress_ratios=deepseek_v4_config["compress_ratios"],
+            model_type="deepseek_v4",
+            qk_rope_head_dim=64,
+        )
+        assert mla_kv_bytes_per_token(kv_dtype="nvfp4_ds_mla", kv_lora_rank=448, **kwargs) == pytest.approx(3157.25)
+        assert mla_kv_bytes_per_token(kv_dtype="nvfp4_ds_mla", kv_lora_rank=99999, **kwargs) == pytest.approx(3157.25)
+
+
+class TestDegenerateCompressRatios:
+    """A ratio list with nothing above 1 must not read as "0 GB of KV needed".
+
+    ``sum()`` over an empty generator is ``0``, which is not ``None`` — so the
+    unsizable guard would be skipped, ``kv_cache_total_gb`` would be 0.0, and
+    the falsy checks downstream would suppress the per-GPU KV and the context
+    budget too.  A zero claim passes every fit check, so the scheduler places a
+    workload that then OOMs — the one failure mode here that is worse than a
+    refused placement.
+    """
+
+    @pytest.mark.parametrize(
+        "ratios",
+        [
+            pytest.param([0] * 43, id="all-zero"),
+            pytest.param([1] * 43, id="all-one"),
+            pytest.param([0, 1, 0, 1, 1, 0], id="mixed-at-or-below-one"),
+            pytest.param([-4, 0, 1], id="negative"),
+        ],
+    )
+    def test_unsizable_rather_than_zero(self, ratios):
+        assert (
+            mla_kv_bytes_per_token(
+                kv_dtype="nvfp4_ds_mla",
+                num_layers=len(ratios),
+                compress_ratios=ratios,
+                model_type="deepseek_v4",
+            )
+            is None
+        )
+
+    def test_estimate_reports_it_instead_of_claiming_zero(self):
+        est = estimate_vram(
+            model_vram=340.0,
+            kv_dtype="nvfp4_ds_mla",
+            num_layers=43,
+            compress_ratios=[0] * 43,
+            model_type="deepseek_v4",
+            max_model_len=1_048_576,
+        )
+        assert est.kv_cache_total_gb is None
+        assert est.kv_cache_per_token_bytes is None
+        assert not est.mla
+        assert any("Cannot size MLA KV cache" in w for w in est.warnings)
+
+    def test_one_compressed_layer_is_enough(self):
+        """The guard must not swallow a genuinely small but non-zero cache."""
+        got = mla_kv_bytes_per_token(
+            kv_dtype="nvfp4_ds_mla",
+            num_layers=43,
+            compress_ratios=[0] * 42 + [128],
+            model_type="deepseek_v4",
+        )
+        assert got == pytest.approx(584 / 128)
+
+
+class TestUnsizableMlaWarningNamesTheCause:
+    """The warning must name the actual gap, not blame the dtype every time."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            pytest.param(
+                dict(kv_dtype="nvfp4_ds_mla", num_layers=43, compress_ratios=[0] * 43, model_type="deepseek_v4"),
+                "compress_ratios",
+                id="degenerate-ratios",
+            ),
+            pytest.param(dict(kv_dtype="bfloat16", num_layers=61, qk_rope_head_dim=64), "kv_lora_rank", id="no-latent"),
+            pytest.param(dict(kv_dtype="bogus_dtype", num_layers=61, kv_lora_rank=512), "unknown KV cache dtype", id="bad-dtype"),
+            pytest.param(dict(kv_dtype="fp8_ds_mla"), "num_layers", id="no-layers"),
+        ],
+    )
+    def test_reason_is_specific(self, kwargs, expected):
+        est = estimate_vram(model_vram=10.0, max_model_len=4096, **kwargs)
+        assert est.kv_cache_total_gb is None
+        assert any(expected in w for w in est.warnings), est.warnings
+
+
+class TestAuxiliaryCacheWarning:
+    """The estimate is a floor for sparse-attention models; say so.
+
+    Keying the warning on ``compress_ratios`` misses DeepSeek V3.2, which has a
+    sparse indexer but no per-layer compression — an under-estimate of roughly
+    20% delivered with no caveat at all.
+    """
+
+    def _estimate(self, info, **overrides):
+        kwargs = dict(
+            model_vram=340.0,
+            kv_dtype="fp8_ds_mla",
+            max_model_len=32768,
+            num_layers=info.get("num_layers"),
+            num_kv_heads=info.get("num_kv_heads"),
+            head_dim=info.get("head_dim"),
+            kv_lora_rank=info.get("kv_lora_rank"),
+            qk_rope_head_dim=info.get("qk_rope_head_dim"),
+            compress_ratios=info.get("compress_ratios"),
+            model_type=info.get("model_type"),
+            index_head_dim=info.get("index_head_dim"),
+        )
+        kwargs.update(overrides)
+        return estimate_vram(**kwargs)
+
+    def test_v32_warns_about_the_sparse_indexer(self, deepseek_v32_config):
+        info = extract_model_info(deepseek_v32_config)
+        assert info["index_head_dim"] == 128
+        warnings = self._estimate(info).warnings
+        assert any("sparse-indexer" in w for w in warnings), warnings
+        # V3.2 has no sliding-window cache, so the wording must not claim one.
+        assert not any("sliding-window" in w for w in warnings)
+
+    def test_v4_warns_about_both(self, deepseek_v4_config):
+        info = extract_model_info(deepseek_v4_config)
+        warnings = self._estimate(info, kv_dtype="nvfp4_ds_mla").warnings
+        assert any("sliding-window" in w and "sparse-indexer" in w for w in warnings), warnings
+        assert any("caches are not included" in w for w in warnings), warnings
+
+    def test_plain_mla_gets_no_spurious_warning(self, deepseek_v3_config):
+        """DeepSeek-V3 has no auxiliary cache — the estimate is complete."""
+        info = extract_model_info(deepseek_v3_config)
+        assert "index_head_dim" not in info
+        assert self._estimate(info).warnings == []

--- a/tests/test_vram.py
+++ b/tests/test_vram.py
@@ -13,8 +13,26 @@ from sparkrun.models.vram import (
     extract_model_info,
     fetch_safetensors_params,
     fetch_safetensors_size,
+    is_mla_kv_layout,
+    kv_bytes_per_element,
+    mla_kv_bytes_per_token,
     parse_param_count,
 )
+
+# DeepSeek-V4-Flash-0731 config.json (abridged to the fields the estimator reads).
+# 21 layers at compress_ratio 4, 20 at 128; ratio-0 layers are sliding-window.
+DEEPSEEK_V4_CONFIG = {
+    "model_type": "deepseek_v4",
+    "torch_dtype": "bfloat16",
+    "num_hidden_layers": 43,
+    "num_attention_heads": 64,
+    "num_key_value_heads": 1,
+    "hidden_size": 4096,
+    "head_dim": 512,
+    "qk_rope_head_dim": 64,
+    "sliding_window": 128,
+    "compress_ratios": [0, 0] + [4, 128] * 20 + [4, 0, 0, 0],
+}
 
 
 class TestParseParamCount:
@@ -937,3 +955,191 @@ class TestResolveTargetAccelerator:
 
         assert _resolve_target_accelerator(C(), None) == (None, None)
         assert _resolve_target_accelerator(None, None) == (None, None)
+
+
+class TestKvBytesPerElement:
+    """KV cache packing differs from weight packing for NVFP4."""
+
+    def test_nvfp4_kv_includes_block_scales(self):
+        # fp4 data (head_size // 2) + fp8 block scales (head_size // 16)
+        assert bytes_per_element("nvfp4") == 0.5
+        assert kv_bytes_per_element("nvfp4") == 0.5625
+
+    def test_falls_back_to_weight_table(self):
+        assert kv_bytes_per_element("bfloat16") == 2.0
+        assert kv_bytes_per_element("fp8") == 1.0
+
+    def test_unknown_dtype(self):
+        assert kv_bytes_per_element("not-a-dtype") is None
+
+
+class TestMlaKvLayout:
+    """Fixed-width DeepSeek MLA KV slot layouts."""
+
+    def test_recognized_layouts(self):
+        assert is_mla_kv_layout("nvfp4_ds_mla")
+        assert is_mla_kv_layout("fp8_ds_mla")
+        assert is_mla_kv_layout("nvfp4-ds-mla")  # hyphen spelling
+        assert not is_mla_kv_layout("bfloat16")
+        assert not is_mla_kv_layout("nvfp4")
+
+    def test_v3_style_656_byte_slot(self):
+        """Without compress_ratios every layer stores one 656-byte slot per token."""
+        assert mla_kv_bytes_per_token(kv_dtype="fp8_ds_mla", num_layers=61) == 61 * 656
+
+    def test_deepseek_v4_uses_584_byte_envelope(self):
+        # 21 layers at ratio 4 + 20 at ratio 128; ratio-0 layers are excluded.
+        expected = 21 * (584 / 4) + 20 * (584 / 128)
+        got = mla_kv_bytes_per_token(
+            kv_dtype="nvfp4_ds_mla",
+            num_layers=43,
+            compress_ratios=DEEPSEEK_V4_CONFIG["compress_ratios"],
+            model_type="deepseek_v4",
+        )
+        assert got == pytest.approx(expected)
+        assert got == pytest.approx(3157.25)
+
+    def test_fp8_and_nvfp4_share_the_v4_envelope(self):
+        kwargs = dict(num_layers=43, compress_ratios=DEEPSEEK_V4_CONFIG["compress_ratios"], model_type="deepseek_v4")
+        assert mla_kv_bytes_per_token(kv_dtype="fp8_ds_mla", **kwargs) == mla_kv_bytes_per_token(kv_dtype="nvfp4_ds_mla", **kwargs)
+
+    def test_generic_mla_sizes_from_latent(self):
+        """Non-slot dtypes: (kv_lora_rank + qk_rope_head_dim) elements per layer."""
+        got = mla_kv_bytes_per_token(kv_dtype="bfloat16", num_layers=61, kv_lora_rank=512, qk_rope_head_dim=64)
+        assert got == 61 * (512 + 64) * 2.0
+
+    def test_returns_none_without_enough_info(self):
+        assert mla_kv_bytes_per_token(kv_dtype="bfloat16", num_layers=61) is None
+        assert mla_kv_bytes_per_token(kv_dtype="fp8_ds_mla") is None
+
+
+class TestMlaEstimateVram:
+    """End-to-end MLA sizing through estimate_vram()."""
+
+    def _v4_kwargs(self, **overrides):
+        info = extract_model_info(DEEPSEEK_V4_CONFIG)
+        kwargs = dict(
+            model_vram=340.0,
+            num_layers=info["num_layers"],
+            num_kv_heads=info["num_kv_heads"],
+            head_dim=info["head_dim"],
+            kv_lora_rank=info.get("kv_lora_rank"),
+            qk_rope_head_dim=info.get("qk_rope_head_dim"),
+            compress_ratios=info.get("compress_ratios"),
+            model_type=info.get("model_type"),
+            max_model_len=1_048_576,
+            kv_dtype="nvfp4_ds_mla",
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_nvfp4_ds_mla_replaces_the_bf16_mha_estimate(self):
+        """The generic 2*L*heads*head_dim formula reads 86 GB; MLA is ~3 GB."""
+        generic = estimate_vram(
+            model_vram=340.0,
+            num_layers=43,
+            num_kv_heads=1,
+            head_dim=512,
+            max_model_len=1_048_576,
+        )
+        assert generic.kv_cache_total_gb == pytest.approx(86.0, abs=0.1)
+        assert not generic.mla
+
+        est = estimate_vram(**self._v4_kwargs())
+        assert est.mla
+        assert est.kv_cache_per_token_bytes == pytest.approx(3157.25)
+        assert est.kv_cache_total_gb == pytest.approx(3.08, abs=0.01)
+
+    def test_kv_cache_is_replicated_across_tensor_parallel_ranks(self):
+        """MLA's latent has no head dim to shard, so TP does not shrink the KV cache."""
+        tp1 = estimate_vram(**self._v4_kwargs(tensor_parallel=1))
+        tp2 = estimate_vram(**self._v4_kwargs(tensor_parallel=2))
+        assert tp2.kv_cache_replicated
+        # Weights halve, KV does not.
+        assert tp2.total_per_gpu_gb == pytest.approx(tp1.model_weights_gb / 2 + tp1.kv_cache_total_gb)
+
+    def test_pipeline_parallel_still_splits_the_kv_cache(self):
+        """Layers — and therefore their latent caches — do split across PP stages."""
+        pp1 = estimate_vram(**self._v4_kwargs(pipeline_parallel=1))
+        pp2 = estimate_vram(**self._v4_kwargs(pipeline_parallel=2))
+        assert pp2.total_per_gpu_gb == pytest.approx(pp1.model_weights_gb / 2 + pp1.kv_cache_total_gb / 2)
+
+    def test_warns_that_auxiliary_caches_are_excluded(self):
+        est = estimate_vram(**self._v4_kwargs())
+        assert any("sliding-window" in w for w in est.warnings)
+
+    def test_mla_layout_alone_is_enough(self):
+        """A recipe naming nvfp4_ds_mla gets MLA sizing even with no architecture info."""
+        est = estimate_vram(model_vram=340.0, kv_dtype="nvfp4_ds_mla", num_layers=43, max_model_len=131_072)
+        assert est.mla
+        assert est.kv_cache_per_token_bytes == 43 * 656
+
+    def test_kv_vram_per_token_override_still_wins(self):
+        est = estimate_vram(**self._v4_kwargs(kv_vram_per_token=1e-6))
+        assert est.kv_cache_total_gb == pytest.approx(1e-6 * 1_048_576)
+
+    def test_unsizable_mla_degrades_with_a_warning(self):
+        est = estimate_vram(model_vram=10.0, kv_dtype="bfloat16", kv_lora_rank=512, max_model_len=4096)
+        assert est.kv_cache_total_gb is None
+        assert any("MLA" in w for w in est.warnings)
+
+
+class TestExtractModelInfoMla:
+    """MLA architecture fields pulled out of a HuggingFace config."""
+
+    def test_deepseek_v4(self):
+        info = extract_model_info(DEEPSEEK_V4_CONFIG)
+        assert info["model_type"] == "deepseek_v4"
+        assert info["qk_rope_head_dim"] == 64
+        # V4 carries the latent dim in head_dim rather than kv_lora_rank.
+        assert info["kv_lora_rank"] == 512
+        assert info["compress_ratios"][:4] == [0, 0, 4, 128]
+
+    def test_deepseek_v3_uses_kv_lora_rank(self):
+        info = extract_model_info(
+            {
+                "model_type": "deepseek_v3",
+                "num_hidden_layers": 61,
+                "num_attention_heads": 128,
+                "hidden_size": 7168,
+                "kv_lora_rank": 512,
+                "qk_rope_head_dim": 64,
+            }
+        )
+        assert info["kv_lora_rank"] == 512
+        assert "compress_ratios" not in info
+
+    def test_non_mla_model_has_no_mla_fields(self):
+        info = extract_model_info({"model_type": "llama", "num_hidden_layers": 32, "num_attention_heads": 32, "hidden_size": 4096})
+        assert "kv_lora_rank" not in info
+        assert "qk_rope_head_dim" not in info
+
+
+class TestMlaDetectionSignals:
+    """Each independent signal that should select MLA sizing."""
+
+    def test_qk_rope_head_dim_with_pinned_head_dim(self):
+        """A recipe pinning head_dim + qk_rope_head_dim skips HF detection but still gets MLA sizing."""
+        est = estimate_vram(
+            model_vram=340.0,
+            num_layers=43,
+            num_kv_heads=1,
+            head_dim=512,
+            qk_rope_head_dim=64,
+            max_model_len=32768,
+        )
+        assert est.mla
+        assert est.kv_cache_per_token_bytes == 43 * (512 + 64) * 2.0
+
+    def test_kv_lora_rank_alone(self):
+        est = estimate_vram(model_vram=340.0, num_layers=61, kv_lora_rank=512, qk_rope_head_dim=64, max_model_len=32768)
+        assert est.mla
+        # DeepSeek's published figure for V3: ~70 KB per token.
+        assert est.kv_cache_per_token_bytes == 70_272
+
+    def test_non_mla_model_is_untouched(self):
+        """Standard GQA sizing must not change for models with no MLA markers."""
+        est = estimate_vram(model_vram=60.0, num_layers=64, num_kv_heads=8, head_dim=128, max_model_len=32768)
+        assert not est.mla
+        assert not est.kv_cache_replicated
+        assert est.kv_cache_per_token_bytes == 2.0 * 64 * 8 * 128 * 2.0

--- a/tests/test_vram.py
+++ b/tests/test_vram.py
@@ -365,7 +365,10 @@ class TestEstimateVram:
         est_big = estimate_vram(model_vram=150.0, tensor_parallel=1)
         assert est_big.fits_dgx_spark is False
 
-    def test_default_kv_dtype_is_bfloat16(self):
+    def test_default_kv_dtype_is_none(self):
+        """When no kv_dtype is passed, the estimate uses bfloat16 for computation but
+        leaves est.kv_dtype as None so display code can show "bfloat16 (default)".
+        """
         est = estimate_vram(
             model_params=7_000_000_000,
             model_dtype="float16",
@@ -374,7 +377,23 @@ class TestEstimateVram:
             head_dim=128,
             max_model_len=4096,
         )
-        assert est.kv_dtype == "bfloat16"
+        # est.kv_dtype is None (not "bfloat16") so the formatter's (default) branch fires
+        assert est.kv_dtype is None
+        # but the KV cache was still sized with bfloat16 (2 bytes)
+        assert est.kv_cache_per_token_bytes == 2.0 * 32 * 32 * 128 * 2
+
+    def test_explicit_kv_dtype_is_preserved(self):
+        """An explicit kv_dtype is preserved on the estimate."""
+        est = estimate_vram(
+            model_params=7_000_000_000,
+            model_dtype="float16",
+            kv_dtype="fp8",
+            num_layers=32,
+            num_kv_heads=32,
+            head_dim=128,
+            max_model_len=4096,
+        )
+        assert est.kv_dtype == "fp8"
 
     def test_gpu_memory_utilization_budget(self):
         """gpu_memory_utilization should compute usable memory and available KV."""

--- a/tests/test_vram.py
+++ b/tests/test_vram.py
@@ -19,21 +19,6 @@ from sparkrun.models.vram import (
     parse_param_count,
 )
 
-# DeepSeek-V4-Flash-0731 config.json (abridged to the fields the estimator reads).
-# 21 layers at compress_ratio 4, 20 at 128; ratio-0 layers are sliding-window.
-DEEPSEEK_V4_CONFIG = {
-    "model_type": "deepseek_v4",
-    "torch_dtype": "bfloat16",
-    "num_hidden_layers": 43,
-    "num_attention_heads": 64,
-    "num_key_value_heads": 1,
-    "hidden_size": 4096,
-    "head_dim": 512,
-    "qk_rope_head_dim": 64,
-    "sliding_window": 128,
-    "compress_ratios": [0, 0] + [4, 128] * 20 + [4, 0, 0, 0],
-}
-
 
 class TestParseParamCount:
     """Test parameter count parsing from various formats."""
@@ -987,20 +972,20 @@ class TestMlaKvLayout:
         """Without compress_ratios every layer stores one 656-byte slot per token."""
         assert mla_kv_bytes_per_token(kv_dtype="fp8_ds_mla", num_layers=61) == 61 * 656
 
-    def test_deepseek_v4_uses_584_byte_envelope(self):
+    def test_deepseek_v4_uses_584_byte_envelope(self, deepseek_v4_config):
         # 21 layers at ratio 4 + 20 at ratio 128; ratio-0 layers are excluded.
         expected = 21 * (584 / 4) + 20 * (584 / 128)
         got = mla_kv_bytes_per_token(
             kv_dtype="nvfp4_ds_mla",
             num_layers=43,
-            compress_ratios=DEEPSEEK_V4_CONFIG["compress_ratios"],
+            compress_ratios=deepseek_v4_config["compress_ratios"],
             model_type="deepseek_v4",
         )
         assert got == pytest.approx(expected)
         assert got == pytest.approx(3157.25)
 
-    def test_fp8_and_nvfp4_share_the_v4_envelope(self):
-        kwargs = dict(num_layers=43, compress_ratios=DEEPSEEK_V4_CONFIG["compress_ratios"], model_type="deepseek_v4")
+    def test_fp8_and_nvfp4_share_the_v4_envelope(self, deepseek_v4_config):
+        kwargs = dict(num_layers=43, compress_ratios=deepseek_v4_config["compress_ratios"], model_type="deepseek_v4")
         assert mla_kv_bytes_per_token(kv_dtype="fp8_ds_mla", **kwargs) == mla_kv_bytes_per_token(kv_dtype="nvfp4_ds_mla", **kwargs)
 
     def test_generic_mla_sizes_from_latent(self):
@@ -1016,8 +1001,8 @@ class TestMlaKvLayout:
 class TestMlaEstimateVram:
     """End-to-end MLA sizing through estimate_vram()."""
 
-    def _v4_kwargs(self, **overrides):
-        info = extract_model_info(DEEPSEEK_V4_CONFIG)
+    def _v4_kwargs(self, config, **overrides):
+        info = extract_model_info(config)
         kwargs = dict(
             model_vram=340.0,
             num_layers=info["num_layers"],
@@ -1033,7 +1018,7 @@ class TestMlaEstimateVram:
         kwargs.update(overrides)
         return kwargs
 
-    def test_nvfp4_ds_mla_replaces_the_bf16_mha_estimate(self):
+    def test_nvfp4_ds_mla_replaces_the_bf16_mha_estimate(self, deepseek_v4_config):
         """The generic 2*L*heads*head_dim formula reads 86 GB; MLA is ~3 GB."""
         generic = estimate_vram(
             model_vram=340.0,
@@ -1045,27 +1030,27 @@ class TestMlaEstimateVram:
         assert generic.kv_cache_total_gb == pytest.approx(86.0, abs=0.1)
         assert not generic.mla
 
-        est = estimate_vram(**self._v4_kwargs())
+        est = estimate_vram(**self._v4_kwargs(deepseek_v4_config))
         assert est.mla
         assert est.kv_cache_per_token_bytes == pytest.approx(3157.25)
         assert est.kv_cache_total_gb == pytest.approx(3.08, abs=0.01)
 
-    def test_kv_cache_is_replicated_across_tensor_parallel_ranks(self):
+    def test_kv_cache_is_replicated_across_tensor_parallel_ranks(self, deepseek_v4_config):
         """MLA's latent has no head dim to shard, so TP does not shrink the KV cache."""
-        tp1 = estimate_vram(**self._v4_kwargs(tensor_parallel=1))
-        tp2 = estimate_vram(**self._v4_kwargs(tensor_parallel=2))
+        tp1 = estimate_vram(**self._v4_kwargs(deepseek_v4_config, tensor_parallel=1))
+        tp2 = estimate_vram(**self._v4_kwargs(deepseek_v4_config, tensor_parallel=2))
         assert tp2.kv_cache_replicated
         # Weights halve, KV does not.
         assert tp2.total_per_gpu_gb == pytest.approx(tp1.model_weights_gb / 2 + tp1.kv_cache_total_gb)
 
-    def test_pipeline_parallel_still_splits_the_kv_cache(self):
+    def test_pipeline_parallel_still_splits_the_kv_cache(self, deepseek_v4_config):
         """Layers — and therefore their latent caches — do split across PP stages."""
-        pp1 = estimate_vram(**self._v4_kwargs(pipeline_parallel=1))
-        pp2 = estimate_vram(**self._v4_kwargs(pipeline_parallel=2))
+        pp1 = estimate_vram(**self._v4_kwargs(deepseek_v4_config, pipeline_parallel=1))
+        pp2 = estimate_vram(**self._v4_kwargs(deepseek_v4_config, pipeline_parallel=2))
         assert pp2.total_per_gpu_gb == pytest.approx(pp1.model_weights_gb / 2 + pp1.kv_cache_total_gb / 2)
 
-    def test_warns_that_auxiliary_caches_are_excluded(self):
-        est = estimate_vram(**self._v4_kwargs())
+    def test_warns_that_auxiliary_caches_are_excluded(self, deepseek_v4_config):
+        est = estimate_vram(**self._v4_kwargs(deepseek_v4_config))
         assert any("sliding-window" in w for w in est.warnings)
 
     def test_mla_layout_alone_is_enough(self):
@@ -1074,8 +1059,8 @@ class TestMlaEstimateVram:
         assert est.mla
         assert est.kv_cache_per_token_bytes == 43 * 656
 
-    def test_kv_vram_per_token_override_still_wins(self):
-        est = estimate_vram(**self._v4_kwargs(kv_vram_per_token=1e-6))
+    def test_kv_vram_per_token_override_still_wins(self, deepseek_v4_config):
+        est = estimate_vram(**self._v4_kwargs(deepseek_v4_config, kv_vram_per_token=1e-6))
         assert est.kv_cache_total_gb == pytest.approx(1e-6 * 1_048_576)
 
     def test_unsizable_mla_degrades_with_a_warning(self):
@@ -1087,8 +1072,8 @@ class TestMlaEstimateVram:
 class TestExtractModelInfoMla:
     """MLA architecture fields pulled out of a HuggingFace config."""
 
-    def test_deepseek_v4(self):
-        info = extract_model_info(DEEPSEEK_V4_CONFIG)
+    def test_deepseek_v4(self, deepseek_v4_config):
+        info = extract_model_info(deepseek_v4_config)
         assert info["model_type"] == "deepseek_v4"
         assert info["qk_rope_head_dim"] == 64
         # V4 carries the latent dim in head_dim rather than kv_lora_rank.

--- a/tests/test_vram.py
+++ b/tests/test_vram.py
@@ -18,7 +18,10 @@ from sparkrun.models.vram import (
     mla_kv_bytes_per_token,
     mla_latent_dim,
     parse_param_count,
+    reconcile_compress_ratios,
 )
+
+_MLA_KEYS = frozenset({"kv_lora_rank", "qk_rope_head_dim", "compress_ratios", "index_head_dim"})
 
 
 class TestParseParamCount:
@@ -1324,3 +1327,318 @@ class TestAuxiliaryCacheWarning:
         info = extract_model_info(deepseek_v3_config)
         assert "index_head_dim" not in info
         assert self._estimate(info).warnings == []
+
+
+class TestReconcileCompressRatios:
+    """`compress_ratios` is indexed by layer upstream, not summed wholesale.
+
+    DeepSeek-V4-Flash ships 46 entries for 43 layers (the extras cover MTP /
+    non-standard layers), so the list length legitimately exceeds the layer
+    count and trimming must be silent in that case — but a short list, or a
+    trimmed tail holding real compressed layers, changes the estimate and has
+    to be surfaced.
+    """
+
+    def test_exact_length_is_untouched(self):
+        ratios, note = reconcile_compress_ratios([4] * 43, 43)
+        assert len(ratios) == 43
+        assert note is None
+
+    def test_trailing_padding_is_trimmed_silently(self, deepseek_v4_config):
+        """The real V4 shape: 46 entries, 43 layers, trailing zeros."""
+        ratios, note = reconcile_compress_ratios(deepseek_v4_config["compress_ratios"], 43)
+        assert len(ratios) == 43
+        assert note is None
+
+    def test_real_v4_estimate_is_unchanged_and_quiet(self, deepseek_v4_config):
+        info = extract_model_info(deepseek_v4_config)
+        est = estimate_vram(
+            model_vram=340.0,
+            kv_dtype="nvfp4_ds_mla",
+            max_model_len=1_048_576,
+            num_layers=info["num_layers"],
+            compress_ratios=info["compress_ratios"],
+            model_type=info["model_type"],
+            index_head_dim=info.get("index_head_dim"),
+        )
+        assert est.kv_cache_per_token_bytes == pytest.approx(3157.25)
+        assert not any("compress_ratios lists" in w for w in est.warnings)
+
+    def test_short_list_is_reported(self):
+        ratios, note = reconcile_compress_ratios([4] * 10, 61)
+        assert len(ratios) == 10  # nothing to trim; we cannot invent the rest
+        assert note is not None and "the remainder is unsized" in note
+
+    def test_trimmed_tail_with_real_layers_is_reported(self):
+        ratios, note = reconcile_compress_ratios([4] * 43 + [4, 128], 43)
+        assert len(ratios) == 43
+        assert note is not None and "beyond the layer count were ignored" in note
+
+    def test_note_surfaces_as_an_estimate_warning(self):
+        est = estimate_vram(
+            model_vram=10.0,
+            kv_dtype="nvfp4_ds_mla",
+            num_layers=61,
+            compress_ratios=[4] * 10,
+            model_type="deepseek_v4",
+            max_model_len=4096,
+        )
+        assert any("compress_ratios lists 10 layers" in w for w in est.warnings), est.warnings
+
+    def test_no_num_layers_means_no_reconciliation(self):
+        ratios, note = reconcile_compress_ratios([4, 128], None)
+        assert list(ratios) == [4, 128]
+        assert note is None
+
+
+class TestKvVramPerTokenOverrideSharding:
+    """The override follows the same replication rule as a computed MLA estimate.
+
+    `is_mla` is resolved before the override branch and drives `kv_shard_factor`
+    for it too, so an MLA recipe's hand-calibrated per-token figure is divided
+    by PP alone. That is the correct behaviour — the latent is replicated — but
+    it is a contract change from the pre-MLA code, so pin it.
+    """
+
+    _BASE = dict(model_vram=100.0, kv_vram_per_token=1e-5, max_model_len=100_000)
+
+    def test_non_mla_override_is_divided_by_tp_and_pp(self):
+        est = estimate_vram(**self._BASE, tensor_parallel=4, pipeline_parallel=2)
+        assert not est.kv_cache_replicated
+        assert est.total_per_gpu_gb == pytest.approx(100.0 / 8 + (1e-5 * 100_000) / 8)
+
+    def test_mla_override_is_divided_by_pp_only(self):
+        est = estimate_vram(**self._BASE, tensor_parallel=4, pipeline_parallel=2, kv_lora_rank=512, qk_rope_head_dim=64)
+        assert est.mla and est.kv_cache_replicated
+        # Weights still shard by TP*PP; the KV override does not shard by TP.
+        assert est.total_per_gpu_gb == pytest.approx(100.0 / 8 + (1e-5 * 100_000) / 2)
+
+    def test_mla_layout_alone_also_replicates_the_override(self):
+        est = estimate_vram(**self._BASE, tensor_parallel=4, kv_dtype="nvfp4_ds_mla")
+        assert est.kv_cache_replicated
+        assert est.total_per_gpu_gb == pytest.approx(100.0 / 4 + 1e-5 * 100_000)
+
+    def test_override_still_beats_computed_mla_sizing(self, deepseek_v4_config):
+        """The override wins outright — no MLA arithmetic is performed."""
+        info = extract_model_info(deepseek_v4_config)
+        est = estimate_vram(
+            model_vram=340.0,
+            kv_vram_per_token=1e-6,
+            max_model_len=1_048_576,
+            kv_dtype="nvfp4_ds_mla",
+            num_layers=info["num_layers"],
+            compress_ratios=info["compress_ratios"],
+            model_type=info["model_type"],
+        )
+        assert est.kv_cache_total_gb == pytest.approx(1e-6 * 1_048_576)
+
+
+class TestNestedMlaConfigs:
+    """Multimodal wrappers hide the text architecture in a nested sub-config.
+
+    Two ways MLA was lost: `model_type` was read only from the top level (so a
+    wrapper took the 656 B fallback instead of V4's 584 B envelope), and the
+    nested scan was gated on the *core* architecture keys — a wrapper complete
+    for those never had its nested MLA markers read at all.
+    """
+
+    def _wrapper(self, inner, **top):
+        return {"model_type": "deepseek_vl_v2", "text_config": inner, **top}
+
+    def test_nested_mla_found_when_top_level_is_incomplete(self, deepseek_v4_config):
+        info = extract_model_info(self._wrapper(deepseek_v4_config))
+        assert info["model_type"] == "deepseek_v4"
+        assert info["kv_lora_rank"] == 448
+        assert info["compress_ratios"] == deepseek_v4_config["compress_ratios"]
+
+    def test_nested_mla_found_when_top_level_is_complete(self, deepseek_v4_config):
+        """The regression case: core keys present up top, MLA markers only below."""
+        info = extract_model_info(
+            self._wrapper(
+                deepseek_v4_config,
+                torch_dtype="bfloat16",
+                num_hidden_layers=43,
+                num_attention_heads=64,
+                num_key_value_heads=1,
+                hidden_size=4096,
+                head_dim=512,
+            )
+        )
+        assert info["model_type"] == "deepseek_v4"
+        assert not _MLA_KEYS.isdisjoint(info)
+
+    def test_nested_wrapper_sizes_to_the_v4_envelope(self, deepseek_v4_config):
+        """End-to-end: the wrapper must not fall back to the 656 B default."""
+        info = extract_model_info(self._wrapper(deepseek_v4_config))
+        got = mla_kv_bytes_per_token(
+            kv_dtype="nvfp4_ds_mla",
+            num_layers=info["num_layers"],
+            compress_ratios=info["compress_ratios"],
+            model_type=info["model_type"],
+        )
+        assert got == pytest.approx(3157.25)
+
+    def test_wrapper_model_type_kept_when_nested_is_not_mla(self):
+        """An ordinary multimodal model keeps the wrapper's model_type."""
+        info = extract_model_info(
+            {
+                "model_type": "qwen2_vl",
+                "text_config": {
+                    "model_type": "qwen2",
+                    "torch_dtype": "bfloat16",
+                    "num_hidden_layers": 28,
+                    "num_attention_heads": 28,
+                    "num_key_value_heads": 4,
+                    "hidden_size": 3584,
+                },
+            }
+        )
+        assert info["model_type"] == "qwen2_vl"
+        assert info["num_layers"] == 28
+        assert _MLA_KEYS.isdisjoint(info)
+
+    def test_flat_configs_are_unaffected(self, deepseek_v4_config, deepseek_v3_config):
+        assert extract_model_info(deepseek_v4_config)["model_type"] == "deepseek_v4"
+        assert extract_model_info(deepseek_v4_config)["kv_lora_rank"] == 448
+        assert extract_model_info(deepseek_v3_config)["model_type"] == "deepseek_v3"
+        assert extract_model_info(deepseek_v3_config)["kv_lora_rank"] == 512
+
+
+class TestWeakMlaSignalIsFlagged:
+    """`qk_rope_head_dim` alone triggers MLA — say so rather than tighten it.
+
+    Every shipping DeepSeek/Kimi config resolves a latent (naming kv_lora_rank,
+    or being V4-shaped), so the weak path is unreachable from auto-detection
+    and only arises from hand-pinned metadata. Requiring corroboration would
+    cost that ergonomic for a hypothetical model; warning keeps it while making
+    the assumption visible — and the assumption matters, because sizing a
+    non-MLA model this way drops `2 * num_kv_heads` and under-estimates.
+    """
+
+    _MSG = "inferred from qk_rope_head_dim alone"
+
+    def test_pinned_qk_rope_alone_warns(self):
+        est = estimate_vram(model_vram=10.0, num_layers=32, num_kv_heads=8, head_dim=128, qk_rope_head_dim=64, max_model_len=4096)
+        assert est.mla
+        assert any(self._MSG in w for w in est.warnings), est.warnings
+
+    def test_kv_lora_rank_alone_warns_about_the_tail(self):
+        """The mirror image: kv_lora_rank alone silently drops the RoPE tail."""
+        est = estimate_vram(model_vram=10.0, num_layers=61, kv_lora_rank=512, kv_dtype="bfloat16", max_model_len=4096)
+        assert est.mla
+        assert any("RoPE tail" in w and "kv_lora_rank" in w for w in est.warnings), est.warnings
+        # And it genuinely under-estimates: tail omitted.
+        assert est.kv_cache_per_token_bytes == 61 * 512 * 2.0
+
+    def test_both_markers_warn_never(self):
+        est = estimate_vram(model_vram=10.0, num_layers=61, kv_lora_rank=512, qk_rope_head_dim=64, kv_dtype="bfloat16", max_model_len=4096)
+        assert not any(self._MSG in w for w in est.warnings)
+        assert not any("RoPE tail" in w for w in est.warnings)
+
+    def test_explicit_latent_does_not_warn(self):
+        est = estimate_vram(model_vram=10.0, num_layers=61, kv_lora_rank=512, qk_rope_head_dim=64, max_model_len=4096)
+        assert not any(self._MSG in w for w in est.warnings)
+
+    def test_ds_mla_layout_does_not_warn(self):
+        est = estimate_vram(model_vram=10.0, kv_dtype="nvfp4_ds_mla", num_layers=43, max_model_len=4096)
+        assert not any(self._MSG in w for w in est.warnings)
+
+    @pytest.mark.parametrize("fixture_name", ["deepseek_v4_config", "deepseek_v3_config", "deepseek_v32_config"])
+    def test_auto_detected_configs_never_warn(self, request, fixture_name):
+        """Auto-detection always resolves a latent, so this must stay quiet."""
+        info = extract_model_info(request.getfixturevalue(fixture_name))
+        est = estimate_vram(
+            model_vram=340.0,
+            kv_dtype="fp8_ds_mla",
+            max_model_len=32768,
+            num_layers=info["num_layers"],
+            num_kv_heads=info.get("num_kv_heads"),
+            head_dim=info.get("head_dim"),
+            kv_lora_rank=info.get("kv_lora_rank"),
+            qk_rope_head_dim=info.get("qk_rope_head_dim"),
+            compress_ratios=info.get("compress_ratios"),
+            model_type=info.get("model_type"),
+            index_head_dim=info.get("index_head_dim"),
+        )
+        assert not any(self._MSG in w for w in est.warnings), est.warnings
+
+    def test_the_underestimate_it_guards_against(self):
+        """Documents the magnitude: a GQA shape sized as MLA reads ~10x low."""
+        gqa = estimate_vram(model_vram=10.0, num_layers=32, num_kv_heads=8, head_dim=128, max_model_len=4096)
+        as_mla = estimate_vram(model_vram=10.0, num_layers=32, num_kv_heads=8, head_dim=128, qk_rope_head_dim=64, max_model_len=4096)
+        assert gqa.kv_cache_per_token_bytes == 2.0 * 32 * 8 * 128 * 2.0
+        assert as_mla.kv_cache_per_token_bytes < gqa.kv_cache_per_token_bytes / 10
+
+
+class TestMlaAloneLayoutOnNonMlaModel:
+    """An `*_ds_mla` layout is authoritative MLA even with no architectural marker.
+
+    That is only safe when the model genuinely is MLA. Forced onto a non-MLA
+    model it sizes the latent instead of the real attention heads — an order of
+    magnitude under-estimate in the OOM direction.
+    """
+
+    _MSG = "forces MLA sizing but the model has no MLA architecture markers"
+
+    def test_non_mla_model_warns(self):
+        est = estimate_vram(model_vram=60.0, num_layers=64, num_kv_heads=8, head_dim=128, kv_dtype="nvfp4_ds_mla", max_model_len=32768)
+        assert est.mla
+        assert any(self._MSG in w for w in est.warnings), est.warnings
+
+    def test_mla_model_does_not_warn(self, deepseek_v4_config):
+        est = estimate_vram(
+            model_vram=340.0,
+            kv_dtype="nvfp4_ds_mla",
+            num_layers=43,
+            kv_lora_rank=448,
+            qk_rope_head_dim=64,
+            max_model_len=32768,
+            index_head_dim=128,
+        )
+        assert not any(self._MSG in w for w in est.warnings)
+
+    def test_v4_config_does_not_warn(self, deepseek_v4_config):
+        """Auto-detected V4 carries kv_lora_rank, so no spurious warning."""
+        info = extract_model_info(deepseek_v4_config)
+        est = estimate_vram(
+            model_vram=340.0,
+            kv_dtype="nvfp4_ds_mla",
+            num_layers=info["num_layers"],
+            kv_lora_rank=info["kv_lora_rank"],
+            qk_rope_head_dim=info["qk_rope_head_dim"],
+            max_model_len=32768,
+            index_head_dim=info.get("index_head_dim"),
+        )
+        assert not any(self._MSG in w for w in est.warnings)
+
+
+class TestShortCompressRatiosSizesAvailableLayersWithWarning:
+    """A ratio list shorter than num_layers sizes what it covers and warns.
+
+    Returning None for a short list serialized to 0.0 GB of KV at the placement
+    boundary (total_per_gpu_gb is what the scheduler reads), which *also* passes
+    the fit check and is strictly worse than sizing the layers the list does
+    cover. So a short list sizes those layers and surfaces the gap as a warning,
+    matching reconcile_compress_ratios' contract.
+    """
+
+    def test_short_list_sizes_the_available_layers(self):
+        # 10 layers at ratio 4 -> 10 * 584/4 = 1460
+        got = mla_kv_bytes_per_token(kv_dtype="nvfp4_ds_mla", num_layers=61, compress_ratios=[4] * 10, model_type="deepseek_v4")
+        assert got == pytest.approx(10 * 584 / 4)
+
+    def test_exact_and_long_lists_size_normally(self):
+        assert mla_kv_bytes_per_token(
+            kv_dtype="nvfp4_ds_mla", num_layers=43, compress_ratios=[4] * 43, model_type="deepseek_v4"
+        ) == pytest.approx(43 * 584 / 4)
+        real = [0, 0] + [4, 128] * 20 + [4, 0, 0, 0]
+        assert mla_kv_bytes_per_token(
+            kv_dtype="nvfp4_ds_mla", num_layers=43, compress_ratios=real, model_type="deepseek_v4"
+        ) == pytest.approx(3157.25)
+
+    def test_estimate_sizes_and_warns_for_the_short_list(self):
+        est = estimate_vram(
+            model_vram=10.0, kv_dtype="nvfp4_ds_mla", num_layers=61, compress_ratios=[4] * 10, model_type="deepseek_v4", max_model_len=4096
+        )
+        assert est.kv_cache_per_token_bytes == pytest.approx(10 * 584 / 4)
+        assert any("compress_ratios lists 10 layers" in w for w in est.warnings), est.warnings


### PR DESCRIPTION
## Problem

`sparkrun run --dry-run` refused to place ranks for a DeepSeek-V4-Flash NVFP4 config that runs fine under compose, because **the estimator had no concept of MLA**. Every model was sized with the generic `2 × layers × kv_heads × head_dim × bytes` formula. For this model the HF config reads `num_hidden_layers: 43`, `num_key_value_heads: 1`, `head_dim: 512` — but `head_dim` there is the *compressed latent* width, not a per-head K/V width. MLA caches one latent per token per layer, not a K and V entry per head:

```
2 × 43 × 1 × 512 × 2 B  =  88,064 B/token  →  86.0 GB at 1M context
```

`nvfp4_ds_mla` compounded it: on `main` that layout is unrecognized, so naming it in `defaults.kv_cache_dtype` **drops** the KV estimate entirely (`"Unknown KV cache dtype"`), and naming it in `metadata.kv_dtype` fails recipe validation. Neither route produced the 86 GB — that figure comes from the missing MLA concept alone, with `kv_dtype` at its `bfloat16` default.

## Fix

An MLA path in `estimate_vram()`, selected by any one of three independent signals — `kv_lora_rank` or `qk_rope_head_dim` from the HF config, or an `*_ds_mla` layout named in the recipe.

- **`mla_kv_bytes_per_token()`** sizes either a fixed-width packed slot (`fp8_ds_mla` / `nvfp4_ds_mla` — 656 B per token per layer, **584 on DeepSeek V4**) or, for ordinary dtypes, `(latent + qk_rope_head_dim)` elements per layer. DeepSeek V4's per-layer `compress_ratios` divides the slot count; ratio ≤ 1 layers are sliding-window and excluded.
- **`mla_latent_dim()`** normalizes the two config shapes. V2/V3 name the latent `kv_lora_rank` and cache the RoPE tail *in addition* to it (576 elements); V4 has no `kv_lora_rank` and folds both into `head_dim` (512, of which 64 is the tail). Reporting the NoPE width for both means the tail is counted exactly once.
- **The latent cache is replicated per TP rank** — no head dimension to shard — so `--tp` no longer divides it. Pipeline parallelism still does.
- **`kv_bytes_per_element()`** accounts for NVFP4's fp8 block scales: **0.5625 B/elem, not 0.5**. Weight sizing is untouched.
- Recipe validation accepts the `*_ds_mla` layouts and now type-checks the MLA metadata fields.
- `recipe show` reports `Architecture: MLA (compressed latent KV cache)` and flags replication.

```
21 layers × 584/4  +  20 layers × 584/128  =  3157.25 B/token  →  3.08 GB at 1M ctx
```

**86.0 GB → 3.08 GB.** Placement succeeds.

## Validation

Measured against real HF configs (32k context, tp=4):

| model | `kv_dtype` | before B/tok | after B/tok |
|---|---|---|---|
| DeepSeek-V3 | bfloat16 | 1,748,992 | **70,272** |
| DeepSeek-V3.2-Exp | bfloat16 | 1,748,992 | 70,272 |
| Kimi-K2-Instruct | bfloat16 | 1,748,992 | 70,272 |
| DeepSeek-V4-Flash-0731 | bfloat16 | 88,064 | 5,536 |
| Qwen3-32B | bfloat16 / fp8 | 262,144 / 131,072 | *unchanged* |
| Qwen3-32B | nvfp4 | 65,536 | 73,728 |

DeepSeek-V3's 70,272 B/token matches DeepSeek's published ~70 KB/token figure. The slot constants are verifiable in **upstream vLLM** (`vllm/v1/kv_cache_interface.py`: 656 for V3.2, and `448B NoPE + 128B RoPE + 8B fp8 scale = 584B` for `deepseek_v4`); only the `nvfp4_ds_mla` *spelling* is fork-only, shipping in the DGX Spark overlay ([Anemll/dspark-vllm-gx10](https://github.com/Anemll/dspark-vllm-gx10)).

The `nvfp4_ds_mla` dtype applies to both the DeepSeek-V4-Flash preview checkpoint and the 0731 variant when running on DGX Spark hardware. A follow-up PR will add full recipe support for DeepSeek-V4-Flash-0731 with dSpark and 1M context.

## Hardenings

Beyond the core fix, several edge cases were caught and addressed across the commits:

- **`estimate_vram()` idempotency.** The metadata write-back persisted the generic architecture fields but not the four MLA ones, and those persisted fields satisfy `needs_detection` — so a second call skipped the HF fetch and lost MLA. DeepSeek-V3 went 70,272 → 1,748,992 B/token on the second call, and since a single `sparkrun run` estimates three times on the same `Recipe` (the last feeding the placement's `ResourceRequest`), the launch decision used the reverted number. The MLA fields are now written back, with repeat-call tests for the fixed-slot, generic-dtype and non-MLA shapes.
- **V4's generic-dtype sizing double-counted the RoPE tail** (6,228 → 5,536 B/token). `mla_latent_dim()` normalizes the V2/V3 (latent + tail) and V4 (tail inside `head_dim`) shapes to the NoPE width so the tail is counted once. This is why the V4 bfloat16 row above changed.
- **A `compress_ratios` list with no entry above 1 summed to `0`, not `None`**, so the estimate read 0.00 GB of KV — which passes every fit check and OOMs at runtime instead of being refused. It now returns `None` and warns.
- **The auxiliary-cache warning was keyed on `compress_ratios`**, so DeepSeek-V3.2 (sparse indexer, no per-layer compression) was understated ~20% in silence. It is now keyed on the caches that actually exist.
- **`kv_vram_per_token` no longer suppresses MLA detection** for the sharding rule, and a pinned MLA `model_type` renders a real MLA verdict so the override is divided by PP, not TP×PP.
- **`compress_ratios` length reconciliation**, the `kv_vram_per_token` sharding contract, MLA metadata validation, nested/multimodal config detection, warnings for the weak MLA signals and for an `*_ds_mla` layout on a non-MLA model, and doc corrections.

## Known limits

- For sparse-attention models the estimate covers the **latent cache only** — a floor. V4's sliding-window and V3.2's sparse-indexer caches (~132 B/token/layer) are not sized; whichever apply are named in a warning.
- A future `model_type` with a different envelope would take the 656 B default. `_MLA_SLOT_BYTES` is keyed `{model_type: bytes}`, so it is a one-line addition, but nothing detects the need.
- Non-DeepSeek MLA using different config keys is not detected and falls back to the generic over-estimate — conservative, and recognisable as the failure this PR fixes.

## Docs & tests

RECIPES.md gains an MLA section (detection fields, the V2/V3-vs-V4 latent shapes, packed layouts, TP replication, the sharding rule for `kv_vram_per_token`, and the pinned-metadata foot-gun); CLAUDE.md notes the two KV sizing paths and the write-back invariant. Full suite: **4714 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)