### PR TITLE
v0.3.3 Alpha to Beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ reference_materials/
 /website/dist/
 /website/package-lock.json
 /MagicMock/
+/build/
 /benchmarks/
 /.slop/
 /runs/
 /data/
+/script-*.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,27 @@ stay in-process (not SAF-scanned) because their resolution is **order-sensitive*
 (most-specific `matches()` first) — transports, which select by exact name, moved
 onto SAF; platforms did not.
 
+**Platform default tiers.** A platform publishes hardware-conditional defaults
+through five hooks, each folded in at a different layer so anything the user
+wrote always wins:
+
+| Hook                                   | Scope                        | Folded in by                                              |
+|----------------------------------------|------------------------------|-----------------------------------------------------------|
+| `default_image(runtime)`               | container image              | `RuntimePlugin.default_image_for()`                        |
+| `default_runtime_flags(runtime, accel)`| recipe `defaults` (serve flags) | `launcher.apply_platform_runtime_flag_defaults` (`setdefault`) |
+| `default_env(runtime, accel, family=)` | container env                | `launcher.resolve_platform_env_defaults` (lowest env tier) |
+| `default_executor_config(executor)`    | `ExecutorConfig`             | `executor.resolve_executor(host_hardware=…)`, layer 9      |
+| `default_max_gpu_memory_utilization`   | usable-memory cap            | `core.limits`                                              |
+
+All are keyed off the **head host's** hardware — one image / serve command /
+executor is built per launch, so a representative host is the right scope.
+`default_env` receives the runtime *family* (`get_family()`, e.g. `"vllm"` for
+vllm-ray / vllm-distributed / eugr-vllm) alongside the exact name, so a platform
+can target a family without enumerating variants; exact name wins over family.
+Today DGX Spark uses this for `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`
+on vllm/sglang and `gpu_access_mode: gpus` (classic `--gpus` rather than CDI,
+whose `/etc/cdi/nvidia.yaml` goes stale across driver upgrades).
+
 ### External Plugins (`core/external_plugins.py`)
 
 Out-of-tree plugins (private executors, transports, runtimes, …) load from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,6 +734,31 @@ SAF's stateful root to `tmp_path`, preventing tests from touching `~/.config/spa
 All SSH/Docker operations in tests are mocked — no real hosts are needed. Common fixtures: `tmp_recipe_dir` (creates
 sample v1/v2 recipes), `cluster_dir`, `hosts_file`, `v` (initialized SAF Variables instance).
 
+**The suite is hermetic — it touches neither the developer's state nor the network.** Both properties are enforced in
+`isolate_stateful`, and both were once broken in ways that hid for a long time:
+
+| Guard                                                          | What it prevents                                                                                    |
+|----------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `DEFAULT_CONFIG_DIR` → `tmp_path` (+ `STATEFUL_ROOT`)          | reading the developer's clusters / registries / default hosts                                        |
+| `DEFAULT_CACHE_DIR` → `tmp_path` (+ `pending_ops`, `tuning._common`, which bind it at import) | reading *live* state — `ProxyEngine` defaults `state_dir` to `DEFAULT_CACHE_DIR/proxy`, so a test would report on (and `stop()` would SIGTERM) a really-running proxy |
+| `BOOTSTRAP_REGISTRY_URLS` → `[]`                               | first-run manifest discovery git-cloning three GitHub repos                                          |
+| `RegistryManager._clone_or_pull` → stub                        | every other registry `git clone` / `fetch`                                                           |
+
+The last two are why the suite runs in ~70s rather than 30+ minutes: registry git was costing seconds *per test*, masked
+for years by the cache dir leaking out to an already-populated `~/.cache/sparkrun/registries`. Sandboxing the cache
+turned those pulls into full clones, which is how it surfaced.
+
+Consequences for writing tests:
+
+- **Never assume a registry recipe exists.** Recipes must be created locally — a flat `*.yaml` in a `monkeypatch.chdir`
+  target (needs `model` + `container` + a resolvable `runtime` to pass `is_recipe_file`), or a direct path passed to a
+  command (`find_recipe` resolves paths before registries).
+- Tests that assert on **git argv** take the `real_registry_git` fixture, which restores the real `_clone_or_pull`;
+  they stay hermetic by mocking `subprocess.run` themselves.
+- Tests that exercise **manifest discovery** supply their own URLs (`bootstrap_urls` in `test_registry.py`) and mock
+  `_discover_manifest_entries`.
+- Assert against `<module>.DEFAULT_CACHE_DIR` rather than an import-time copy, which would be the real path.
+
 Test files cover: benchmarking, bootstrap, CLI commands, CLI recipe integration, cluster manager, config, distribution,
 Docker command generation, GGUF handling, host resolution, InfiniBand, networking, orchestration primitives, recipes,
 registry (including manifest discovery, fallback merging, shared clones, and reserved name enforcement), runtimes,

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -92,6 +92,21 @@ On DGX Spark (1 GPU per node), `tensor_parallel: N` = N hosts.
 > references there resolve at launch time from that file only, never from
 > `os.environ`, so secrets stay out of both the recipe and the cluster YAML.
 
+**Container env tiers** (highest priority first):
+
+1. Recipe `env` — including `-o env.FOO=bar` on the CLI, which is written into it.
+2. Cluster `env` / `env_file`.
+3. **Platform** — `HardwarePlatformPlugin.default_env(runtime_name, accelerator,
+   runtime_family=…)`, targeted at platform × runtime × accelerator. Today
+   DGX Spark (GB10) sets `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` for
+   the `vllm` and `sglang` families, which reduces allocator fragmentation on
+   GB10's unified memory. Runtimes that manage their own memory (llama.cpp,
+   TRT-LLM) are untargeted. Because this is a *tier* rather than a default
+   written into the recipe, you can override it with any value — including an
+   empty one (`-o env.PYTORCH_CUDA_ALLOC_CONF=`).
+
+Below all of these sit the runtime's own `get_common_env()` / cluster env.
+
 ### Metadata
 
 Informational fields for VRAM estimation, display, and search. Not passed to runtime.
@@ -357,7 +372,8 @@ executor_config:
 | `auto_remove`    | bool   | `true`      | `--rm`         | Remove container on exit                                                                                            |
 | `restart_policy` | string | `null`      | `--restart`    | `always`, `unless-stopped`, `on-failure:N`. **Mutually exclusive with `auto_remove`** — forces `auto_remove: false` |
 | `privileged`     | bool   | `true`      | `--privileged` | Privileged mode                                                                                                     |
-| `gpus`           | string | `"all"`     | `--gpus`       | GPU device spec                                                                                                     |
+| `gpus`           | string | `"all"`     | (see below)    | GPU device spec (`all`, `device=0,1`)                                                                               |
+| `gpu_access_mode`| string | platform    | `--device` / `--gpus` | How the GPU request is spelled: `cdi` → `--device nvidia.com/gpu=<id>`, `gpus` → `--gpus <gpus>`. Defaults per hardware platform (DGX Spark/GB10 → `gpus`, everything else → `cdi`) |
 | `ipc`            | string | `"host"`    | `--ipc`        | IPC namespace                                                                                                       |
 | `shm_size`       | string | `"10.24gb"` | `--shm-size`   | Shared memory size                                                                                                  |
 | `network`        | string | `"host"`    | `--network`    | Network mode                                                                                                        |

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -94,7 +94,16 @@ On DGX Spark (1 GPU per node), `tensor_parallel: N` = N hosts.
 
 **Container env tiers** (highest priority first):
 
-1. Recipe `env` — including `-o env.FOO=bar` on the CLI, which is written into it.
+1. Recipe `env` — including both CLI forms, which are written into it:
+   - `-e KEY=VALUE` / `--env KEY=VALUE` (repeatable) — value used **verbatim**.
+     Hidden from `--help` unless `SPARKRUN_ADVANCED=1`.
+   - `-o env.KEY=VALUE` — the generic override path, so the value goes through
+     `coerce_value`: `-o env.X=true` arrives as `True`, not `true`. Prefer `-e`
+     for anything a runtime parses itself.
+
+   Both split on the **first** `=` only (`-e ALLOC=expandable_segments:True` is
+   safe), and `-e KEY=` sets an empty value — the way to blank out a platform or
+   cluster default. `-e` wins if a key is given both ways.
 2. Cluster `env` / `env_file`.
 3. **Platform** — `HardwarePlatformPlugin.default_env(runtime_name, accelerator,
    runtime_family=…)`, targeted at platform × runtime × accelerator. Today

--- a/docs/EXECUTORS.md
+++ b/docs/EXECUTORS.md
@@ -154,8 +154,15 @@ CDI (Container Device Interface, Docker >= 25) is the portable path and is
 *required* on daemons that reject `--gpus` (e.g. Thunder Compute), but it
 depends on a present, non-stale `/etc/cdi/nvidia.yaml` — the spec pins versioned
 absolute paths, so a driver upgrade can leave it dangling and containers then
-fail to start (`sparkrun setup check` flags this). `--gpus` resolves through the
-container runtime at launch instead.
+fail to start. `--gpus` resolves through the container runtime at launch instead.
+
+`sparkrun setup check` reports on the spec at a severity that follows this
+setting: it resolves each host's effective `gpu_access_mode` through the real
+executor chain, so a missing spec is a **FAIL** only for a cluster that would
+actually read it. Under `gpus` the finding drops to **SKIP** (it doesn't count
+as a gap or affect the exit code) while still naming the staleness, because it
+becomes real the moment the mode changes. A mode that can't be resolved fails
+safe to "CDI required".
 
 The default comes from the resolved hardware platform
 (`HardwarePlatformPlugin.default_executor_config("docker")`), which sits just

--- a/docs/EXECUTORS.md
+++ b/docs/EXECUTORS.md
@@ -22,8 +22,13 @@ point. It layers (highest priority first):
    auto_user=)`. Docker reads these here; Local/K8s ignore.
 6. **Runtime executor-config defaults** — `runtime.default_executor_config()` (`{}` by default; runtimes can set overridable executor defaults).
 7. **`SparkrunConfig`** — `config.default_executor` + `config.executor_config`.
-8. **Per-executor defaults** — `cls.default_config()` (e.g. `DOCKER_DEFAULTS`).
-9. **Dataclass field defaults** — `ExecutorConfig` declares the floor.
+8. **Platform** — `platform.default_executor_config(<name>)` for the platform
+   resolved from the launching host's hardware (`host_hardware=`, the head
+   node's). Hardware-conditional container plumbing that should still lose to
+   anything the user wrote — e.g. DGX Spark pins `gpu_access_mode: gpus`.
+   Dropped entirely when no hardware is threaded (naming / teardown / log paths).
+9. **Per-executor defaults** — `cls.default_config()` (e.g. `DOCKER_DEFAULTS`).
+10. **Dataclass field defaults** — `ExecutorConfig` declares the floor.
 
 A selector that is unknown — or names a real executor whose feature flag is
 off — raises `ExecutorUnavailableError` naming the flag to enable. Resolution
@@ -74,7 +79,8 @@ lists. Falsy values fall through to the dataclass defaults.
 | `auto_remove`         | bool        | Docker              | `True`        | Adds `--rm`. Force-flipped to `False` when `restart_policy` is set.                            |
 | `restart_policy`      | str?        | Docker              | `None`        | Docker `--restart` value.                                                                      |
 | `privileged`          | bool        | Docker              | `True`        | Off in rootless mode.                                                                          |
-| `gpus`                | str         | Docker, Local, K8s  | `"all"`       | Docker emits `--gpus`. Local translates `device=0,2` → `CUDA_VISIBLE_DEVICES`. K8s extracts a count for `nvidia.com/gpu`. |
+| `gpus`                | str         | Docker, Local, K8s  | `"all"`       | The GPU spec. Docker spells it per `gpu_access_mode`. Local translates `device=0,2` → `CUDA_VISIBLE_DEVICES`. K8s extracts a count for `nvidia.com/gpu`. |
+| `gpu_access_mode`     | str         | Docker              | `"cdi"`       | `cdi` → `--device nvidia.com/gpu=<id>`; `gpus` → `--gpus <gpus>`. Platform-defaulted (DGX Spark pins `gpus`). |
 | `ipc`                 | str         | Docker              | `"host"`      | `--ipc=host`. K8s drops.                                                                       |
 | `shm_size`            | str         | Docker              | `"25gb"`      | `--shm-size`. K8s drops.                                                                       |
 | `network`             | str         | Docker              | `"host"`      | `--network`. K8s drops.                                                                        |
@@ -126,10 +132,41 @@ lists. Falsy values fall through to the dataclass defaults.
 
 | Vendor      | Flags                                                              |
 |-------------|--------------------------------------------------------------------|
-| `nvidia`/None | `--gpus <gpus>`                                                  |
+| `nvidia`/None | per `gpu_access_mode` — see below                                |
 | `amd`         | `--device /dev/kfd --device /dev/dri --group-add video`           |
 | `intel`       | `--device /dev/accel`                                             |
 | `apple`/`cpu` | (none — route to a non-Docker executor)                           |
+
+### NVIDIA GPU access mode
+
+There are two ways to ask Docker for NVIDIA GPUs and neither works everywhere,
+so `gpu_access_mode` selects between them:
+
+| Mode           | Flags for `gpus: all`          | Flags for `gpus: device=0,1`                                       |
+|----------------|--------------------------------|---------------------------------------------------------------------|
+| `cdi` (default) | `--device nvidia.com/gpu=all` | `--device nvidia.com/gpu=0 --device nvidia.com/gpu=1`               |
+| `gpus`          | `--gpus all`                  | `--gpus device=0,1` (value passed through verbatim)                 |
+
+A falsy `gpus` still means "no GPU request" in both modes. An unrecognised mode
+warns and falls back to `cdi`.
+
+CDI (Container Device Interface, Docker >= 25) is the portable path and is
+*required* on daemons that reject `--gpus` (e.g. Thunder Compute), but it
+depends on a present, non-stale `/etc/cdi/nvidia.yaml` — the spec pins versioned
+absolute paths, so a driver upgrade can leave it dangling and containers then
+fail to start (`sparkrun setup check` flags this). `--gpus` resolves through the
+container runtime at launch instead.
+
+The default comes from the resolved hardware platform
+(`HardwarePlatformPlugin.default_executor_config("docker")`), which sits just
+above `DOCKER_DEFAULTS` in the chain: **DGX Spark / GB10 pins `gpus`**, every
+other platform inherits `cdi`. Override anywhere higher — recipe, cluster, or
+`config.yaml`:
+
+```yaml
+executor_config:
+  gpu_access_mode: cdi
+```
 
 ## `LocalExecutor` (experimental)
 

--- a/src/sparkrun/cli/_registry.py
+++ b/src/sparkrun/cli/_registry.py
@@ -68,7 +68,9 @@ def registry_list(ctx, show_disabled, only_show_visible, output_json, config_pat
     has_benchmarks = any(r.benchmark_subpath for r in display_registries)
 
     # Table header
-    header = f"{'Name':<25} {'URL':<45} {'Enabled':<9} {'Visible':<9} {'Trusted':<9}"
+    # "Stemless" is `visible`: whether a bare recipe stem resolves against this
+    # registry. A stemless=no registry is still reachable as @registry/name.
+    header = f"{'Name':<25} {'URL':<45} {'Enabled':<9} {'Stemless':<9} {'Trusted':<9}"
     sep_width = 98
     if has_tuning:
         header += f" {'Tuning':<8}"
@@ -297,7 +299,7 @@ def registry_show(ctx, name, config_path=None):
     if entry.description:
         click.echo("Description: %s" % entry.description)
     click.echo("Enabled:     %s" % ("yes" if entry.enabled else "no"))
-    click.echo("Visible:     %s" % ("yes" if entry.visible else "no"))
+    click.echo("Stemless:    %s" % ("yes" if entry.visible else "no"))
     click.echo("Trusted:     %s" % ("yes" if entry.trusted else "no"))
     if entry.tuning_subpath:
         click.echo("Tuning:      %s" % entry.tuning_subpath)

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -175,6 +175,14 @@ def _summarize_platforms(
     "Overrides the recipe's builder_config.rebuild setting.",
     hidden=HIDE_ADVANCED_OPTIONS,
 )
+@click.option(
+    "--env",
+    "-e",
+    "env_overrides",
+    multiple=True,
+    hidden=HIDE_ADVANCED_OPTIONS,
+    help="Set a container environment variable: -e KEY=VALUE (repeatable). Value is used verbatim, unlike -o env.KEY=VALUE.",
+)
 @click.option("--label", "labels_override", multiple=True, help="Set meta data on a container (e.g., --label com.example.key=value)")
 @click.option(
     "--executor-args",
@@ -219,6 +227,7 @@ def run(
     trust,
     scheduler_name,
     rebuild,
+    env_overrides,
     labels_override,
     options,
     executor_args,
@@ -242,6 +251,8 @@ def run(
       sparkrun run my-recipe.yaml --port 9000 --gpu-mem 0.8
 
       sparkrun run my-recipe.yaml -o attention_backend=triton -o max_model_len=4096
+
+      sparkrun run my-recipe.yaml -e VLLM_USE_V1=1 -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
     """
     from sparkrun.core.bootstrap import get_runtime
 
@@ -289,6 +300,17 @@ def run(
         port=port,
         served_model_name=served_model_name,
     )
+
+    # -e/--env lands in the same place as -o env.KEY=VALUE (recipe.env, the top
+    # container-env tier) but keeps the value verbatim. Applied after, so it
+    # wins if a key is given both ways.
+    if env_overrides:
+        from sparkrun.core.resolve import apply_env_overrides
+
+        try:
+            apply_env_overrides(recipe, env_overrides)
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
 
     # --rebuild/--no-rebuild is a builder-agnostic override carried in
     # builder_config so any builder (present or future) can honor it. Only

--- a/src/sparkrun/cli/_self_update.py
+++ b/src/sparkrun/cli/_self_update.py
@@ -112,9 +112,9 @@ def describe_change(channel: str, old: tuple[str | None, str | None], new: tuple
         if new_commit is None:
             return "sparkrun %s updated (could not determine new commit)." % channel
         if old_commit == new_commit:
-            return "sparkrun %s is already on the latest commit (g%s)." % (channel, new_commit[:7])
-        old_disp = ("g%s" % old_commit[:7]) if old_commit else "unknown"
-        return "sparkrun %s updated: %s -> g%s" % (channel, old_disp, new_commit[:7])
+            return "sparkrun %s is already on the latest commit (%s)." % (channel, new_commit[:7])
+        old_disp = old_commit[:7] if old_commit else "unknown"
+        return "sparkrun %s updated: commit %s -> %s" % (channel, old_disp, new_commit[:7])
     # stable / PyPI
     if new_version is None:
         return "sparkrun updated (could not determine new version)."

--- a/src/sparkrun/cli/_setup/_check.py
+++ b/src/sparkrun/cli/_setup/_check.py
@@ -28,6 +28,8 @@ from typing import Callable, TYPE_CHECKING
 
 import click
 
+from sparkrun.orchestration.executors.docker import GPU_ACCESS_CDI
+
 from .._common import host_options, json_option
 
 if TYPE_CHECKING:
@@ -65,10 +67,28 @@ class CheckContext:
     cluster_name: str | None
     multi_host: bool
 
+    gpu_access_modes: dict[str, str] = field(default_factory=dict)
+    """host -> the ``gpu_access_mode`` a launch on that host would resolve to.
+
+    Empty (or missing a host) when resolution failed; see :meth:`cdi_required`.
+    """
+
     @property
     def cluster_flag(self) -> str:
         """`` --cluster <name>`` suffix for guidance commands (empty if unknown)."""
         return " --cluster %s" % self.cluster_name if self.cluster_name else ""
+
+    def cdi_required(self, host: str) -> bool:
+        """Would a launch on *host* actually need a CDI spec?
+
+        Only when the resolved ``gpu_access_mode`` is ``cdi`` — a cluster that
+        requests GPUs with ``--gpus`` never reads ``/etc/cdi/nvidia.yaml``, so a
+        missing or stale spec is not a gap for it.
+
+        Fails **safe**: an unresolvable mode is treated as requiring CDI, which
+        is the historical behavior (a missing spec is a hard failure).
+        """
+        return self.gpu_access_modes.get(host, GPU_ACCESS_CDI) == GPU_ACCESS_CDI
 
 
 @dataclass
@@ -107,6 +127,10 @@ def _int_fact(facts: dict[str, str], key: str) -> int:
 #: string so the manual command can never drift from the wizard step that
 #: runs it.
 _CDI_REGENERATE = "sparkrun setup wizard%s (NVIDIA CDI step) — or: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+
+#: Why a CDI finding is reported at SKIP rather than FAIL/WARN. Shown verbatim
+#: in the detail so the reader knows it is a mode question, not a broken host.
+_CDI_UNUSED = "this cluster requests GPUs with --gpus (executor_config.gpu_access_mode); regenerate before switching to cdi"
 
 
 def _as_int(value: str | None) -> int:
@@ -183,30 +207,40 @@ def _check_cdi_spec(state: HostState, ctx: CheckContext) -> CheckItem:
         return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", SKIP, "no NVIDIA GPU detected")
     if not _truthy(facts, "CHECK_NVIDIA_CTK"):
         return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", SKIP, "requires nvidia-ctk (see above)")
+
+    # Severity is conditional on how this cluster actually asks for GPUs. With
+    # ``gpu_access_mode: gpus`` (the DGX Spark default) nothing reads the CDI
+    # spec, so its absence is not a gap — reporting FAIL would send the user to
+    # fix something that cannot affect their launches. The finding is still
+    # surfaced, at SKIP, because it becomes real the moment they switch modes.
+    required = ctx.cdi_required(state.host)
+
+    missing = _int_fact(facts, "CHECK_CDI_PATHS_MISSING")
+    checked = _int_fact(facts, "CHECK_CDI_PATHS_CHECKED")
+    stale = bool(checked and missing)
+
     if _truthy(facts, "CHECK_CDI_SPEC"):
         # Present, but possibly stale: the spec pins absolute driver-library
         # and device-node paths, and a driver upgrade moves them. Reported as
         # WARN rather than FAIL because a spec may legitimately reference an
         # optional path, and a false hard-failure on a working host is worse
         # than a prompt to regenerate.
-        missing = _int_fact(facts, "CHECK_CDI_PATHS_MISSING")
-        checked = _int_fact(facts, "CHECK_CDI_PATHS_CHECKED")
-        if checked and missing:
-            return CheckItem(
-                "cdi_spec",
-                "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)",
-                WARN,
-                "%d of %d referenced paths missing — spec looks stale (driver upgraded?)" % (missing, checked),
-                _CDI_REGENERATE % ctx.cluster_flag,
-            )
-        return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", OK)
-    return CheckItem(
-        "cdi_spec",
-        "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)",
-        FAIL,
-        "/etc/cdi/nvidia.yaml missing or empty",
-        _CDI_REGENERATE % ctx.cluster_flag,
-    )
+        if not stale:
+            return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", OK)
+        detail = "%d of %d referenced paths missing — spec looks stale (driver upgraded?)" % (missing, checked)
+        if required:
+            return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", WARN, detail, _CDI_REGENERATE % ctx.cluster_flag)
+        return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", SKIP, "%s — %s" % (detail, _CDI_UNUSED))
+
+    if required:
+        return CheckItem(
+            "cdi_spec",
+            "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)",
+            FAIL,
+            "/etc/cdi/nvidia.yaml missing or empty",
+            _CDI_REGENERATE % ctx.cluster_flag,
+        )
+    return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", SKIP, "not needed — %s" % _CDI_UNUSED)
 
 
 def _check_earlyoom(state: HostState, ctx: CheckContext) -> CheckItem:
@@ -377,6 +411,44 @@ def register(setup_group) -> None:
     group is defined there).
     """
 
+    def _resolve_gpu_access_modes(host_list, *, cluster_name, hosts, hosts_file, config) -> dict[str, str]:
+        """Map each host to the ``gpu_access_mode`` a launch on it would resolve to.
+
+        Runs the *real* executor resolution chain per host (the platform tier is
+        keyed off that host's hardware), so the check reports on the same value
+        the launch would use rather than re-deriving the rule. Mirrors the
+        launcher's fallback: with no cluster definition, hardware defaults to
+        DGX Spark.
+
+        Best-effort — any failure yields an empty/partial map and
+        :meth:`CheckContext.cdi_required` falls back to "CDI is required".
+        """
+        from sparkrun.core.hardware import default_dgx_spark_hardware
+        from sparkrun.orchestration.executor import resolve_executor
+
+        from .._common import _get_cluster_manager
+
+        modes: dict[str, str] = {}
+        cluster_def = None
+        try:
+            cluster_mgr = _get_cluster_manager()
+            # Same "which cluster" rule as resolve_cluster_config: an explicit
+            # --hosts/--hosts-file means the named cluster isn't the host source.
+            resolved = cluster_name or (cluster_mgr.get_default() if not (hosts or hosts_file) else None)
+            if resolved:
+                cluster_def = cluster_mgr.get(resolved)
+        except Exception:
+            logger.debug("Could not resolve cluster for gpu_access_mode", exc_info=True)
+
+        for host in host_list:
+            try:
+                hw = cluster_def.hardware_for(host) if cluster_def is not None else default_dgx_spark_hardware()
+                executor = resolve_executor(cluster=cluster_def, config=config, host_hardware=hw, rootless=False, auto_user=False)
+                modes[host] = executor.config.gpu_access_mode
+            except Exception:
+                logger.debug("Could not resolve gpu_access_mode for %s", host, exc_info=True)
+        return modes
+
     @setup_group.command("check")
     @host_options
     @json_option(help="Emit the full results as JSON")
@@ -410,7 +482,17 @@ def register(setup_group) -> None:
         host_list, user, ssh_kwargs = _resolve_setup_context(hosts, hosts_file, cluster_name, config, user=None)
 
         multi_host = len(host_list) > 1
-        check_ctx = CheckContext(cluster_name=cluster_name, multi_host=multi_host)
+        check_ctx = CheckContext(
+            cluster_name=cluster_name,
+            multi_host=multi_host,
+            gpu_access_modes=_resolve_gpu_access_modes(
+                host_list,
+                cluster_name=cluster_name,
+                hosts=hosts,
+                hosts_file=hosts_file,
+                config=config,
+            ),
+        )
 
         target = "cluster '%s'" % cluster_name if cluster_name else "%d host(s)" % len(host_list)
         click.echo("Setup check for %s (%d host(s))" % (target, len(host_list)))

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -357,6 +357,40 @@ def apply_platform_runtime_flag_defaults(recipe: Recipe, runtime_name: str, host
     return applied
 
 
+def resolve_platform_env_defaults(runtime: RuntimePlugin, host_hardware) -> dict[str, str]:
+    """Return the platform's container-env defaults for *runtime*.
+
+    The env peer of :func:`apply_platform_runtime_flag_defaults`: resolves the
+    hardware platform for *host_hardware* and asks it for
+    :meth:`~sparkrun.platforms.base.HardwarePlatformPlugin.default_env`, passing
+    both the runtime's name and its family (``get_family()``) so a platform can
+    target one variant or a whole family (``"vllm"``).
+
+    Unlike the flag defaults this returns rather than mutates: env is merged as
+    a *tier* by the caller (below the cluster's env and the recipe's ``env``),
+    so a user can override a platform default with any value, including an
+    empty one — a ``setdefault`` into ``recipe.env`` could not express that.
+
+    Never raises: a platform whose hook misbehaves contributes nothing.
+    """
+    from sparkrun.platforms import resolve_platform
+
+    if host_hardware is None or not getattr(host_hardware, "accelerators", None):
+        return {}
+
+    platform = resolve_platform(host_hardware)
+    if platform is None:
+        return {}
+
+    accel = host_hardware.accelerators[0]
+    try:
+        env = platform.default_env(runtime.runtime_name, accel, runtime_family=runtime.get_family()) or {}
+    except Exception:
+        logger.debug("Platform %r default_env raised", getattr(platform, "platform_name", "?"), exc_info=True)
+        return {}
+    return {str(k): str(val) for k, val in env.items()}
+
+
 def resolve_per_host_backends(
     host_list: list[str],
     cluster=None,
@@ -1010,7 +1044,10 @@ def launch_inference(
     # Build executor via the unified resolution chain (single source of
     # truth shared with cli._stop_logs).  Order: CLI → recipe → runtime
     # → per-executor adjustments (Docker reads rootless/auto_user here)
-    # → SparkrunConfig → per-executor defaults → dataclass field defaults.
+    # → SparkrunConfig → platform → per-executor defaults → dataclass field
+    # defaults.  The head host's hardware supplies the platform tier (e.g. DGX
+    # Spark pinning docker's GPU request to --gpus rather than CDI); one
+    # executor is built per launch, so a representative host is the right scope.
     from sparkrun.orchestration.executor import resolve_executor
 
     executor = resolve_executor(
@@ -1021,17 +1058,24 @@ def launch_inference(
         cli_overrides=executor_config if isinstance(executor_config, dict) else None,
         rootless=rootless,
         auto_user=auto_user,
+        host_hardware=_head_hw,
         v=v,
     )
 
-    # Cluster-level container env (e.g. CONTAINER_* imported from a legacy
-    # spark-vllm-docker .env), resolved from the cluster's env_file.  Layered
-    # UNDER recipe env so recipe/CLI env values win.  Single chokepoint —
-    # covers solo and cluster mode, all runtimes and executors.
+    # Container env tiers, lowest first:
+    #   platform (hardware tuning, e.g. PYTORCH_CUDA_ALLOC_CONF on GB10)
+    #   < cluster env_file (e.g. CONTAINER_* imported from a legacy
+    #     spark-vllm-docker .env)
+    #   < recipe env (which already carries any -e CLI override).
+    # Single chokepoint — covers solo and cluster mode, all runtimes and
+    # executors.  Keyed off the head host, like the platform flag defaults.
+    platform_env = resolve_platform_env_defaults(runtime, _head_hw)
+    if platform_env:
+        logger.debug("Applied platform env defaults: %s", sorted(platform_env))
+    cluster_env = cluster.resolve_env() if (cluster is not None and getattr(cluster, "env", None)) else {}
     effective_env = recipe.env
-    if cluster is not None and getattr(cluster, "env", None):
-        cluster_env = cluster.resolve_env()
-        effective_env = {**cluster_env, **(recipe.env or {})}
+    if platform_env or cluster_env:
+        effective_env = {**platform_env, **cluster_env, **(recipe.env or {})}
 
     # Launch
     rc = runtime.run(

--- a/src/sparkrun/core/registry.py
+++ b/src/sparkrun/core/registry.py
@@ -295,6 +295,15 @@ BOOTSTRAP_REGISTRY_URLS = [
     "https://github.com/spark-arena/community-recipe-registry.git",
 ]
 
+# Shared by the shipped default and the URL migration, so a migrated config and
+# a fresh install describe the ``eugr`` registry identically.
+EUGR_REGISTRY_DESCRIPTION = "Official mirror of eugr/spark-vllm-docker recipes and mods"
+
+# Prior description shipped alongside the pre-mirror upstream URL. The migration
+# refreshes a description only when it still matches this exactly, so a user who
+# edited theirs keeps it.
+_LEGACY_EUGR_DESCRIPTION = "Official eugr/spark-vllm-docker repo recipes"
+
 
 FALLBACK_DEFAULT_REGISTRIES = [
     RegistryEntry(
@@ -319,9 +328,14 @@ FALLBACK_DEFAULT_REGISTRIES = [
     ),
     RegistryEntry(
         name="eugr",
-        url="https://github.com/eugr/spark-vllm-docker",
+        # Our mirror of eugr/spark-vllm-docker's recipes+mods, not the upstream
+        # repo itself: the upstream repo is primarily a container build whose
+        # recipes are a small corner of it, and mirroring lets the registry
+        # carry its own .sparkrun/registry.yaml.  Existing configs pointing at
+        # the upstream URL are rewritten by MIGRATED_REGISTRY_URLS.
+        url="https://github.com/spark-arena/eugr-recipes",
         subpath="recipes",
-        description="Official eugr/spark-vllm-docker repo recipes",
+        description=EUGR_REGISTRY_DESCRIPTION,
         mods_subpath="mods",
         visible=True,
         trusted=True,
@@ -382,10 +396,29 @@ def _default_trusted_urls() -> set[str]:
 
 # List of git URLs for registries that have been superseded and should be cleaned up.
 # Comparison strips trailing .git from entry URLs before matching.
+#
+# A URL listed here is **removed** from the user's config, taking its recipes
+# with it.  When a registry *moves* rather than dies, list it in
+# :data:`MIGRATED_REGISTRY_URLS` instead — that rewrites the entry in place and
+# keeps the user's per-entry state (enabled/visible/trust).
 DEPRECATED_REGISTRIES: list[str] = [
     "https://github.com/scitrera/oss-spark-run",
-    # 'https://github.com/eugr/spark-vllm-docker',
+    # NOT the old eugr URL: it moved, it wasn't retired. See MIGRATED_REGISTRY_URLS.
 ]
+
+# Git URLs that have **moved**, mapped old -> new.  Applied as a one-time
+# rewrite of the user's ``registries.yaml`` on load, so an existing install
+# follows the move instead of pinning to the old repo forever.
+#
+# Keys and values are compared/stored via :func:`_normalize_registry_url`, so a
+# ``.git`` suffix or trailing slash on either side still matches.
+#
+# The ``eugr`` recipes moved from eugr's container-build repo to our mirror of
+# its ``recipes/`` + ``mods/`` trees.  The layout (``recipes``/``mods``
+# subpaths) is identical on both sides, so only the URL needs rewriting.
+MIGRATED_REGISTRY_URLS: dict[str, str] = {
+    "https://github.com/eugr/spark-vllm-docker": "https://github.com/spark-arena/eugr-recipes",
+}
 
 # Reserved name prefixes — only URLs from allowed GitHub orgs may use these.
 # This prevents third-party registries from impersonating official sources.
@@ -907,6 +940,54 @@ class RegistryManager:
         logger.info("Migrated registries.yaml to per-registry trust model")
         return entries
 
+    @staticmethod
+    def _migrate_registry_urls(entries: list[RegistryEntry]) -> bool:
+        """Rewrite entries whose URL appears in :data:`MIGRATED_REGISTRY_URLS`.
+
+        A moved registry keeps the user's own choices — name, subpaths,
+        ``enabled``/``visible`` — and follows the repo to its new home.
+        Without this an existing install would keep pulling the old repo
+        indefinitely, since nothing re-reads the shipped default URL once
+        ``registries.yaml`` exists.
+
+        **Trust is re-asserted from the shipped default** when the new URL is
+        one we ship as ``trusted=True``.  The one-shot backfill in
+        :meth:`_migrate_trust_field` only ever runs against a pre-trust file,
+        so a registry that became a trusted default *after* that file was
+        written is stuck untrusted forever — which is exactly the ``eugr``
+        case, and would leave its mods prompting on every launch.  Moving the
+        registry to a repo we publish is the natural point to apply the
+        default.
+
+        The tradeoff: ``_save_registries`` omits ``trusted: false``, so an
+        explicit ``registry untrust`` is indistinguishable on disk from "never
+        granted", and a user who had untrusted a now-moved default gets it
+        re-granted once.  Re-run ``sparkrun registry untrust <name>`` to
+        restore it; the move only happens once.
+
+        The ``eugr`` description is refreshed too, but only when it still
+        matches the string that shipped alongside the old URL, so a
+        user-customized description survives.
+
+        Returns:
+            True when at least one entry changed (the caller persists).
+        """
+        changed = False
+        trusted_urls = _default_trusted_urls()
+        for entry in entries:
+            new_url = MIGRATED_REGISTRY_URLS.get(_normalize_registry_url(entry.url))
+            if not new_url or _normalize_registry_url(entry.url) == _normalize_registry_url(new_url):
+                continue
+            logger.info("Registry %r moved: %s -> %s", entry.name, entry.url, new_url)
+            entry.url = new_url
+            if entry.description == _LEGACY_EUGR_DESCRIPTION:
+                entry.description = EUGR_REGISTRY_DESCRIPTION
+            if not entry.trusted and _normalize_registry_url(new_url) in trusted_urls:
+                logger.info("Registry %r ships trusted; applying that default after the move", entry.name)
+                entry.trusted = True
+            changed = True
+        return changed
+
     def _load_registries(self) -> list[RegistryEntry]:
         """Load registries from YAML configuration.
 
@@ -925,6 +1006,14 @@ class RegistryManager:
 
         try:
             entries = self._load_registries_from_file()
+
+            # Follow moved registries BEFORE anything else inspects the URL.
+            # Ordering is load-bearing for the trust backfill below: it marks an
+            # entry trusted by matching its URL against `_default_trusted_urls()`,
+            # which holds the *new* URLs — a pre-trust config still carrying an
+            # old URL would otherwise be backfilled as untrusted.
+            urls_migrated = self._migrate_registry_urls(entries)
+
             # Filter out any entries whose URL matches a deprecated registry
             filtered = []
             for entry in entries:
@@ -937,7 +1026,10 @@ class RegistryManager:
                 else:
                     filtered.append(entry)
             if needs_migration:
+                # Persists as part of the trust migration; no second write.
                 self._migrate_trust_field(filtered)
+            elif urls_migrated:
+                self._save_registries(filtered)
             return filtered
         except Exception as e:
             logger.warning("Failed to load registries.yaml: %s", e)
@@ -1128,6 +1220,13 @@ class RegistryManager:
         cache_dir = self._cache_dir(entry.name)
         git_env = self._git_env()
 
+        # A cached clone is keyed by registry *name*, but its `origin` is the
+        # URL it was cloned from. If the entry's URL has since changed (a
+        # MIGRATED_REGISTRY_URLS rewrite, or a hand-edited registries.yaml),
+        # the `git fetch origin` below would silently keep pulling the old
+        # repo. Drop the stale cache so the fresh-clone path runs.
+        self._drop_cache_if_url_changed(entry)
+
         try:
             if (cache_dir / ".git").exists():
                 # Update existing repository
@@ -1235,6 +1334,68 @@ class RegistryManager:
             logger.debug("Failed to sync registry %s: %s", entry.name, e)
             return False
 
+        return True
+
+    def _drop_cache_if_url_changed(self, entry: RegistryEntry) -> bool:
+        """Remove ``entry``'s cached clone when it came from a different URL.
+
+        The per-registry cache dir is keyed by name, so a registry that changes
+        URL keeps a checkout of the *old* repo whose ``origin`` still points
+        there.  ``_clone_or_pull_single`` fetches from ``origin``, so without
+        this the new URL would never actually be pulled.
+
+        Best-effort: an unreadable or remote-less cache is left alone rather
+        than deleted, since a failed sync is recoverable and a wrong delete is
+        not.  The cache dir may be a link into a shared clone (several
+        registries on one URL), so unlink rather than delete *through* it.
+
+        Returns:
+            True when a stale cache was dropped.
+        """
+        cache_dir = self._cache_dir(entry.name)
+        if not (cache_dir / ".git").exists():
+            return False
+
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(cache_dir), "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                env=self._git_env(),
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            logger.debug("Could not read origin for registry %s: %s", entry.name, e)
+            return False
+
+        if result.returncode != 0 or not isinstance(result.stdout, str):
+            # No origin remote, or output we can't read. "Can't tell" is not
+            # "changed" — a failed sync is recoverable, a wrong delete isn't.
+            logger.debug("Registry %s cache has no readable origin; leaving it alone", entry.name)
+            return False
+
+        cached_url = _normalize_registry_url(result.stdout.strip())
+        if cached_url == _normalize_registry_url(entry.url):
+            return False
+
+        logger.info(
+            "Registry %r cache was cloned from %s but is now %s; re-cloning",
+            entry.name,
+            cached_url,
+            entry.url,
+        )
+        try:
+            if is_dir_link(cache_dir):
+                remove_dir_link(cache_dir)
+            else:
+                import shutil
+
+                shutil.rmtree(cache_dir)
+        except OSError as e:
+            logger.warning("Could not remove stale cache for registry %s: %s", entry.name, e)
+            return False
         return True
 
     def _clone_or_pull(self, entry: RegistryEntry) -> bool:

--- a/src/sparkrun/core/resolve.py
+++ b/src/sparkrun/core/resolve.py
@@ -94,6 +94,39 @@ def apply_recipe_overrides(
     return recipe, overrides
 
 
+def apply_env_overrides(recipe, env_pairs) -> dict[str, str]:
+    """Apply ``KEY=VALUE`` container-env overrides to *recipe*.
+
+    The peer of ``-o env.KEY=VALUE`` (handled inside
+    :func:`apply_recipe_overrides`) for the direct ``-e/--env`` form, with one
+    deliberate difference: values are taken **verbatim**. The ``-o`` path routes
+    through ``coerce_value``, which turns ``-o env.X=true`` into the string
+    ``"True"`` — right for a serve flag, wrong for an env var a runtime parses
+    itself.
+
+    Only the first ``=`` splits, so ``FOO=a=b`` and
+    ``PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`` survive intact, and
+    ``FOO=`` sets an empty value (the way to blank out a lower-tier default).
+
+    Pure logic: no console I/O. Malformed entries raise ``ValueError``; the CLI
+    wrapper translates that into a ``UsageError``.
+
+    Returns the mapping that was applied (for logging / testing).
+    """
+    applied: dict[str, str] = {}
+    for pair in env_pairs or ():
+        if "=" not in pair:
+            raise ValueError("--env must be KEY=VALUE, got: %s" % pair)
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        if not key:
+            raise ValueError("--env has empty key: %s" % pair)
+        applied[key] = value
+    if recipe is not None and applied:
+        recipe.env.update(applied)
+    return applied
+
+
 def load_recipe(
     config: "SparkrunConfig",
     recipe_name: str,

--- a/src/sparkrun/models/vram.py
+++ b/src/sparkrun/models/vram.py
@@ -25,6 +25,7 @@ _DTYPE_BYTES: dict[str, float] = {
     "awq": 0.5,
     "nvfp4": 0.5,
     "awq4": 0.5,
+    "fp4": 0.5,
     "w4a16_awq": 0.5,
     "w4a16_nvfp4": 0.5,
     "awq8": 1.0,

--- a/src/sparkrun/orchestration/executor.py
+++ b/src/sparkrun/orchestration/executor.py
@@ -348,6 +348,38 @@ def _runtime_exec_config_dict(runtime: "RuntimePlugin | None") -> dict:
     return _coerce_dict(fn())
 
 
+def _platform_exec_dict(host_hardware, executor_name: str) -> dict:
+    """Flatten the resolved platform's executor defaults into a chain layer.
+
+    Resolves the :class:`~sparkrun.platforms.base.HardwarePlatformPlugin` for
+    *host_hardware* and asks it for
+    :meth:`~sparkrun.platforms.base.HardwarePlatformPlugin.default_executor_config`.
+    Sits directly above the executor's own ``default_config()`` so a
+    hardware-conditional default (DGX Spark's ``gpu_access_mode: gpus``) beats
+    the generic one while every user-facing layer still wins.
+
+    Contributes nothing when no hardware was threaded (naming/teardown paths),
+    when no platform claims the host, or when the platform raises — the
+    executor must resolve regardless.
+
+    Note this is the *head* host's platform: the executor is built once per
+    launch, so a mixed-hardware cluster resolves against a representative host
+    exactly like :func:`~sparkrun.core.launcher.apply_platform_runtime_flag_defaults`.
+    """
+    if host_hardware is None:
+        return {}
+    try:
+        from sparkrun.platforms import resolve_platform
+
+        platform = resolve_platform(host_hardware)
+        if platform is None:
+            return {}
+        return _coerce_dict(platform.default_executor_config(executor_name))
+    except Exception:
+        logger.debug("Platform executor-config resolution failed for %r", executor_name, exc_info=True)
+        return {}
+
+
 def _config_exec_dict(config: "SparkrunConfig | None") -> dict:
     """Flatten SparkrunConfig executor defaults into a chain layer."""
     if config is None:
@@ -530,6 +562,7 @@ def resolve_executor(
     cli_overrides: dict | None = None,
     rootless: bool = True,
     auto_user: bool = True,
+    host_hardware=None,
     v: Variables | None = None,
 ) -> Executor:
     """Single entry point that produces an :class:`Executor` for a launch.
@@ -544,8 +577,15 @@ def resolve_executor(
         6. ``cls.apply_runtime_adjustments(rootless=, auto_user=)``
         7. ``runtime.default_executor_config()``
         8. ``config.default_executor`` + ``config.executor_config``
-        9. ``cls.default_config()``
-        10. :class:`ExecutorConfig` dataclass field defaults
+        9. ``platform.default_executor_config(name)``  *(from* ``host_hardware`` *)*
+        10. ``cls.default_config()``
+        11. :class:`ExecutorConfig` dataclass field defaults
+
+    *host_hardware* is the launching host's :class:`~sparkrun.core.hardware.HostHardware`
+    (the head node's, since one executor is built per launch).  It selects the
+    hardware platform whose defaults form layer 9 — the tier that lets DGX Spark
+    request GPUs with ``--gpus`` while everything else stays on CDI.  Omitting it
+    (naming / teardown / log paths) simply drops that layer.
 
     The cluster layer sits between the recipe (workload-specific) and
     the runtime/config (generic) so a cluster's standing preferences
@@ -582,6 +622,7 @@ def resolve_executor(
             cls.apply_runtime_adjustments(rootless=rootless, auto_user=auto_user),
             _runtime_exec_config_dict(runtime),
             _config_exec_dict(config),
+            _platform_exec_dict(host_hardware, name),
             cls.default_config(),
         ),
         env_placement=EnvPlacement.IGNORED,

--- a/src/sparkrun/orchestration/executors/_base.py
+++ b/src/sparkrun/orchestration/executors/_base.py
@@ -128,6 +128,23 @@ class ExecutorConfig:
     For all non-NVIDIA values, ``gpus`` is ignored.
     """
 
+    gpu_access_mode: str = "cdi"
+    """How an NVIDIA GPU request is spelled on the container command line.
+
+    - ``"cdi"`` (default): Container Device Interface —
+      ``--device nvidia.com/gpu=<id>``.  Portable (Docker >= 25) and
+      *required* on daemons that reject ``--gpus`` (e.g. Thunder Compute),
+      but it depends on a valid, non-stale ``/etc/cdi/nvidia.yaml``.
+    - ``"gpus"``: the classic nvidia-container-runtime flag,
+      ``--gpus <gpus>``.
+
+    Resolved through the normal executor chain, so it can be pinned per
+    recipe / cluster / config; the platform tier
+    (:meth:`~sparkrun.platforms.base.HardwarePlatformPlugin.default_executor_config`)
+    supplies the per-hardware default — DGX Spark pins ``"gpus"``.  Only the
+    Docker executor consumes it (``gpus`` itself is what Local/K8s read).
+    """
+
     # Executor selector.  ``"docker"`` (default) uses
     # :class:`DockerExecutor`; ``"local"`` opts into the experimental
     # :class:`LocalExecutor` that runs the serve command as a native
@@ -178,7 +195,7 @@ class ExecutorConfig:
                 kwargs[key] = ext_parse_bool(v)
 
         # Plain (non-nullable) string fields — only forward when present.
-        for key in ("gpus", "ipc", "shm_size", "network"):
+        for key in ("gpus", "gpu_access_mode", "ipc", "shm_size", "network"):
             v = chain.get(key)
             if v is not None:
                 kwargs[key] = str(v)

--- a/src/sparkrun/orchestration/executors/docker.py
+++ b/src/sparkrun/orchestration/executors/docker.py
@@ -34,20 +34,55 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _nvidia_gpu_args(gpus: str | None) -> list[str]:
-    """Request NVIDIA GPUs via CDI (Container Device Interface).
+#: ``gpu_access_mode`` — request GPUs via the Container Device Interface,
+#: ``--device nvidia.com/gpu=<id>``.
+GPU_ACCESS_CDI = "cdi"
 
-    Emits ``--device nvidia.com/gpu=<id>``.  CDI is the modern, portable path
-    (Docker >= 25): it works on DGX Spark (``nvidia-ctk`` auto-registers the
-    devices) and is *required* on environments whose custom docker rejects
-    ``--gpus`` (e.g. Thunder Compute).  Maps the legacy ``gpus`` value —
-    ``"all"`` → ``nvidia.com/gpu=all``; ``"device=0,1"`` / ``"0,1"`` → one
-    ``--device`` per id.
+#: ``gpu_access_mode`` — request GPUs via the classic nvidia-container-runtime
+#: flag, ``--gpus <spec>``.
+GPU_ACCESS_GPUS = "gpus"
+
+GPU_ACCESS_MODES = frozenset({GPU_ACCESS_CDI, GPU_ACCESS_GPUS})
+
+#: Used when ``gpu_access_mode`` is unset or unrecognised.  CDI is the portable
+#: choice and the only one some daemons accept (see :func:`_nvidia_gpu_args`);
+#: hardware that prefers ``--gpus`` says so at the platform tier.
+GPU_ACCESS_DEFAULT = GPU_ACCESS_CDI
+
+
+def _nvidia_gpu_args(gpus: str | None, mode: str | None = None) -> list[str]:
+    """Emit the NVIDIA GPU request flags for *gpus* in the given access *mode*.
+
+    Two spellings exist and neither works everywhere:
+
+    - :data:`GPU_ACCESS_CDI` — ``--device nvidia.com/gpu=<id>`` (Container
+      Device Interface).  The modern, portable path (Docker >= 25) and
+      *required* on environments whose custom docker rejects ``--gpus`` (e.g.
+      Thunder Compute).  It depends on a present, non-stale
+      ``/etc/cdi/nvidia.yaml`` — a versioned driver upgrade leaves the spec
+      pointing at paths that no longer exist and containers then fail to start,
+      which is why some GB10 hosts do better on the classic flag.
+    - :data:`GPU_ACCESS_GPUS` — ``--gpus <spec>``, the nvidia-container-runtime
+      flag.  Passes the value straight through.
+
+    Maps the ``gpus`` value for CDI — ``"all"`` → ``nvidia.com/gpu=all``;
+    ``"device=0,1"`` / ``"0,1"`` → one ``--device`` per id.
     """
     # Falsy gpus (None / "") means "no GPU request" — preserve that (byte-identical
     # to the legacy `if cfg.gpus:` guard) rather than forcing all GPUs.
     if not gpus:
         return []
+    resolved = (mode or GPU_ACCESS_DEFAULT).strip().lower()
+    if resolved not in GPU_ACCESS_MODES:
+        logger.warning(
+            "DockerExecutor: unknown gpu_access_mode %r — falling back to %r. Known: %s",
+            mode,
+            GPU_ACCESS_DEFAULT,
+            sorted(GPU_ACCESS_MODES),
+        )
+        resolved = GPU_ACCESS_DEFAULT
+    if resolved == GPU_ACCESS_GPUS:
+        return ["--gpus", quote(gpus)]
     spec = gpus.strip().strip('"')
     if not spec or spec == "all":
         return ["--device", "nvidia.com/gpu=all"]
@@ -129,6 +164,7 @@ DOCKER_DEFAULTS = {
     "restart_policy": None,
     "privileged": True,
     "gpus": "all",
+    "gpu_access_mode": GPU_ACCESS_DEFAULT,
     "ipc": "host",
     "shm_size": "32gb",
     "network": "host",
@@ -193,7 +229,9 @@ class DockerExecutor(Executor):
     def _accelerator_opts(self) -> list[str]:
         """Emit accelerator device flags based on ``config.accelerator_vendor``.
 
-        - ``None`` (default) or ``"nvidia"`` → CDI (``--device nvidia.com/gpu=…``).
+        - ``None`` (default) or ``"nvidia"`` → the GPU request spelled per
+          ``config.gpu_access_mode`` (CDI ``--device nvidia.com/gpu=…`` or
+          classic ``--gpus``).
         - ``"amd"`` → ROCm device + render-group flags.
         - ``"intel"`` → Intel Gaudi device flag.
         - ``"apple"`` / ``"cpu"`` → no device flag.  Apple MLX cannot
@@ -204,7 +242,7 @@ class DockerExecutor(Executor):
         vendor = (cfg.accelerator_vendor or "").lower()
 
         if not vendor or vendor == "nvidia":
-            return _nvidia_gpu_args(cfg.gpus)
+            return _nvidia_gpu_args(cfg.gpus, cfg.gpu_access_mode)
         if vendor == "amd":
             return [
                 "--device",

--- a/src/sparkrun/platforms/base.py
+++ b/src/sparkrun/platforms/base.py
@@ -104,6 +104,25 @@ class HardwarePlatformPlugin(Plugin):
         """
         return None
 
+    def default_executor_config(self, executor_name: str) -> dict[str, object]:
+        """Platform-specific executor-config defaults for *executor_name*.
+
+        Returns a mapping of :class:`~sparkrun.orchestration.executor.ExecutorConfig`
+        keys that should apply on this platform.  Folded into the executor
+        resolution chain **below** ``config.executor_config`` and **above** the
+        executor's own ``default_config()``, so a recipe / cluster / user config
+        always wins while the platform still outranks the generic per-executor
+        default.
+
+        This is the platform tier for hardware-conditional container plumbing —
+        e.g. DGX Spark returns ``{"gpu_access_mode": "gpus"}`` for ``docker``
+        because CDI is fragile on GB10 hosts whose ``/etc/cdi/nvidia.yaml`` goes
+        stale across driver upgrades.
+
+        Base implementation returns ``{}`` (no platform-specific defaults).
+        """
+        return {}
+
     def default_runtime_flags(self, runtime_name: str, accelerator: AcceleratorSpec) -> dict[str, object]:
         """Platform/runtime/accelerator-specific recipe-flag defaults.
 
@@ -119,6 +138,38 @@ class HardwarePlatformPlugin(Plugin):
         memory.
 
         Base implementation returns ``{}`` (no platform-specific defaults).
+        """
+        return {}
+
+    def default_env(
+        self,
+        runtime_name: str,
+        accelerator: AcceleratorSpec,
+        *,
+        runtime_family: str | None = None,
+    ) -> dict[str, str]:
+        """Platform/runtime/accelerator-specific container env defaults.
+
+        The env-var peer of :meth:`default_runtime_flags`: same
+        platform × runtime × accelerator targeting, but the result is merged
+        into the container environment instead of the recipe's serve flags.
+        Use it for hardware tuning that a runtime reads from the environment
+        rather than the command line — e.g. DGX Spark sets
+        ``PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`` for vLLM/SGLang on
+        GB10.
+
+        *runtime_family* is :meth:`~sparkrun.runtimes.base.RuntimePlugin.get_family`
+        (``"vllm"`` for ``vllm-ray`` / ``vllm-distributed`` / ``eugr-vllm``), so a
+        platform can target a whole family without enumerating every variant.
+        Implementations should let an exact *runtime_name* match win over the
+        family match.
+
+        The launcher folds the result in as the **lowest** env tier — under the
+        cluster's ``env_file``, the recipe's ``env``, and any ``-e`` CLI
+        override — so a platform default can always be overridden, including
+        with an empty value.
+
+        Base implementation returns ``{}`` (no platform-specific env).
         """
         return {}
 

--- a/src/sparkrun/platforms/dgx_spark.py
+++ b/src/sparkrun/platforms/dgx_spark.py
@@ -39,6 +39,38 @@ _DGX_SPARK_RUNTIME_FLAGS: dict[str, dict[str, object]] = {
 }
 
 
+# Per-runtime container env defaults for GB10, keyed by runtime **family**
+# first (``get_family()``: ``"vllm"`` covers vllm-ray / vllm-distributed /
+# eugr-vllm) with exact ``runtime_name`` keys taking precedence.  Applied as the
+# lowest env tier, so a cluster / recipe / ``-e`` override always wins.
+#
+# ``expandable_segments`` lets PyTorch's caching allocator grow a segment in
+# place instead of reserving fixed-size blocks, which cuts the fragmentation
+# that GB10's unified memory makes expensive — the GPU's pool is shared with the
+# CPU/OS, so reserved-but-unused blocks are not free.  vLLM and SGLang are the
+# torch-allocator-bound runtimes; llama.cpp / TRT-LLM manage their own memory
+# and are deliberately left alone.
+_TORCH_EXPANDABLE_SEGMENTS = {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+
+_DGX_SPARK_RUNTIME_ENV: dict[str, dict[str, str]] = {
+    "vllm": _TORCH_EXPANDABLE_SEGMENTS,
+    "sglang": _TORCH_EXPANDABLE_SEGMENTS,
+}
+
+
+# Per-executor config defaults for GB10.  DGX Spark pins the docker executor
+# back to the classic ``--gpus`` flag: CDI (``--device nvidia.com/gpu=all``) is
+# the portable default elsewhere, but on GB10 it depends on an
+# ``/etc/cdi/nvidia.yaml`` that goes stale across driver upgrades (the spec pins
+# versioned absolute paths), and a stale spec fails ``docker run`` outright.
+# ``--gpus`` resolves through the container runtime at launch instead, so it
+# survives driver churn.  Override per cluster/recipe/config with
+# ``executor_config.gpu_access_mode: cdi``.
+_DGX_SPARK_EXECUTOR_CONFIG: dict[str, dict[str, object]] = {
+    "docker": {"gpu_access_mode": "gpus"},
+}
+
+
 class DgxSparkPlatform(HardwarePlatformPlugin):
     """NVIDIA DGX Spark (GB10, ConnectX-7 RoCEv2 fabric)."""
 
@@ -58,10 +90,33 @@ class DgxSparkPlatform(HardwarePlatformPlugin):
     def default_image(self, runtime_name: str) -> str | None:
         return _DGX_SPARK_DEFAULTS.get(runtime_name)
 
+    def default_executor_config(self, executor_name: str) -> dict[str, object]:
+        """GB10 executor defaults (docker requests GPUs via ``--gpus``)."""
+        return dict(_DGX_SPARK_EXECUTOR_CONFIG.get(executor_name, {}))
+
     def default_runtime_flags(self, runtime_name: str, accelerator: AcceleratorSpec) -> dict[str, object]:
         """GB10 recipe-flag defaults (e.g. ``mmap: False`` for llama.cpp)."""
         if accelerator.vendor == "nvidia" and accelerator.model == "gb10":
             return dict(_DGX_SPARK_RUNTIME_FLAGS.get(runtime_name, {}))
+        return {}
+
+    def default_env(
+        self,
+        runtime_name: str,
+        accelerator: AcceleratorSpec,
+        *,
+        runtime_family: str | None = None,
+    ) -> dict[str, str]:
+        """GB10 container env defaults (torch expandable segments for vLLM/SGLang).
+
+        An exact ``runtime_name`` entry wins over the family entry, so a single
+        variant can opt out or differ without disturbing the rest of its family.
+        """
+        if not (accelerator.vendor == "nvidia" and accelerator.model == "gb10"):
+            return {}
+        for key in (runtime_name, runtime_family):
+            if key and key in _DGX_SPARK_RUNTIME_ENV:
+                return dict(_DGX_SPARK_RUNTIME_ENV[key])
         return {}
 
     def default_max_gpu_memory_utilization(self, accelerator: AcceleratorSpec) -> float | None:

--- a/src/sparkrun/runtimes/_cluster_ops.py
+++ b/src/sparkrun/runtimes/_cluster_ops.py
@@ -856,7 +856,12 @@ def run_native_cluster(
     resolved_hosts = resolve_hosts_for_init(ctx, head_ip)
 
     # Do full reachability check to ensure that the head IP is reachable from all hosts.
-    from sparkrun.runtimes._init_network import InitNetworkCandidates, select_init_network
+    from sparkrun.runtimes._init_network import (
+        InitNetworkCandidates,
+        init_address_map,
+        remap_placement_addresses,
+        select_init_network,
+    )
 
     init_selection = select_init_network(
         ctx,
@@ -864,6 +869,14 @@ def run_native_cluster(
     )
     head_ip = init_selection.head_ip
     resolved_hosts = list(init_selection.hosts)
+
+    # The scheduler's placement still carries cluster-config host identifiers
+    # (``127.0.0.1`` for the control machine's own node).  Runtimes resolve
+    # ``--master-addr`` from placement *before* the resolved host list, so the
+    # placement handed to command generation must speak the selected init
+    # network too — otherwise workers are told to rendezvous on their own
+    # loopback.  Address-only view: never used for SSH targeting.
+    init_placement = remap_placement_addresses(ctx.placement, init_address_map(ctx.hosts, init_selection))
 
     # When init falls back to the fabric, the management/default-route
     # interface is the one that is unreachable — re-pin the per-host comm env
@@ -905,7 +918,7 @@ def run_native_cluster(
         init_port=init_port,
         skip_keys=skip_keys,
         hosts=resolved_hosts,
-        placement=ctx.placement,
+        placement=init_placement,
     )
     logger.info("Serve command (head, rank 0):")
     for line in head_command.strip().splitlines():
@@ -1047,7 +1060,7 @@ def run_native_cluster(
                     init_port=init_port,
                     skip_keys=skip_keys,
                     hosts=resolved_hosts,
-                    placement=ctx.placement,
+                    placement=init_placement,
                 )
                 worker_container = all_nodes[rank][2]
                 worker_sparkrun_labels = executor.workload_labels_for_cluster(

--- a/src/sparkrun/runtimes/_init_network.py
+++ b/src/sparkrun/runtimes/_init_network.py
@@ -95,6 +95,60 @@ def select_init_network(ctx: ClusterContext, candidates: InitNetworkCandidates) 
     return management
 
 
+def init_address_map(cluster_hosts: Sequence[str], selection: InitNetworkSelection) -> dict[str, str]:
+    """Map each cluster host identifier to the init address chosen for it.
+
+    ``selection.hosts`` is positionally aligned with the cluster's host
+    list — both the loopback substitution (``resolve_hosts_for_init``)
+    and the IB substitution (:func:`_build_ib_selection`) preserve order
+    and length — so the mapping is a positional zip.  A length mismatch
+    means the selection was not derived from *cluster_hosts*; the
+    identity map is returned rather than a silently skewed one.
+    """
+    if len(cluster_hosts) != len(selection.hosts):
+        logger.debug(
+            "  Init address map skipped: %d cluster host(s) vs %d selected address(es)",
+            len(cluster_hosts),
+            len(selection.hosts),
+        )
+        return {host: host for host in cluster_hosts}
+    return dict(zip(cluster_hosts, selection.hosts))
+
+
+def remap_placement_addresses(placement, addr_map: Mapping[str, str]):
+    """Return *placement* with every host replaced by its init address.
+
+    The scheduler's ``RankAssignment`` carries *cluster-config* host
+    identifiers — ``127.0.0.1`` for the control machine's own node, a
+    short DNS name, a management IP on a network a worker may not share.
+    Those identifiers are correct for SSH (they are how sparkrun reaches
+    the host) but wrong as a rendezvous address handed to a *worker*:
+    ``--master-addr 127.0.0.1`` points every worker at its own loopback.
+
+    :func:`select_init_network` already resolves the routable address
+    set, but ``RuntimePlugin._resolve_master_addr`` consults *placement*
+    ahead of the resolved host list (placement is the only source that
+    is correct for multi-rank-per-host topologies).  Remapping here keeps
+    that precedence while making the selected init network authoritative
+    for both sources.
+
+    The result is an address-only view: use it for emitting rendezvous
+    addresses into serve commands, never for SSH targeting.
+    """
+    if placement is None:
+        return None
+    if all(host == addr_map.get(host, host) for host in placement.hosts_used):
+        return placement
+
+    from dataclasses import replace
+
+    return replace(
+        placement,
+        by_rank=tuple(replace(slot, host=addr_map.get(slot.host, slot.host)) for slot in placement.by_rank),
+        hosts_used=tuple(addr_map.get(host, host) for host in placement.hosts_used),
+    )
+
+
 def workers_can_reach(ctx: ClusterContext, target_ip: str) -> bool:
     """Return whether every worker host can reach *target_ip*."""
     if ctx.dry_run or not ctx.worker_hosts:

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -304,6 +304,15 @@ class RuntimePlugin(Plugin):
            (1-GPU-per-host topologies).
         3. *head_ip* as final fallback (unit-test / solo paths).
 
+        Every source must already speak the selected *init* network — the
+        returned value is advertised to remote workers as a rendezvous
+        address, so a cluster-config identifier like ``127.0.0.1`` points
+        each worker at its own loopback.  ``head_ip`` and ``hosts`` are
+        resolved by ``_cluster_ops.resolve_hosts_for_init`` +
+        ``_init_network.select_init_network``; ``placement``, which the
+        scheduler emits with raw cluster-config hosts, must be passed
+        through ``_init_network.remap_placement_addresses`` first.
+
         Args:
             head_ip: The cluster head node IP.
             node_rank: Global rank for this node.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,11 @@ import pytest
 import yaml
 
 from sparkrun.core.bootstrap import init_sparkrun
+from sparkrun.core.registry import RegistryManager
+
+#: Captured before ``isolate_stateful`` stubs it out, so the ``real_registry_git``
+#: opt-out fixture can hand the genuine implementation back.
+_REAL_CLONE_OR_PULL = RegistryManager._clone_or_pull
 
 
 @pytest.fixture(autouse=True)
@@ -47,11 +52,71 @@ def isolate_stateful(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(_config_module, "DEFAULT_CONFIG_DIR", tmp_path / "config", raising=False)
 
+    # Same treatment for the cache dir, and for the same reason -- but the
+    # stakes are higher here because the cache holds *live* state, not just
+    # preferences. Unpatched, ProxyEngine defaults its state_dir to
+    # DEFAULT_CACHE_DIR/"proxy", so `api.proxy.status()` in a test reads the
+    # developer's really-running proxy and `api.proxy.stop()` SIGTERMs it.
+    # Job metadata, pending-op lock files and cached remote recipes land in the
+    # real cache the same way.
+    # Keep the trailing "sparkrun" segment: the real cache is ~/.cache/sparkrun
+    # and callers derive subpaths from it, so tests that assert on the shape of
+    # a derived path (".../sparkrun/tuning/vllm") stay meaningful.
+    _cache = tmp_path / "cache" / "sparkrun"
+    monkeypatch.setattr(_config_module, "DEFAULT_CACHE_DIR", _cache, raising=False)
+    # Two modules bind the symbol at import time, so patching core.config alone
+    # does not reach them. Keep this list in sync with:
+    #   grep -rn '^from sparkrun.core.config import.*DEFAULT_CACHE_DIR' src/
+    import sparkrun.core.pending_ops as _pending_ops
+    import sparkrun.tuning._common as _tuning_common
+
+    monkeypatch.setattr(_pending_ops, "DEFAULT_CACHE_DIR", _cache, raising=False)
+    monkeypatch.setattr(_tuning_common, "DEFAULT_CACHE_DIR", _cache, raising=False)
+
+    # No network from the test suite. The sandboxed config dir never has a
+    # registries.yaml, so every RegistryManager falls into first-run bootstrap
+    # (_default_registries -> _init_defaults_from_manifests) and git-clones each
+    # BOOTSTRAP_REGISTRY_URLS entry. That was previously masked by the cache dir
+    # leaking out to the developer's real, already-populated
+    # ~/.cache/sparkrun/registries; with the cache sandboxed it becomes a full
+    # clone of three GitHub repos, and a single CLI test went from 1.4s to 6.6s.
+    # Emptying the list takes the documented offline path: discovery yields
+    # nothing and FALLBACK_DEFAULT_REGISTRIES supplies the defaults.
+    # Tests that exercise discovery set their own URLs or mock subprocess.run.
+    import sparkrun.core.registry as _registry_module
+
+    monkeypatch.setattr(_registry_module, "BOOTSTRAP_REGISTRY_URLS", [], raising=False)
+
+    # ...and no `git clone` / `git fetch` either. `_clone_or_pull` is the single
+    # choke point for every registry git operation (registry.py + core/mods.py);
+    # it is documented best-effort and already returns False on failure, so
+    # stubbing it takes a path callers handle. Profiling one CLI test showed
+    # 5.3s of its 5.9s inside `_sync_url` / `_clone_or_pull_single` -- real
+    # network round-trips, in a suite that is supposed to be hermetic.
+    monkeypatch.setattr(_registry_module.RegistryManager, "_clone_or_pull", lambda self, entry: False, raising=False)
+
     import sparkrun.core.bootstrap
 
     sparkrun.core.bootstrap._variables = None
     yield
     sparkrun.core.bootstrap._variables = None
+
+
+@pytest.fixture
+def real_registry_git(isolate_stateful, monkeypatch):
+    """Restore ``RegistryManager._clone_or_pull`` for tests that mock git themselves.
+
+    ``isolate_stateful`` stubs the method so no test can reach the network by
+    accident. Tests that assert on the git argv (``update`` calls clone/pull,
+    ``--`` before the URL) patch ``subprocess.run`` in their own body, so the
+    real implementation is hermetic for them — they just need it back.
+
+    Depends on ``isolate_stateful`` so the ordering is explicit: the stub is
+    installed first, this undoes it.
+    """
+    import sparkrun.core.registry as registry_module
+
+    monkeypatch.setattr(registry_module.RegistryManager, "_clone_or_pull", _REAL_CLONE_OR_PULL)
 
 
 @pytest.fixture

--- a/tests/test_cdi_diagnostics.py
+++ b/tests/test_cdi_diagnostics.py
@@ -17,6 +17,7 @@ import pytest
 from sparkrun.cli._setup._check import (
     FAIL,
     OK,
+    SKIP,
     WARN,
     CheckContext,
     HostState,
@@ -75,6 +76,56 @@ def test_missing_staleness_facts_do_not_invent_a_finding():
 def test_unparseable_counts_do_not_invent_a_finding():
     item = _check_cdi_spec(_state(CHECK_CDI_SPEC="1", CHECK_CDI_PATHS_CHECKED="?", CHECK_CDI_PATHS_MISSING="?"), _ctx())
     assert item.status == OK
+
+
+# ---------------------------------------------------------------------------
+# Severity is conditional on the cluster's resolved gpu_access_mode
+# ---------------------------------------------------------------------------
+
+
+def _gpus_ctx() -> CheckContext:
+    """A cluster that requests GPUs with ``--gpus`` — CDI is off its launch path."""
+    return CheckContext(cluster_name="mylab", multi_host=True, gpu_access_modes={"h1": "gpus"})
+
+
+def _cdi_ctx() -> CheckContext:
+    return CheckContext(cluster_name="mylab", multi_host=True, gpu_access_modes={"h1": "cdi"})
+
+
+def test_absent_spec_is_not_a_gap_when_gpus_mode():
+    """No FAIL for a mechanism this cluster never uses (the DGX Spark default)."""
+    item = _check_cdi_spec(_state(CHECK_CDI_SPEC="0"), _gpus_ctx())
+    assert item.status == SKIP
+    assert "not needed" in item.detail
+    assert "gpu_access_mode" in item.detail
+
+
+def test_stale_spec_is_not_a_gap_when_gpus_mode():
+    item = _check_cdi_spec(_state(CHECK_CDI_SPEC="1", CHECK_CDI_PATHS_CHECKED="12", CHECK_CDI_PATHS_MISSING="5"), _gpus_ctx())
+    assert item.status == SKIP
+    # The staleness itself is still reported — it becomes real on a mode switch.
+    assert "5 of 12" in item.detail
+    assert "switching to cdi" in item.detail
+
+
+def test_healthy_spec_is_ok_regardless_of_mode():
+    facts = dict(CHECK_CDI_SPEC="1", CHECK_CDI_PATHS_CHECKED="12", CHECK_CDI_PATHS_MISSING="0")
+    assert _check_cdi_spec(_state(**facts), _gpus_ctx()).status == OK
+    assert _check_cdi_spec(_state(**facts), _cdi_ctx()).status == OK
+
+
+def test_explicit_cdi_mode_keeps_the_hard_failure():
+    item = _check_cdi_spec(_state(CHECK_CDI_SPEC="0"), _cdi_ctx())
+    assert item.status == FAIL
+    assert "nvidia-ctk cdi generate" in item.guidance
+
+
+def test_unresolved_mode_fails_safe_to_requiring_cdi():
+    """An unknown host (resolution failed) keeps the historical severity."""
+    ctx = CheckContext(cluster_name="mylab", multi_host=True, gpu_access_modes={"other-host": "gpus"})
+    assert _check_cdi_spec(_state(CHECK_CDI_SPEC="0"), ctx).status == FAIL
+    assert ctx.cdi_required("h1") is True
+    assert ctx.cdi_required("other-host") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,7 +211,32 @@ class TestListCommand:
 class TestSearchCommand:
     """Test the search command."""
 
-    def test_search_shows_recipes(self, runner):
+    @pytest.fixture
+    def cwd_recipe(self, tmp_path, monkeypatch):
+        """A working-directory recipe for search to find.
+
+        These tests used to search for "llama-cpp" and expect hits from the
+        *default registries* — i.e. they only passed if the machine could git
+        clone three GitHub repos and those repos still shipped a llama-cpp
+        recipe. The suite no longer touches the network (see conftest), so the
+        catalog has to be seeded locally.
+        """
+        (tmp_path / "cwd-llama-cpp.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "cwd-llama-cpp",
+                    "model": "unsloth/Qwen3-1.7B-GGUF:Q4_K_M",
+                    "runtime": "llama-cpp",
+                    # discover_cwd_recipes -> is_recipe_file requires container
+                    "container": "scitrera/dgx-spark-llama-cpp:latest",
+                    "description": "local recipe for search tests",
+                }
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        return tmp_path
+
+    def test_search_shows_recipes(self, runner, cwd_recipe):
         """Test that sparkrun search finds matching recipes."""
         result = runner.invoke(main, ["search", "llama-cpp"])
         assert result.exit_code == 0
@@ -224,7 +249,7 @@ class TestSearchCommand:
         assert result.exit_code == 0
         assert "No recipes found matching" in result.output
 
-    def test_search_json(self, runner):
+    def test_search_json(self, runner, cwd_recipe):
         """Test that sparkrun recipe search --json outputs a valid JSON list."""
         import json
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2523,6 +2523,19 @@ class TestOptionOverrides:
             assert call_kwargs["overrides"]["attention_backend"] == "triton"
             assert call_kwargs["overrides"]["max_model_len"] == 4096  # auto-coerced to int
 
+    def test_env_dot_option_reaches_container_env(self, runner, reset_bootstrap):
+        """-o env.KEY=VALUE lands in the container env, not in overrides."""
+        with mock.patch.object(SglangRuntime, "run", return_value=0) as mock_run:
+            result = runner.invoke(
+                main,
+                ["run", _TEST_RECIPE_NAME, "--solo", "--dry-run", "--hosts", "localhost", "-o", "env.MY_FLAG=hello"],
+            )
+
+            assert result.exit_code == 0
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["env"]["MY_FLAG"] == "hello"
+            assert "env.MY_FLAG" not in call_kwargs["overrides"]
+
     def test_dedicated_cli_param_overrides_option(self, runner, reset_bootstrap):
         """--port takes priority over -o port=XXXX."""
         with mock.patch.object(SglangRuntime, "run", return_value=0) as mock_run:
@@ -2694,6 +2707,80 @@ class TestOptionOverrides:
 
         assert result.exit_code != 0
         assert "must be key=value" in result.output
+
+
+class TestEnvOverrides:
+    """Test -e/--env container environment variables on `sparkrun run`."""
+
+    def _run_env(self, runner, *args):
+        """Invoke a dry run with *args* and return the env dict the runtime got."""
+        with mock.patch.object(SglangRuntime, "run", return_value=0) as mock_run:
+            result = runner.invoke(
+                main,
+                ["run", _TEST_RECIPE_NAME, "--solo", "--dry-run", "--hosts", "localhost", *args],
+            )
+            assert result.exit_code == 0, result.output
+            return mock_run.call_args.kwargs["env"]
+
+    def test_env_reaches_the_container(self, runner, reset_bootstrap):
+        env = self._run_env(runner, "-e", "MY_FLAG=hello")
+        assert env["MY_FLAG"] == "hello"
+
+    def test_env_is_repeatable(self, runner, reset_bootstrap):
+        env = self._run_env(runner, "-e", "A=1", "--env", "B=2")
+        assert env["A"] == "1"
+        assert env["B"] == "2"
+
+    def test_env_value_is_verbatim_unlike_the_o_form(self, runner, reset_bootstrap):
+        """The point of the flag: -o routes through coerce_value, -e does not.
+
+        A runtime that parses ``true`` itself must not receive Python's ``True``.
+        """
+        env = self._run_env(runner, "-e", "VIA_E=true", "-o", "env.VIA_O=true")
+        assert env["VIA_E"] == "true"
+        assert env["VIA_O"] == "True"
+
+    def test_only_the_first_equals_splits(self, runner, reset_bootstrap):
+        env = self._run_env(runner, "-e", "ALLOC=expandable_segments:True", "-e", "PAIR=a=b")
+        assert env["ALLOC"] == "expandable_segments:True"
+        assert env["PAIR"] == "a=b"
+
+    def test_empty_value_is_allowed(self, runner, reset_bootstrap):
+        """`-e KEY=` is how a lower-tier default (platform/cluster) gets blanked."""
+        assert self._run_env(runner, "-e", "BLANKED=")["BLANKED"] == ""
+
+    def test_env_wins_over_the_o_form_for_the_same_key(self, runner, reset_bootstrap):
+        env = self._run_env(runner, "-o", "env.CONFLICT=from-o", "-e", "CONFLICT=from-e")
+        assert env["CONFLICT"] == "from-e"
+
+    def test_malformed_env_is_a_usage_error(self, runner, reset_bootstrap):
+        result = runner.invoke(
+            main,
+            ["run", _TEST_RECIPE_NAME, "--solo", "--dry-run", "--hosts", "localhost", "-e", "NOEQUALS"],
+        )
+        assert result.exit_code != 0
+        assert "must be KEY=VALUE" in result.output
+
+    def test_empty_key_is_a_usage_error(self, runner, reset_bootstrap):
+        result = runner.invoke(
+            main,
+            ["run", _TEST_RECIPE_NAME, "--solo", "--dry-run", "--hosts", "localhost", "-e", "=orphan"],
+        )
+        assert result.exit_code != 0
+        assert "empty key" in result.output
+
+    def test_visibility_follows_the_advanced_flag(self, runner):
+        """Hidden from --help unless SPARKRUN_ADVANCED is set.
+
+        Read the constant rather than assuming: it is resolved at import time,
+        so a developer running the suite with SPARKRUN_ADVANCED=1 sees the
+        opposite and neither answer is a failure.
+        """
+        from sparkrun.cli._common import HIDE_ADVANCED_OPTIONS
+
+        result = runner.invoke(main, ["run", "--help"])
+        assert result.exit_code == 0
+        assert ("--env" in result.output) is not HIDE_ADVANCED_OPTIONS
 
 
 class TestFollowLogs:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import yaml
 
-from sparkrun.core.config import SparkrunConfig, DEFAULT_CACHE_DIR, DEFAULT_HF_CACHE_DIR
+import sparkrun.core.config as config_module
+from sparkrun.core.config import SparkrunConfig, DEFAULT_HF_CACHE_DIR
 
 
 def test_config_defaults_no_file(tmp_path: Path):
@@ -17,8 +18,11 @@ def test_config_defaults_no_file(tmp_path: Path):
     nonexistent = tmp_path / "nonexistent" / "config.yaml"
     config = SparkrunConfig(config_path=nonexistent)
 
-    # Should use defaults when file doesn't exist
-    assert config.cache_dir == DEFAULT_CACHE_DIR
+    # Should use defaults when file doesn't exist. Read DEFAULT_CACHE_DIR off
+    # the module rather than binding it at import: the isolate_stateful fixture
+    # redirects it into the sandbox, so an import-time copy would be the real
+    # ~/.cache/sparkrun and never match.
+    assert config.cache_dir == config_module.DEFAULT_CACHE_DIR
     assert config.hf_cache_dir == DEFAULT_HF_CACHE_DIR
     assert config.default_hosts == []
     assert config.ssh_user is None

--- a/tests/test_executor_accelerator.py
+++ b/tests/test_executor_accelerator.py
@@ -9,8 +9,8 @@ from sparkrun.orchestration.executor import ExecutorConfig, accelerator_vendor_f
 from sparkrun.orchestration.executors.docker import DockerExecutor
 
 
-def _build_opts(vendor: str | None = None, gpus: str = "all") -> list[str]:
-    cfg = ExecutorConfig(accelerator_vendor=vendor, gpus=gpus, privileged=False, network="")
+def _build_opts(vendor: str | None = None, gpus: str = "all", mode: str = "cdi") -> list[str]:
+    cfg = ExecutorConfig(accelerator_vendor=vendor, gpus=gpus, gpu_access_mode=mode, privileged=False, network="")
     return DockerExecutor(cfg)._accelerator_opts()
 
 
@@ -41,6 +41,49 @@ def test_nvidia_with_custom_gpu_spec_maps_to_cdi():
 def test_default_with_empty_gpus_emits_nothing():
     """Empty gpus -> no device flag (preserved from the legacy behavior)."""
     assert _build_opts(vendor=None, gpus="") == []
+
+
+# --------------------------------------------------------------------------
+# gpu_access_mode — CDI vs the classic --gpus flag
+# --------------------------------------------------------------------------
+
+
+def test_gpus_mode_emits_legacy_flag():
+    """gpu_access_mode=gpus -> the classic --gpus <spec>."""
+    assert _build_opts(gpus="all", mode="gpus") == ["--gpus", "all"]
+
+
+def test_gpus_mode_passes_device_spec_through_verbatim():
+    """Unlike CDI, --gpus takes the spec as-is (no per-id expansion)."""
+    assert _build_opts(gpus="device=0,1", mode="gpus") == ["--gpus", "device=0,1"]
+
+
+def test_gpus_mode_with_empty_gpus_emits_nothing():
+    """Falsy gpus still means "no GPU request" in either mode."""
+    assert _build_opts(gpus="", mode="gpus") == []
+
+
+def test_unknown_gpu_access_mode_falls_back_to_cdi_with_warning(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        opts = _build_opts(gpus="all", mode="nvidia-docker2")
+    assert opts == ["--device", "nvidia.com/gpu=all"]
+    assert any("unknown gpu_access_mode" in rec.message for rec in caplog.records)
+
+
+def test_default_config_gpu_access_mode_is_cdi():
+    """DOCKER_DEFAULTS keeps CDI — hardware that wants --gpus says so at the platform tier."""
+    from sparkrun.orchestration.executors.docker import DOCKER_DEFAULTS
+
+    assert DOCKER_DEFAULTS["gpu_access_mode"] == "cdi"
+
+
+def test_run_cmd_gpus_mode_emits_legacy_flag():
+    cfg = ExecutorConfig(privileged=False, gpus="all", gpu_access_mode="gpus", network="")
+    cmd = DockerExecutor(cfg).run_cmd(image="img", container_name="test")
+    assert "--gpus all" in cmd
+    assert "nvidia.com/gpu" not in cmd
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_executor_resolution.py
+++ b/tests/test_executor_resolution.py
@@ -623,6 +623,83 @@ class TestClusterLayer:
         assert ex.config.shm_size == "100g"
 
 
+class TestPlatformLayer:
+    """``platform.default_executor_config(name)`` sits above the executor's own
+    defaults and below every user-facing layer.  Threaded via ``host_hardware``.
+    """
+
+    @staticmethod
+    def _gb10():
+        from sparkrun.core.hardware import default_dgx_spark_hardware
+
+        return default_dgx_spark_hardware()
+
+    @staticmethod
+    def _h100():
+        from sparkrun.core.hardware import AcceleratorSpec, HostHardware
+
+        return HostHardware(accelerators=[AcceleratorSpec(vendor="nvidia", model="h100", memory_gb=80.0)])
+
+    def test_no_hardware_keeps_executor_default(self):
+        """Naming / teardown paths pass no hardware — the layer drops out."""
+        ex = resolve_executor(rootless=False, auto_user=False)
+        assert ex.config.gpu_access_mode == "cdi"
+
+    def test_dgx_spark_pins_gpus_mode(self):
+        ex = resolve_executor(host_hardware=self._gb10(), rootless=False, auto_user=False)
+        assert ex.config.gpu_access_mode == "gpus"
+
+    def test_generic_nvidia_inherits_cdi(self):
+        """Only DGX Spark opts out of CDI; other NVIDIA hosts keep the default."""
+        ex = resolve_executor(host_hardware=self._h100(), rootless=False, auto_user=False)
+        assert ex.config.gpu_access_mode == "cdi"
+
+    def test_recipe_overrides_platform(self):
+        ex = resolve_executor(
+            recipe=_FakeRecipe(executor_config={"gpu_access_mode": "cdi"}),
+            host_hardware=self._gb10(),
+            rootless=False,
+            auto_user=False,
+        )
+        assert ex.config.gpu_access_mode == "cdi"
+
+    def test_config_overrides_platform(self):
+        class _Cfg:
+            default_executor = None
+            executor_config = {"gpu_access_mode": "cdi"}
+
+        ex = resolve_executor(config=_Cfg(), host_hardware=self._gb10(), rootless=False, auto_user=False)
+        assert ex.config.gpu_access_mode == "cdi"
+
+    def test_platform_layer_is_executor_scoped(self):
+        """DGX Spark publishes docker defaults only — a different executor is untouched."""
+        ex = resolve_executor(
+            recipe=_FakeRecipe(executor="local"),
+            host_hardware=self._gb10(),
+            rootless=False,
+            auto_user=False,
+        )
+        assert ex.config.gpu_access_mode == "cdi"
+
+    def test_platform_error_is_swallowed(self, monkeypatch):
+        import sparkrun.platforms as platforms
+
+        def _raise(hw):
+            raise ValueError("boom")
+
+        monkeypatch.setattr(platforms, "resolve_platform", _raise)
+        ex = resolve_executor(host_hardware=self._gb10(), rootless=False, auto_user=False)
+        assert ex.config.gpu_access_mode == "cdi"
+
+    def test_unclaimed_hardware_contributes_nothing(self):
+        """A host no platform claims (AMD today) falls through to the executor default."""
+        from sparkrun.core.hardware import AcceleratorSpec, HostHardware
+
+        hw = HostHardware(accelerators=[AcceleratorSpec(vendor="amd", model="mi300x")])
+        ex = resolve_executor(host_hardware=hw, rootless=False, auto_user=False)
+        assert ex.config.gpu_access_mode == "cdi"
+
+
 class TestBuilderEnvFileLayer:
     """A builder that produces a shell env_file auto-populates the executor's
     ``env_file`` — below an explicit recipe/CLI ``executor_config.env_file``

--- a/tests/test_export_systemd.py
+++ b/tests/test_export_systemd.py
@@ -1,10 +1,11 @@
 """Test systemd export correctly outputs YAML."""
 
+import yaml
 from click.testing import CliRunner
 from sparkrun.cli import main
 
 
-def test_export_systemd_preserves_single_quotes(monkeypatch):
+def test_export_systemd_preserves_single_quotes(monkeypatch, tmp_path):
     """Test systemd export does not escape single quotes in YAML."""
     runner = CliRunner()
 
@@ -14,10 +15,28 @@ def test_export_systemd_preserves_single_quotes(monkeypatch):
         lambda host, ssh_kwargs, dry_run=False: ("/usr/local/bin/sparkrun", "/home/user"),
     )
 
-    # Use a recipe that contains single quotes in env vars
-    result = runner.invoke(main, ["export", "systemd", "@official/qwen3-coder-next-int4-autoround-vllm", "--hosts", "127.0.0.1"])
+    # A recipe whose env values are quoted strings. This used to name
+    # `@official/qwen3-coder-next-int4-autoround-vllm`, which made the test
+    # depend on git-cloning the official registry *and* on that remote recipe
+    # keeping this exact env var. The subject here is the export's YAML
+    # quoting, so a local file (find_recipe resolves a direct path) tests it
+    # without either dependency.
+    recipe = tmp_path / "quoted-env-vllm.yaml"
+    recipe.write_text(
+        yaml.safe_dump(
+            {
+                "name": "quoted-env-vllm",
+                "model": "Qwen/Qwen3-1.7B",
+                "runtime": "vllm",
+                "container": "vllm/vllm-openai:latest",
+                "env": {"VLLM_MARLIN_USE_ATOMIC_ADD": "1"},
+            }
+        )
+    )
 
-    assert result.exit_code == 0
+    result = runner.invoke(main, ["export", "systemd", str(recipe), "--hosts", "127.0.0.1"])
+
+    assert result.exit_code == 0, result.output
     # Look for the env var VLLM_MARLIN_USE_ATOMIC_ADD which should have single quotes
     # Before the fix, it would be VLLM_MARLIN_USE_ATOMIC_ADD: '\''1'\''
     # After the fix, it should be VLLM_MARLIN_USE_ATOMIC_ADD: '1'

--- a/tests/test_init_network.py
+++ b/tests/test_init_network.py
@@ -2,11 +2,12 @@
 
 from unittest import mock
 
+from sparkrun.core.scheduler import RankAssignment, RankSlot
 from sparkrun.orchestration.comm_env import ClusterCommEnv
 from sparkrun.runtimes import _cluster_ops, _init_network
 
 
-def _make_ctx(hosts: list[str], *, dry_run: bool = False) -> _cluster_ops.ClusterContext:
+def _make_ctx(hosts: list[str], *, dry_run: bool = False, placement=None) -> _cluster_ops.ClusterContext:
     return _cluster_ops.ClusterContext(
         hosts=list(hosts),
         head_host=hosts[0],
@@ -19,6 +20,14 @@ def _make_ctx(hosts: list[str], *, dry_run: bool = False) -> _cluster_ops.Cluste
         image="test:image",
         dry_run=dry_run,
         config=None,
+        placement=placement,
+    )
+
+
+def _one_gpu_per_host_placement(hosts: list[str]) -> RankAssignment:
+    return RankAssignment(
+        by_rank=tuple(RankSlot(host=host, local_gpu=0) for host in hosts),
+        hosts_used=tuple(hosts),
     )
 
 
@@ -258,3 +267,147 @@ def test_launch_containers_parallel_applies_runtime_finalize_hook():
     runtime.finalize_host_comm_env.assert_called_once()
     assert captured["nccl_env"]["NODE_IP"] == "192.168.0.155"
     assert captured["nccl_env"]["VLLM_HOST_IP"] == "192.168.0.155"
+
+
+class TestPlacementInitAddresses:
+    """The scheduler's placement must speak the selected init network."""
+
+    def test_address_map_zips_cluster_hosts_to_selection(self):
+        """Given aligned lists, the map pairs each cluster host with its init address."""
+        selection = _init_network.InitNetworkSelection(
+            head_ip="10.113.145.138",
+            hosts=("10.113.145.138", "10.113.145.65"),
+            network="management",
+        )
+
+        assert _init_network.init_address_map(["127.0.0.1", "10.113.145.65"], selection) == {
+            "127.0.0.1": "10.113.145.138",
+            "10.113.145.65": "10.113.145.65",
+        }
+
+    def test_address_map_falls_back_to_identity_on_length_mismatch(self):
+        """A selection not derived from these hosts must not produce a skewed map."""
+        selection = _init_network.InitNetworkSelection(head_ip="10.0.0.1", hosts=("10.0.0.1",), network="management")
+
+        assert _init_network.init_address_map(["127.0.0.1", "node-2"], selection) == {
+            "127.0.0.1": "127.0.0.1",
+            "node-2": "node-2",
+        }
+
+    def test_remap_rewrites_loopback_rank_host(self):
+        """Given a loopback placement, the remapped view carries the routable head IP."""
+        placement = _one_gpu_per_host_placement(["127.0.0.1", "10.113.145.65"])
+
+        remapped = _init_network.remap_placement_addresses(
+            placement,
+            {"127.0.0.1": "10.113.145.138", "10.113.145.65": "10.113.145.65"},
+        )
+
+        assert remapped.host_for_rank(0) == "10.113.145.138"
+        assert remapped.host_for_rank(1) == "10.113.145.65"
+        assert remapped.hosts_used == ("10.113.145.138", "10.113.145.65")
+        # Source placement is untouched — it stays the SSH-addressable truth.
+        assert placement.host_for_rank(0) == "127.0.0.1"
+
+    def test_remap_preserves_slot_resources_and_multi_gpu_ranks(self):
+        """Per-rank GPU index and fractional claims survive the address rewrite."""
+        placement = RankAssignment(
+            by_rank=(
+                RankSlot(host="127.0.0.1", local_gpu=0, util_fraction=0.5, memory_gb=40.0),
+                RankSlot(host="127.0.0.1", local_gpu=1),
+            ),
+            hosts_used=("127.0.0.1",),
+        )
+
+        remapped = _init_network.remap_placement_addresses(placement, {"127.0.0.1": "10.0.0.1"})
+
+        assert [(s.host, s.local_gpu, s.util_fraction, s.memory_gb) for s in remapped.by_rank] == [
+            ("10.0.0.1", 0, 0.5, 40.0),
+            ("10.0.0.1", 1, 1.0, None),
+        ]
+
+    def test_remap_is_identity_when_no_host_changes(self):
+        """An all-routable placement is returned verbatim (no needless copy)."""
+        placement = _one_gpu_per_host_placement(["node-1", "node-2"])
+
+        assert _init_network.remap_placement_addresses(placement, {"node-1": "node-1", "node-2": "node-2"}) is placement
+
+    def test_remap_of_none_is_none(self):
+        """Callers that never scheduled keep their None placement."""
+        assert _init_network.remap_placement_addresses(None, {"a": "b"}) is None
+
+
+def test_native_cluster_remaps_loopback_placement_to_routable_head(monkeypatch):
+    """Given a 127.0.0.1 head, node commands must not receive a loopback placement.
+
+    Regression: ``_resolve_master_addr`` consults placement *before* the
+    resolved host list, so a cluster whose head is listed as ``127.0.0.1``
+    emitted ``--master-addr 127.0.0.1`` and every worker rendezvoused on
+    its own loopback — even though head-IP detection and the reachability
+    guard had both resolved the routable address.
+    """
+    hosts = ["127.0.0.1", "10.113.145.65"]
+    ctx = _make_ctx(hosts, placement=_one_gpu_per_host_placement(hosts))
+    monkeypatch.setattr(_cluster_ops, "cleanup_ranked_containers", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        _cluster_ops,
+        "detect_ib_with_ips",
+        lambda *_a, **_k: (ClusterCommEnv.empty(), {}, {}),
+    )
+    monkeypatch.setattr(_cluster_ops, "detect_head_ip", lambda _ctx: "10.113.145.138")
+    monkeypatch.setattr(_cluster_ops, "find_port", lambda _ctx, _host, port: port)
+    # Management head is reachable from the worker — the real-world case.
+    monkeypatch.setattr(_init_network, "workers_can_reach", lambda _ctx, _target: True)
+    monkeypatch.setattr(_cluster_ops, "launch_containers_parallel", lambda *_a, **_k: 1)
+
+    runtime = mock.MagicMock()
+    runtime._resolve_executor.return_value.node_container_name = lambda cid, rank: "%s_node_%d" % (cid, rank)
+    runtime.generate_node_command = mock.MagicMock(return_value="serve")
+    runtime.get_extra_docker_opts = lambda: []
+    runtime._print_cluster_banner = mock.MagicMock()
+
+    _cluster_ops.run_native_cluster(runtime=runtime, ctx=ctx)
+
+    call = runtime.generate_node_command.call_args
+    assert call.kwargs["head_ip"] == "10.113.145.138"
+    assert call.kwargs["hosts"] == ["10.113.145.138", "10.113.145.65"]
+    assert call.kwargs["placement"].host_for_rank(0) == "10.113.145.138"
+    # SSH targeting still uses the cluster-config identifiers.
+    assert ctx.hosts == ["127.0.0.1", "10.113.145.65"]
+
+
+def test_native_cluster_remaps_placement_onto_fabric_on_ib_fallback(monkeypatch):
+    """Given the IB fallback verdict, placement addresses follow the fabric too."""
+    hosts = ["node-1", "node-2"]
+    ctx = _make_ctx(hosts, placement=_one_gpu_per_host_placement(hosts))
+    monkeypatch.setattr(_cluster_ops, "cleanup_ranked_containers", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        _cluster_ops,
+        "detect_ib_with_ips",
+        lambda *_a, **_k: (
+            ClusterCommEnv.empty(),
+            {"node-1": "192.168.100.10", "node-2": "192.168.100.11"},
+            {"node-1": "cx0", "node-2": "cx0"},
+        ),
+    )
+    monkeypatch.setattr(_cluster_ops, "detect_head_ip", lambda _ctx: "192.168.128.10")
+    monkeypatch.setattr(
+        _cluster_ops,
+        "resolve_hosts_for_init",
+        lambda _ctx, _head_ip: ["192.168.128.10", "192.168.96.114"],
+    )
+    monkeypatch.setattr(_cluster_ops, "find_port", lambda _ctx, _host, port: port)
+    monkeypatch.setattr(_init_network, "workers_can_reach", lambda _ctx, target: target == "192.168.100.10")
+    monkeypatch.setattr(_cluster_ops, "launch_containers_parallel", lambda *_a, **_k: 1)
+
+    runtime = mock.MagicMock()
+    runtime._resolve_executor.return_value.node_container_name = lambda cid, rank: "%s_node_%d" % (cid, rank)
+    runtime.generate_node_command = mock.MagicMock(return_value="serve")
+    runtime.get_extra_docker_opts = lambda: []
+    runtime._print_cluster_banner = mock.MagicMock()
+
+    _cluster_ops.run_native_cluster(runtime=runtime, ctx=ctx)
+
+    call = runtime.generate_node_command.call_args
+    assert call.kwargs["placement"].host_for_rank(0) == "192.168.100.10"
+    assert call.kwargs["placement"].host_for_rank(1) == "192.168.100.11"

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -7,7 +7,11 @@ import pytest
 from sparkrun.core.backend_select import BackendBundle
 from sparkrun.core.cluster_manager import ClusterDefinition
 from sparkrun.core.hardware import AcceleratorSpec, HostHardware
-from sparkrun.core.launcher import apply_platform_runtime_flag_defaults, resolve_per_host_backends
+from sparkrun.core.launcher import (
+    apply_platform_runtime_flag_defaults,
+    resolve_per_host_backends,
+    resolve_platform_env_defaults,
+)
 from sparkrun.core.recipe import Recipe
 from sparkrun.orchestration.collectives import NcclBackend, RcclBackend
 
@@ -86,6 +90,77 @@ def test_platform_flag_defaults_non_gb10_noop():
     applied = apply_platform_runtime_flag_defaults(recipe, "llama-cpp", _amd_hw())
     assert applied == {}
     assert "mmap" not in recipe.defaults
+
+
+# ---------------------------------------------------------------------------
+# Platform/runtime container env defaults (GB10 torch expandable segments)
+# ---------------------------------------------------------------------------
+
+
+class _StubRuntimeForEnv:
+    def __init__(self, runtime_name: str, family: str | None = None):
+        self.runtime_name = runtime_name
+        self._family = family or runtime_name
+
+    def get_family(self) -> str:
+        return self._family
+
+
+_EXPANDABLE = {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+
+
+@pytest.mark.parametrize(
+    "runtime_name,family",
+    [
+        ("vllm-ray", "vllm"),
+        ("vllm-distributed", "vllm"),
+        ("eugr-vllm", "vllm"),  # family match — variant is never enumerated
+        ("sglang", "sglang"),
+    ],
+)
+def test_platform_env_defaults_for_torch_runtimes_on_gb10(runtime_name, family):
+    got = resolve_platform_env_defaults(_StubRuntimeForEnv(runtime_name, family), _nvidia_hw())
+    assert got == _EXPANDABLE
+
+
+@pytest.mark.parametrize("runtime_name", ["llama-cpp", "trtllm", "modular-max"])
+def test_platform_env_defaults_skips_non_torch_runtimes(runtime_name):
+    """Runtimes that manage their own memory get no allocator env."""
+    assert resolve_platform_env_defaults(_StubRuntimeForEnv(runtime_name), _nvidia_hw()) == {}
+
+
+def test_platform_env_defaults_non_gb10_noop():
+    """A non-GB10 NVIDIA host is served by the generic platform — no env."""
+    h100 = HostHardware(accelerators=[AcceleratorSpec(vendor="nvidia", model="h100")])
+    assert resolve_platform_env_defaults(_StubRuntimeForEnv("vllm-ray", "vllm"), h100) == {}
+
+
+def test_platform_env_defaults_unclaimed_hardware_noop():
+    assert resolve_platform_env_defaults(_StubRuntimeForEnv("vllm-ray", "vllm"), _amd_hw()) == {}
+
+
+def test_platform_env_defaults_no_hardware_noop():
+    assert resolve_platform_env_defaults(_StubRuntimeForEnv("vllm-ray", "vllm"), None) == {}
+    assert resolve_platform_env_defaults(_StubRuntimeForEnv("vllm-ray", "vllm"), HostHardware()) == {}
+
+
+def test_platform_env_defaults_platform_error_is_swallowed(monkeypatch):
+    """A misbehaving platform hook contributes nothing rather than failing the launch."""
+    from sparkrun.platforms.dgx_spark import DgxSparkPlatform
+
+    def _raise(self, runtime_name, accelerator, *, runtime_family=None):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(DgxSparkPlatform, "default_env", _raise)
+    assert resolve_platform_env_defaults(_StubRuntimeForEnv("vllm-ray", "vllm"), _nvidia_hw()) == {}
+
+
+def test_platform_env_defaults_returns_a_copy():
+    """Callers must not be able to mutate the platform's table via the result."""
+    runtime = _StubRuntimeForEnv("sglang", "sglang")
+    got = resolve_platform_env_defaults(runtime, _nvidia_hw())
+    got["PYTORCH_CUDA_ALLOC_CONF"] = "mutated"
+    assert resolve_platform_env_defaults(runtime, _nvidia_hw()) == _EXPANDABLE
 
 
 def test_platform_flag_defaults_then_command_emits_no_mmap():

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -110,6 +110,58 @@ def test_dgx_spark_runtime_flags_non_gb10_empty():
     assert DgxSparkPlatform().default_runtime_flags("llama-cpp", h100) == {}
 
 
+def test_dgx_spark_env_defaults_match_by_family():
+    """The table is family-keyed, so every vllm variant inherits without enumeration."""
+    p = DgxSparkPlatform()
+    want = {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+    assert p.default_env("vllm-ray", _gb10_accel(), runtime_family="vllm") == want
+    assert p.default_env("eugr-vllm", _gb10_accel(), runtime_family="vllm") == want
+    assert p.default_env("sglang", _gb10_accel(), runtime_family="sglang") == want
+
+
+def test_dgx_spark_env_defaults_family_omitted_falls_back_to_name():
+    """Callers that pass no family still match a runtime whose name IS the family."""
+    assert DgxSparkPlatform().default_env("sglang", _gb10_accel()) == {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+    assert DgxSparkPlatform().default_env("vllm-ray", _gb10_accel()) == {}
+
+
+def test_dgx_spark_env_defaults_untargeted_runtime_empty():
+    assert DgxSparkPlatform().default_env("llama-cpp", _gb10_accel(), runtime_family="llama-cpp") == {}
+
+
+def test_dgx_spark_env_defaults_non_gb10_accelerator_empty():
+    h100 = AcceleratorSpec(vendor="nvidia", model="h100", memory_gb=80.0)
+    assert DgxSparkPlatform().default_env("vllm-ray", h100, runtime_family="vllm") == {}
+
+
+def test_base_platform_env_defaults_empty():
+    assert GenericNvidiaPlatform().default_env("vllm-ray", _gb10_accel(), runtime_family="vllm") == {}
+
+
+def test_dgx_spark_executor_config_pins_gpus_mode():
+    """GB10 requests GPUs with --gpus: CDI specs go stale across driver upgrades."""
+    assert DgxSparkPlatform().default_executor_config("docker") == {"gpu_access_mode": "gpus"}
+
+
+def test_dgx_spark_executor_config_other_executor_empty():
+    """The pin is docker-specific — local/k8s spell GPU access their own way."""
+    assert DgxSparkPlatform().default_executor_config("local") == {}
+    assert DgxSparkPlatform().default_executor_config("k8s") == {}
+
+
+def test_dgx_spark_executor_config_returns_a_copy():
+    """Callers must not be able to mutate the platform's default table."""
+    p = DgxSparkPlatform()
+    got = p.default_executor_config("docker")
+    got["gpu_access_mode"] = "cdi"
+    assert p.default_executor_config("docker") == {"gpu_access_mode": "gpus"}
+
+
+def test_generic_nvidia_executor_config_empty():
+    """Generic NVIDIA inherits the executor's own default (CDI)."""
+    assert GenericNvidiaPlatform().default_executor_config("docker") == {}
+
+
 def test_base_platform_runtime_flags_default_empty():
     """Generic NVIDIA platform publishes no per-runtime flag defaults."""
     assert GenericNvidiaPlatform().default_runtime_flags("llama-cpp", _gb10_accel()) == {}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -51,6 +51,22 @@ def mgr(reg_dirs):
 
 
 @pytest.fixture
+def bootstrap_urls(monkeypatch) -> list[str]:
+    """Give manifest discovery a deterministic two-URL list.
+
+    conftest empties ``BOOTSTRAP_REGISTRY_URLS`` so that no test git-clones the
+    real default registries. Tests that exercise the discovery loop itself
+    supply their own URLs and mock the per-URL ``_discover_manifest_entries``,
+    which is what makes them hermetic.
+    """
+    from sparkrun.core import registry as reg_module
+
+    urls = ["https://example.com/r1", "https://example.com/r2"]
+    monkeypatch.setattr(reg_module, "BOOTSTRAP_REGISTRY_URLS", urls)
+    return urls
+
+
+@pytest.fixture
 def sample_entry() -> RegistryEntry:
     """A sample registry entry for testing."""
     return RegistryEntry(
@@ -356,7 +372,7 @@ class TestRegistryCache:
 class TestRegistryUpdate:
     """Test registry update (git clone/pull) operations."""
 
-    def test_update_calls_clone_for_new(self, mgr, sample_entry):
+    def test_update_calls_clone_for_new(self, mgr, sample_entry, real_registry_git):
         """Test that update clones a new registry."""
         mgr._save_registries([sample_entry])
         with mock.patch("subprocess.run") as mock_run:
@@ -366,7 +382,7 @@ class TestRegistryUpdate:
             calls = mock_run.call_args_list
             assert any("clone" in str(c) for c in calls)
 
-    def test_update_calls_pull_for_existing(self, mgr, sample_entry):
+    def test_update_calls_pull_for_existing(self, mgr, sample_entry, real_registry_git):
         """Test that update pulls an existing registry."""
         mgr._save_registries([sample_entry])
         # Create fake .git dir to simulate existing clone
@@ -380,7 +396,7 @@ class TestRegistryUpdate:
             calls = mock_run.call_args_list
             assert any("pull" in str(c) for c in calls)
 
-    def test_update_all_registries(self, mgr, sample_entry):
+    def test_update_all_registries(self, mgr, sample_entry, real_registry_git):
         """Test that update() with no name updates all enabled registries."""
         second = RegistryEntry(
             name="second",
@@ -1714,7 +1730,7 @@ class TestDiscoverManifestEntries:
 class TestInitDefaultsFromManifests:
     """Test _init_defaults_from_manifests bulk-save flow."""
 
-    def test_returns_entries_without_saving_or_calling_add_registry(self, mgr):
+    def test_returns_entries_without_saving_or_calling_add_registry(self, mgr, bootstrap_urls):
         """Entries are returned without saving or calling add_registry (no re-entrancy)."""
         entries_url1 = [
             RegistryEntry(name="m1", url="https://example.com/r1", subpath="recipes"),
@@ -1770,7 +1786,7 @@ class TestInitDefaultsFromManifests:
         assert len(result) == 1
         assert result[0].name == "good-reg"
 
-    def test_deduplicates_by_name(self, mgr):
+    def test_deduplicates_by_name(self, mgr, bootstrap_urls):
         """Duplicate names across URLs are deduplicated (first wins)."""
         entries_url1 = [
             RegistryEntry(name="shared-name", url="https://example.com/r1", subpath="from-r1"),
@@ -1804,7 +1820,7 @@ class TestInitDefaultsFromManifests:
         # No file should have been saved
         assert not mgr._registries_path.exists()
 
-    def test_no_re_entrancy_on_first_run(self, reg_dirs):
+    def test_no_re_entrancy_on_first_run(self, reg_dirs, bootstrap_urls):
         """Full integration: first-run path does not re-enter _load_registries via add_registry."""
         config, cache = reg_dirs
         mgr = RegistryManager(config, cache)
@@ -2029,7 +2045,7 @@ class TestValidateGitUrl:
         with pytest.raises(ValueError, match="must not start with"):
             validate_git_url("--upload-pack=evil /tmp/target")
 
-    def test_clone_subprocess_args_contain_double_dash(self, mgr, sample_entry):
+    def test_clone_subprocess_args_contain_double_dash(self, mgr, sample_entry, real_registry_git):
         """Confirm that git clone subprocess calls include '--' before the URL."""
         mgr._save_registries([sample_entry])
         with mock.patch("subprocess.run") as mock_run:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest import mock
 
@@ -9,13 +10,17 @@ import pytest
 import yaml
 
 from sparkrun.core.registry import (
+    DEPRECATED_REGISTRIES,
+    EUGR_REGISTRY_DESCRIPTION,
     EXTERNAL_RESERVED_NAMES,
     FALLBACK_DEFAULT_REGISTRIES,
+    MIGRATED_REGISTRY_URLS,
     RESERVED_NAME_PREFIXES,
     RegistryEntry,
     RegistryError,
     RegistryManager,
     _get_git_org,
+    _normalize_registry_url,
     validate_registry_name,
     is_dir_link,
     link_directory,
@@ -168,9 +173,54 @@ class TestDefaultRegistries:
         assert len(FALLBACK_DEFAULT_REGISTRIES) >= 3
         eugr = FALLBACK_DEFAULT_REGISTRIES[2]
         assert eugr.name == "eugr"
-        assert "eugr/spark-vllm-docker" in eugr.url
+        # Our mirror, not eugr's container-build repo (which the *builder*
+        # still clones — see sparkrun.builders.eugr.EUGR_REPO_URL).
+        assert "spark-arena/eugr-recipes" in eugr.url
+        assert eugr.subpath == "recipes"
+        assert eugr.mods_subpath == "mods"
         assert eugr.enabled is True
         assert eugr.visible is True
+        assert eugr.trusted is True
+
+    def test_eugr_default_url_is_the_migration_target(self):
+        """The shipped eugr URL must be what MIGRATED_REGISTRY_URLS points at.
+
+        Otherwise a migrated config and a fresh install would disagree, and the
+        migrated one would never converge.
+        """
+        eugr = next(e for e in FALLBACK_DEFAULT_REGISTRIES if e.name == "eugr")
+        target = MIGRATED_REGISTRY_URLS["https://github.com/eugr/spark-vllm-docker"]
+        assert _normalize_registry_url(eugr.url) == _normalize_registry_url(target)
+
+    def test_eugr_builder_still_clones_the_upstream_build_repo(self):
+        """The two "eugr" URLs are different things and must stay that way.
+
+        - The *registry* is a mirror of upstream's ``recipes/`` + ``mods/``.
+        - The *builder* clones upstream's container build (Dockerfile,
+          ``build-and-copy.sh``, wheels) — none of which the mirror carries.
+
+        Repointing the builder at the mirror would break every v1 recipe that
+        actually builds (``--use-wheels`` and friends), so migrating the
+        registry URL must not drag the builder along with it.
+        """
+        from sparkrun.builders.eugr import EUGR_REPO_URL
+
+        eugr_registry = next(e for e in FALLBACK_DEFAULT_REGISTRIES if e.name == "eugr")
+        assert _normalize_registry_url(EUGR_REPO_URL) == "https://github.com/eugr/spark-vllm-docker"
+        assert _normalize_registry_url(EUGR_REPO_URL) != _normalize_registry_url(eugr_registry.url)
+        # And the builder URL must never be swept up by the registry migration.
+        assert _normalize_registry_url(EUGR_REPO_URL) in MIGRATED_REGISTRY_URLS
+        assert "spark-arena" not in EUGR_REPO_URL
+
+    def test_old_eugr_url_is_migrated_not_deprecated(self):
+        """The old eugr URL must not be in DEPRECATED_REGISTRIES.
+
+        Listing it there would *delete* the user's registry instead of moving
+        it, silently taking every @eugr recipe with it.
+        """
+        old = "https://github.com/eugr/spark-vllm-docker"
+        assert old in MIGRATED_REGISTRY_URLS
+        assert not any(_normalize_registry_url(u) == _normalize_registry_url(old) for u in DEPRECATED_REGISTRIES)
 
     def test_seven_default_registries(self):
         """Test that there are exactly seven default registries."""
@@ -2018,3 +2068,189 @@ class TestValidateGitUrl:
         """add_registry_from_url must raise RegistryError for http:// URLs."""
         with pytest.raises(RegistryError, match="Invalid registry URL"):
             mgr.add_registry_from_url("http://insecure.example.com/repo.git")
+
+
+class TestMigratedRegistryUrls:
+    """A registry that *moved* is rewritten in place, not dropped or re-added."""
+
+    OLD_URL = "https://github.com/eugr/spark-vllm-docker"
+    NEW_URL = "https://github.com/spark-arena/eugr-recipes"
+
+    @staticmethod
+    def _write(mgr, entries: list[dict]):
+        with open(mgr._registries_path, "w") as f:
+            yaml.dump({"registries": entries}, f)
+
+    def _write_eugr(self, mgr, **overrides):
+        entry = {
+            "name": "eugr",
+            "url": self.OLD_URL,
+            "subpath": "recipes",
+            "description": "Official eugr/spark-vllm-docker repo recipes",
+            "mods_subpath": "mods",
+            "trusted": True,
+        }
+        entry.update(overrides)
+        self._write(mgr, [entry])
+
+    def test_old_url_is_rewritten(self, mgr):
+        self._write_eugr(mgr)
+        eugr = next(e for e in mgr._load_registries() if e.name == "eugr")
+        assert _normalize_registry_url(eugr.url) == _normalize_registry_url(self.NEW_URL)
+
+    def test_rewrite_is_persisted(self, mgr):
+        self._write_eugr(mgr)
+        mgr._load_registries()
+        with open(mgr._registries_path) as f:
+            raw = yaml.safe_load(f)
+        assert _normalize_registry_url(raw["registries"][0]["url"]) == _normalize_registry_url(self.NEW_URL)
+
+    def test_rewrite_matches_dot_git_and_trailing_slash(self, mgr):
+        """The stored URL may carry .git or a trailing slash; both must match."""
+        for spelling in (self.OLD_URL + ".git", self.OLD_URL + "/"):
+            self._write_eugr(mgr, url=spelling)
+            eugr = next(e for e in mgr._load_registries() if e.name == "eugr")
+            assert _normalize_registry_url(eugr.url) == _normalize_registry_url(self.NEW_URL), spelling
+
+    def test_user_state_survives_the_move(self, mgr):
+        """Name, subpaths and enabled/visible choices are the user's, not ours.
+
+        (Trust is the deliberate exception — see
+        ``test_move_applies_the_shipped_default_trust``.)
+        """
+        self._write_eugr(mgr, enabled=False, visible=False, subpath="recipes")
+        eugr = next(e for e in mgr._load_registries() if e.name == "eugr")
+        assert eugr.enabled is False
+        assert eugr.visible is False
+        assert eugr.subpath == "recipes"
+        assert eugr.mods_subpath == "mods"
+
+    def test_move_applies_the_shipped_default_trust(self, mgr):
+        """An untrusted eugr entry becomes trusted when it follows the move.
+
+        The one-shot backfill in ``_migrate_trust_field`` only runs against a
+        pre-trust registries.yaml, so an entry written before eugr became a
+        trusted default is stuck untrusted forever — and its mods (pre_exec
+        hooks) would prompt on every launch. The move re-applies the default.
+        """
+        self._write_eugr(mgr, trusted=False)
+        assert next(e for e in mgr._load_registries() if e.name == "eugr").trusted is True
+
+    def test_move_applies_default_trust_when_the_key_is_absent(self, mgr):
+        """`_save_registries` omits `trusted: false`, so absent is the common case."""
+        self._write(mgr, [{"name": "eugr", "url": self.OLD_URL, "subpath": "recipes", "trusted": True}])
+        # Sanity: an already-trusted entry stays trusted (no revoke on move).
+        assert next(e for e in mgr._load_registries() if e.name == "eugr").trusted is True
+
+        self._write(mgr, [{"name": "eugr", "url": self.OLD_URL, "subpath": "recipes"}])
+        assert next(e for e in mgr._load_registries() if e.name == "eugr").trusted is True
+
+    def test_move_does_not_grant_trust_to_untrusted_defaults(self, mgr):
+        """Only registries we ship as trusted get the grant — not every move."""
+        untrusted_target = "https://github.com/someone/not-a-default"
+        with mock.patch.dict(
+            "sparkrun.core.registry.MIGRATED_REGISTRY_URLS",
+            {"https://github.com/old/thing": untrusted_target},
+            clear=True,
+        ):
+            self._write(mgr, [{"name": "thing", "url": "https://github.com/old/thing", "subpath": "recipes"}])
+            entry = next(e for e in mgr._load_registries() if e.name == "thing")
+        assert entry.url == untrusted_target
+        assert entry.trusted is False
+
+    def test_default_description_is_refreshed(self, mgr):
+        self._write_eugr(mgr)
+        eugr = next(e for e in mgr._load_registries() if e.name == "eugr")
+        assert eugr.description == EUGR_REGISTRY_DESCRIPTION
+
+    def test_custom_description_is_preserved(self, mgr):
+        self._write_eugr(mgr, description="my notes about this registry")
+        eugr = next(e for e in mgr._load_registries() if e.name == "eugr")
+        assert eugr.description == "my notes about this registry"
+
+    def test_registry_is_not_dropped(self, mgr):
+        """Regression guard: migrating must not behave like DEPRECATED_REGISTRIES."""
+        self._write_eugr(mgr)
+        assert any(e.name == "eugr" for e in mgr._load_registries())
+
+    def test_migration_is_idempotent(self, mgr):
+        self._write_eugr(mgr)
+        mgr._load_registries()
+        first = mgr._registries_path.read_text()
+        mgr._load_registries()
+        assert mgr._registries_path.read_text() == first
+
+    def test_unrelated_registries_untouched(self, mgr):
+        self._write(
+            mgr,
+            [
+                {"name": "mine", "url": "https://github.com/me/recipes", "subpath": "recipes"},
+                {"name": "eugr", "url": self.OLD_URL, "subpath": "recipes"},
+            ],
+        )
+        by_name = {e.name: e for e in mgr._load_registries()}
+        assert by_name["mine"].url == "https://github.com/me/recipes"
+        assert _normalize_registry_url(by_name["eugr"].url) == _normalize_registry_url(self.NEW_URL)
+
+    def test_legacy_config_migrates_url_before_trust(self, mgr):
+        """Ordering guard.
+
+        A pre-trust registries.yaml (no `trusted` key anywhere) gets its trust
+        backfilled by matching URLs against the shipped defaults. Those defaults
+        hold the NEW url, so the URL rewrite has to happen first — otherwise the
+        entry is backfilled untrusted and eugr mods start prompting.
+        """
+        self._write(mgr, [{"name": "eugr", "url": self.OLD_URL, "subpath": "recipes"}])
+        eugr = next(e for e in mgr._load_registries() if e.name == "eugr")
+        assert _normalize_registry_url(eugr.url) == _normalize_registry_url(self.NEW_URL)
+        assert eugr.trusted is True
+
+
+class TestStaleCacheOnUrlChange:
+    """A cached clone from the old URL must not survive the move."""
+
+    @staticmethod
+    def _make_clone(path: Path, origin: str):
+        path.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", str(path)], check=True)
+        subprocess.run(["git", "-C", str(path), "remote", "add", "origin", origin], check=True)
+
+    def test_cache_dropped_when_origin_differs(self, mgr, reg_dirs):
+        _, cache = reg_dirs
+        self._make_clone(cache / "eugr", "https://github.com/eugr/spark-vllm-docker")
+        entry = RegistryEntry(name="eugr", url="https://github.com/spark-arena/eugr-recipes", subpath="recipes")
+        assert mgr._drop_cache_if_url_changed(entry) is True
+        assert not (cache / "eugr").exists()
+
+    def test_cache_kept_when_origin_matches(self, mgr, reg_dirs):
+        _, cache = reg_dirs
+        url = "https://github.com/spark-arena/eugr-recipes"
+        self._make_clone(cache / "eugr", url)
+        entry = RegistryEntry(name="eugr", url=url, subpath="recipes")
+        assert mgr._drop_cache_if_url_changed(entry) is False
+        assert (cache / "eugr" / ".git").exists()
+
+    def test_dot_git_suffix_is_not_a_difference(self, mgr, reg_dirs):
+        """`.git` on one side only must not trigger a pointless re-clone."""
+        _, cache = reg_dirs
+        self._make_clone(cache / "eugr", "https://github.com/spark-arena/eugr-recipes.git")
+        entry = RegistryEntry(name="eugr", url="https://github.com/spark-arena/eugr-recipes", subpath="recipes")
+        assert mgr._drop_cache_if_url_changed(entry) is False
+        assert (cache / "eugr" / ".git").exists()
+
+    def test_missing_cache_is_a_noop(self, mgr):
+        entry = RegistryEntry(name="nope", url="https://github.com/spark-arena/eugr-recipes", subpath="recipes")
+        assert mgr._drop_cache_if_url_changed(entry) is False
+
+    def test_link_into_shared_clone_is_unlinked_not_deleted_through(self, mgr, reg_dirs):
+        """The cache dir may be a link to a shared clone others still use."""
+        _, cache = reg_dirs
+        shared = cache / "_url_shared"
+        self._make_clone(shared, "https://github.com/eugr/spark-vllm-docker")
+        link_directory(cache / "eugr", shared)
+
+        entry = RegistryEntry(name="eugr", url="https://github.com/spark-arena/eugr-recipes", subpath="recipes")
+        assert mgr._drop_cache_if_url_changed(entry) is True
+        assert not (cache / "eugr").exists()
+        # The shared clone itself survives — another registry may still use it.
+        assert (shared / ".git").exists()

--- a/tests/test_setup_check.py
+++ b/tests/test_setup_check.py
@@ -228,13 +228,44 @@ def test_check_all_good_exits_zero(runner, v, patched_cluster_mgr):
 def test_check_reports_critical_gap_exits_one(runner, v, patched_cluster_mgr):
     patched_cluster_mgr.create("mylab", ["10.0.0.1"])
 
-    facts = dict(_FACTS_ALL_GOOD, CHECK_CDI_SPEC="0")
+    facts = dict(_FACTS_ALL_GOOD, CHECK_DOCKER_USABLE="0", CHECK_DOCKER_GROUP="0")
     with mock.patch("sparkrun.orchestration.ssh.run_remote_script") as mock_run:
         mock_run.return_value = RemoteResult("10.0.0.1", 0, _facts_kv(facts), "")
         result = runner.invoke(main, ["setup", "check", "--cluster", "mylab"])
 
     assert result.exit_code == 1
     assert "[FAIL]" in result.output
+    assert "critical gap" in result.output
+    assert "sparkrun setup docker-group" in result.output
+
+
+def test_check_missing_cdi_is_not_a_gap_when_cluster_uses_gpus_mode(runner, v, patched_cluster_mgr):
+    """A DGX Spark cluster requests GPUs with --gpus, so no CDI spec is needed.
+
+    Hardware defaults to DGX Spark when the cluster carries none (same fallback
+    the launcher uses), whose platform tier pins ``gpu_access_mode: gpus``.
+    """
+    patched_cluster_mgr.create("mylab", ["10.0.0.1"])
+
+    facts = dict(_FACTS_ALL_GOOD, CHECK_CDI_SPEC="0")
+    with mock.patch("sparkrun.orchestration.ssh.run_remote_script") as mock_run:
+        mock_run.return_value = RemoteResult("10.0.0.1", 0, _facts_kv(facts), "")
+        result = runner.invoke(main, ["setup", "check", "--cluster", "mylab"])
+
+    assert result.exit_code == 0
+    assert "No setup gaps found" in result.output
+
+
+def test_check_missing_cdi_is_critical_when_cluster_pins_cdi_mode(runner, v, patched_cluster_mgr):
+    """The same host fails the check once the cluster opts back into CDI."""
+    patched_cluster_mgr.create("mylab", ["10.0.0.1"], executor_config={"gpu_access_mode": "cdi"})
+
+    facts = dict(_FACTS_ALL_GOOD, CHECK_CDI_SPEC="0")
+    with mock.patch("sparkrun.orchestration.ssh.run_remote_script") as mock_run:
+        mock_run.return_value = RemoteResult("10.0.0.1", 0, _facts_kv(facts), "")
+        result = runner.invoke(main, ["setup", "check", "--cluster", "mylab"])
+
+    assert result.exit_code == 1
     assert "critical gap" in result.output
     assert "nvidia-ctk cdi generate" in result.output
 

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -46,9 +46,17 @@ class TestGetSglangTuningDir:
         assert isinstance(d, Path)
         assert str(d).endswith("sparkrun/tuning/sglang")
 
-    def test_is_under_home(self):
+    def test_is_under_the_cache_root(self):
+        """The tuning dir hangs off DEFAULT_CACHE_DIR, wherever that points.
+
+        Was ``startswith(Path.home())`` — which only held because the cache dir
+        leaked out to the real ``~/.cache/sparkrun`` during tests. Asserting
+        against the configured root tests the actual contract.
+        """
+        import sparkrun.tuning._common as tuning_common
+
         d = get_sglang_tuning_dir()
-        assert str(d).startswith(str(Path.home()))
+        assert str(d).startswith(str(tuning_common.DEFAULT_CACHE_DIR))
 
 
 class TestGetSglangTuningVolumes:
@@ -436,9 +444,12 @@ class TestGetVllmTuningDir:
         assert isinstance(d, Path)
         assert str(d).endswith("sparkrun/tuning/vllm")
 
-    def test_is_under_home(self):
+    def test_is_under_the_cache_root(self):
+        """See :meth:`TestGetSglangTuningDir.test_is_under_the_cache_root`."""
+        import sparkrun.tuning._common as tuning_common
+
         d = get_vllm_tuning_dir()
-        assert str(d).startswith(str(Path.home()))
+        assert str(d).startswith(str(tuning_common.DEFAULT_CACHE_DIR))
 
 
 class TestGetVllmTuningVolumes:

--- a/tests/test_update_channels.py
+++ b/tests/test_update_channels.py
@@ -136,12 +136,12 @@ def test_describe_change_stable_updated():
 
 def test_describe_change_git_same_commit():
     msg = describe_change("beta", ("0.2.40", "abcdef123456"), ("0.2.40", "abcdef123456"))
-    assert "already on the latest commit" in msg and "gabcdef1" in msg
+    assert "already on the latest commit" in msg and "(abcdef1)" in msg
 
 
 def test_describe_change_git_new_commit():
     msg = describe_change("alpha", ("0.3.0", "aaaaaaa1"), ("0.3.0", "bbbbbbb2"))
-    assert "-> gbbbbbbb" in msg
+    assert msg == "sparkrun alpha updated: commit aaaaaaa -> bbbbbbb"
 
 
 # --- CLI integration ---


### PR DESCRIPTION
This pull request introduces several important improvements and clarifications to the documentation and codebase, primarily focused on container environment variable handling, platform-specific executor configuration (especially GPU access modes), and registry terminology. The changes enhance user control, clarify platform behaviors, and improve test isolation.

**Container environment variable handling and CLI improvements:**

- Added support for the `-e`/`--env` CLI option in `sparkrun run`, allowing users to set container environment variables directly with verbatim values. These overrides are applied after other env settings, ensuring user-specified values always take precedence. [[1]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08R178-R185) [[2]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08R230) [[3]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08R254-R255) [[4]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08R304-R314)
- Updated documentation in `RECIPES.md` to clarify the tiered precedence of container environment variables, detailing how `-e`/`--env` and `-o env.KEY=VALUE` interact and how platform and cluster defaults can be overridden.

**Platform and executor configuration enhancements:**

- Documented and implemented platform-defaulted executor configuration, especially for GPU access modes. The `gpu_access_mode` (either `cdi` or `gpus`) is now set by platform hardware, with DGX Spark pinning `gpus` and others defaulting to `cdi`. This is reflected in both the code and documentation, and users can override it at any configuration tier. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R154-R174) [[2]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611L360-R385) [[3]](diffhunk://#diff-5d212d961af70f70f74b55e25d054bf27dde13aa3f128866d046e7c7ecb8da1dL25-R31) [[4]](diffhunk://#diff-5d212d961af70f70f74b55e25d054bf27dde13aa3f128866d046e7c7ecb8da1dL77-R83) [[5]](diffhunk://#diff-5d212d961af70f70f74b55e25d054bf27dde13aa3f128866d046e7c7ecb8da1dL129-R177)

- Expanded documentation in `docs/EXECUTORS.md` on how `gpu_access_mode` affects Docker flags, with detailed tables and guidance on when CDI is required and how the system reports missing or stale specs.

**Test suite isolation and reliability:**

- Improved test hermeticity by sandboxing stateful directories and disabling network access during tests. This ensures tests do not touch user state or the network, and significantly reduces test suite runtime by eliminating unnecessary git operations.

**Registry terminology and CLI output:**

- Changed the registry CLI and documentation to use "Stemless" instead of "Visible" for clarity, reflecting whether a registry can resolve bare recipe stems. [[1]](diffhunk://#diff-bfc5422c94cebf8b627331ebf2540241824a667a2caece6db1b250e88bc1a66aL71-R73) [[2]](diffhunk://#diff-bfc5422c94cebf8b627331ebf2540241824a667a2caece6db1b250e88bc1a66aL300-R302)

**Other improvements:**

- Clarified and improved update messaging in the self-update CLI.
- Bumped the package version to `0.3.3` in `pyproject.toml`.