### PR TITLE
v0.3.4 Beta to Stable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ occupancy-aware one without launching something.
 
 ### `--ensure` ("is this workload already up?")
 
-`--ensure` matches on the launch **intent** (recipe + parallelism + port) via
+`--ensure` matches on the launch **intent** (see below) via
 `api.find_running_intent(intent_id, hosts) -> IntentMatch | None`, never on a
 cluster_id. A cluster_id encodes *placement* as well as intent, so the old
 `derive_cluster_id(recipe, host_list)` lookup could only match a job the greedy
@@ -377,6 +377,39 @@ scheduler had put on exactly the host set being asked about — under an
   honors `RunOptions.ensure` after planning and returns a `RunResult` with
   `already_running=True`, `launch_result=None`, describing the *pre-existing*
   deployment. Both go through `find_running_intent`.
+
+### Workload identity — intent vs. fingerprint
+
+Three different questions, two digests. Getting them confused is destructive,
+because a matching intent is `api.run`'s licence to **destroy**:
+
+| Question | Key | Consumers |
+|----------|-----|-----------|
+| Which served endpoint is this? | `generate_intent_id` | `stop` / `logs` / `status` / `--ensure` |
+| May I replace that? | `generate_intent_id` | occupancy exclusion + eviction |
+| Is this *exactly* this configuration? | `derive_recipe_fingerprint` | benchmark identity, provenance |
+
+`generate_intent_id` hashes runtime + model + **container** + port +
+served-model-name + non-default parallelism. The container image is in there
+because the intent is the destroy key: two recipes serving the same model on
+the same port through different images (a stable build and a nightly) are
+workloads a user runs side by side, and while the image was excluded, launching
+the second silently evicted the first (observed live on a 4-host cluster).
+`--image` writes through to `recipe.container`, so overrides are covered.
+
+It stays narrow otherwise — serve arguments are **not** hashed — because
+`stop` / `logs` / `--ensure` recompute it from the recipe without the flags the
+user typed at launch. Three reasons not to widen it to the fingerprint:
+
+1. Discovery breaks: `run r --gpu-mem 0.9` then `stop r` would not match.
+2. Eviction stops working for the common relaunch (tweak one flag → a
+   different intent → the old deployment is never replaced and keeps the GPUs).
+3. The fingerprint is not stable across the launch boundary:
+   `launch_inference` calls `apply_platform_runtime_flag_defaults`, which
+   `setdefault`s platform flags into `recipe.defaults` keyed off the **head
+   host's** hardware — so the config chain it hashes differs before vs. after
+   launch, and is placement-dependent. Fine as a provenance digest derived once
+   and threaded down; unusable as a lookup key.
 
 ### Status Discovery ("what's running where?")
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,6 +464,41 @@ blocks — only a *confirmed*-missing path fails the launch. This is why an
 absolute-path model works from a **remote control machine** that isn't a cluster
 member: the check runs on the *targets*, not the control node.
 
+**ENTRYPOINT preflight** (`Executor.verify_command_passthrough(image, hosts, …)`)
+is the second write-path preflight: "will the command I append actually *run* on
+this image?" sparkrun always emits its launcher as CMD **arguments** (`docker run
+<image> bash -c <b64 cmd>`), so the image's ENTRYPOINT decides their fate — and
+the two idioms in wide use are indistinguishable by `docker image inspect`:
+a **passthrough** wrapper (`/opt/nvidia/nvidia_entrypoint.sh` → `exec "$@"`,
+inherited by nearly every NGC image, so this is the *common* case) versus a
+**consuming** one (`ENTRYPOINT ["vllm","serve"]`, which parses sparkrun's
+`bash -c …` as its own flags and never starts the workload). Warning on "non-empty
+ENTRYPOINT" would fire on every working image; auto-clearing would strip the NGC
+wrapper's setup from all of them.
+
+So the verdict is established *empirically* (`containers/entrypoint.py` +
+`scripts/image_entrypoint_probe.sh`): no ENTRYPOINT → `absent`, no container
+started; else run the real argv shape and look for a **computed** sentinel on
+stdout (computed because a consuming entrypoint typically echoes the argv it
+rejected — an echo can reproduce a literal token, never the evaluated one) →
+`pass`; else re-run with `--entrypoint ''` and only call it `fail` if *that*
+succeeds, so a stale CDI spec / absent GPU / missing bash degrades to `unknown`
+rather than a bogus verdict. That second run is also what lets the error claim
+the fix is *verified*.
+
+Wired via `distribute_from_config`'s `after_container_sync` hook — the image is
+resident everywhere but the long, interruptible model sync hasn't started — and
+`launcher._verify_image_command_passthrough` raises a `RecipeError` naming both
+fixes (`executor_config: {entrypoint: ""}` or `-o entrypoint=''`) rather than
+auto-clearing: the probe proves clearing *works*, not that it's *harmless*.
+`DockerExecutor` skips the probe entirely when `config.entrypoint is not None` —
+otherwise it would reject the very fix it recommends. One host is probed (the
+verdict is a property of the image; distribution already established it matches
+everywhere), ~0.7s for the passthrough case. Fail-open throughout; kill switch
+`SPARKRUN_NO_IMAGE_PROBE=1`. `entrypoint` is in `cli/_run.py`'s
+`_EXECUTOR_OVERRIDE_KEYS`, which is what makes `-o entrypoint=''` reach
+`ExecutorConfig` instead of the serve command.
+
 ### Live monitoring (telemetry + occupancy)
 
 Monitoring has a second axis alongside occupancy — **telemetry** (per-host/node

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,18 @@ deciding and starts acting:
 | Function | Does | Returns |
 |----------|------|---------|
 | `api.plan(options)` | resolve recipe/cluster/runtime, `prepare_transport`, one `api.status` sweep, **one** `api.schedule`, compose intent/token/cluster_id | `RunPlan` |
-| `api.run(options, plan=…)` | evict superseded deployments, `launch_inference`, build result | `RunResult` |
+| `api.run(options, plan=…)` | `launch_inference` (evicting superseded deployments just before containers start), build result | `RunResult` |
+
+**Eviction timing is load-bearing.** `_evict_superseded_deployments` tears down
+a *serving* workload, so it runs from `launch_inference`'s `before_start` hook
+— fired at phase 5, after image distribution, model download and tuning sync
+have all succeeded — not at the top of `api.run`. Those steps take minutes and
+are routinely interrupted; evicting up front meant a `sparkrun run` killed with
+Ctrl-C during distribution left the cluster with *neither* the old deployment
+nor the new one. `api.run` passes `before_start=None` under `--dry-run` (the
+launcher guards too, so a dry run stays read-only regardless). The experimental
+k8s path returns before `launch_inference` and so evicts explicitly, without
+that guarantee.
 
 `run(options)` with no plan plans internally, so the split is invisible to
 callers that render nothing. It exists for the ones that don't: **anything that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,83 @@ every `KeyboardInterrupt` state-preservation path already in the codebase runs).
 `SIGKILL` remains unreachable — it leaves the ssh client alive, the session
 healthy, and the guard correctly dormant.
 
+### Launch Placement (`api.plan` → `api.run`)
+
+A launch **decides once**. The launch path is split at the point where it stops
+deciding and starts acting:
+
+| Function | Does | Returns |
+|----------|------|---------|
+| `api.plan(options)` | resolve recipe/cluster/runtime, `prepare_transport`, one `api.status` sweep, **one** `api.schedule`, compose intent/token/cluster_id | `RunPlan` |
+| `api.run(options, plan=…)` | evict superseded deployments, `launch_inference`, build result | `RunResult` |
+
+`run(options)` with no plan plans internally, so the split is invisible to
+callers that render nothing. It exists for the ones that don't: **anything that
+shows the target hosts before launching must plan, render, then
+`run(options, plan=plan)`.**
+
+The alternative — schedule yourself, then pass the winners as `options.hosts` —
+is what the CLI and the benchmark flow used to do, and it is a trap: `RunOptions.hosts`
+is the *candidate* set, so narrowing it makes the display pass authoritative over
+placement and leaves `run` unable to reach any host the display pass discarded.
+That is how a `tp 2` launch on a 4-host `occupancy-sparse` cluster with 2 idle
+hosts died with *"cluster has insufficient free capacity for 2 node(s)"*: the CLI
+trimmed with the greedy default (it never forwarded the resolved scheduler), then
+`api.run` re-placed with `occupancy-sparse` over only the busy pair it had been
+handed.
+
+`RunPlan` therefore keeps **both** host sets. They are not interchangeable:
+
+- `candidate_hosts` — what placement could choose from. Feeds
+  `derive_placement_token_from_hosts` (the deterministic/greedy cluster_id) and
+  `_evict_superseded_deployments`, so that `stop` / `status` — which only know
+  the cluster's full host list — derive the same cluster_id the launch used.
+- `host_list` — what it chose. What actually runs.
+
+`sparkrun run` previously scheduled three times (trim, a statusless
+display-placement for the per-host VRAM fit table, then the launch) across two
+SSH occupancy sweeps. Both are now one. The fit table renders `plan.placement`,
+which is why it can no longer show every target as `[OK]` above the capacity
+error that rejected them. Regression tests: `tests/test_api_plan.py`,
+`tests/test_cli_run_single_placement.py`.
+
+`api/_hosts.py:resolve_effective_hosts()` remains the single placement authority
+underneath; `plan` is its one caller on the launch path.
+
+**Which scheduler is in effect** is reported by
+`core/scheduler.py:describe_effective_scheduler()` — the display peer of
+`resolve_scheduler_selector` (that returns the *selector*, `None` when nothing
+named one; this resolves it to the scheduler that would run, plus a `defaulted`
+flag). Used by `cluster show`, `cluster inspect`, and the `run` banner so none
+can disagree with the launch. A cluster predating the `scheduler` field stores
+`None` and silently resolves to greedy; `cluster show` previously printed
+nothing at all in that case, leaving no way to tell a greedy cluster from an
+occupancy-aware one without launching something.
+
+### `--ensure` ("is this workload already up?")
+
+`--ensure` matches on the launch **intent** (recipe + parallelism + port) via
+`api.find_running_intent(intent_id, hosts) -> IntentMatch | None`, never on a
+cluster_id. A cluster_id encodes *placement* as well as intent, so the old
+`derive_cluster_id(recipe, host_list)` lookup could only match a job the greedy
+scheduler had put on exactly the host set being asked about — under an
+`occupancy-*` scheduler (random placement token) it matched nothing, ever, and
+`--ensure` launched a duplicate on every invocation.
+
+- `core/cluster_status.py:workload_matches_intent()` is the shared predicate.
+  Placement subtracts its own intent's workloads from the occupancy snapshot
+  (`exclude_intent_id`) while `--ensure` looks for exactly those; the two must
+  agree or `--ensure` would decline to launch something placement had already
+  decided to replace.
+- Pass the cluster's **full** host list, not a placement subset — a deployment
+  that landed elsewhere still counts as running.
+- A failed status probe means "not running" and the launch proceeds. Refusing
+  to launch because we couldn't tell is the worse failure.
+- The CLI queries before planning (skip → no scheduling at all); `api.run`
+  honors `RunOptions.ensure` after planning and returns a `RunResult` with
+  `already_running=True`, `launch_result=None`, describing the *pre-existing*
+  deployment. Both go through `find_running_intent`.
+
 ### Status Discovery ("what's running where?")
 
 All workload-status discovery flows through **one source**, `api.status`, in two

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -402,6 +402,26 @@ executor_config:
   entrypoint: ""
 ```
 
+Or, for a one-off run without editing the recipe:
+
+```bash
+sparkrun run <recipe> -o entrypoint=''
+```
+
+**Which images need this.** sparkrun always appends its launcher as CMD *arguments*, so what an ENTRYPOINT does with
+them decides whether the workload starts at all — and the two idioms look identical to `docker image inspect`:
+
+| ENTRYPOINT | Behaviour | Needs `entrypoint: ""` |
+|---|---|---|
+| absent | the appended CMD *is* the argv | no |
+| `["/opt/nvidia/nvidia_entrypoint.sh"]` (and most NGC-derived images) | passthrough wrapper — does setup, then `exec "$@"` | **no** — clearing it *skips that setup* |
+| `["vllm","serve"]` | consuming — parses sparkrun's `bash -c …` as its own flags | **yes** |
+
+A consuming ENTRYPOINT fails in a way that points nowhere near the cause: the container's program rejects some flag it
+mis-parsed out of sparkrun's launcher, and the serve log dies with the container. sparkrun therefore probes the image
+during distribution (before the model sync) and refuses the launch with the fix above; see
+[docs/EXECUTORS.md](docs/EXECUTORS.md#entrypoint-preflight). Set `SPARKRUN_NO_IMAGE_PROBE=1` to skip the probe.
+
 ### LocalExecutor fields (experimental, `executor: local`)
 
 `LocalExecutor` runs the runtime's serve command as a native subprocess on the

--- a/docs/EXECUTORS.md
+++ b/docs/EXECUTORS.md
@@ -137,6 +137,51 @@ lists. Falsy values fall through to the dataclass defaults.
 | `intel`       | `--device /dev/accel`                                             |
 | `apple`/`cpu` | (none — route to a non-Docker executor)                           |
 
+### ENTRYPOINT preflight
+
+`Executor.verify_command_passthrough(image, hosts)` is the second write-path
+preflight alongside `verify_mount_sources` — that one asks "do the paths I will
+mount exist on this substrate?", this one asks "will the command I append
+actually run on this image?".
+
+sparkrun composes every workload as `docker run <opts> <image> bash -c <b64 cmd>`,
+so the command is always CMD *arguments* and the image's ENTRYPOINT decides what
+happens to them. Two opposite idioms are in wide use and `docker image inspect`
+cannot tell them apart — both are simply "a non-empty ENTRYPOINT":
+
+- **passthrough** — `/opt/nvidia/nvidia_entrypoint.sh` and friends: do setup,
+  then `exec "$@"`. Inherited by nearly every NGC-derived image, so this is the
+  *common* case. Clearing it would skip the setup.
+- **consuming** — `ENTRYPOINT ["vllm","serve"]`: the appended `bash -c …` is
+  parsed as that program's own flags, so the workload never starts.
+
+The verdict is therefore established empirically (`containers/entrypoint.py` +
+`scripts/image_entrypoint_probe.sh`) rather than by inspection or an allowlist:
+
+1. No ENTRYPOINT → `absent`, no container started (the cheap exit for most images).
+2. Run the real argv shape and look for a **computed** sentinel on stdout. Found
+   → `pass`. The sentinel is computed, not literal, because a consuming
+   entrypoint typically echoes the argv it rejected — an echo can reproduce a
+   literal token but never the evaluated one.
+3. Not found → re-run byte-identically with `--entrypoint ''`. Only if *that*
+   succeeds is the entrypoint provably the cause (`fail`); otherwise the fault
+   is elsewhere — stale CDI, no GPU, no bash — and the verdict is `unknown`.
+
+Only `fail` blocks, and `launcher._verify_image_command_passthrough` raises a
+`RecipeError` naming both fixes (`executor_config: {entrypoint: ""}` or
+`-o entrypoint=''`) rather than auto-clearing: the probe shows that clearing
+*works*, not that it is *harmless* — a consuming entrypoint may also be doing
+setup the workload needs.
+
+It runs from `distribute_from_config`'s `after_container_sync` hook — the image
+is resident on every target but the long, routinely-interrupted model sync has
+not started yet. One host is probed (the verdict is a property of the image, and
+distribution already established the image matches everywhere), under the
+launch's own accelerator flags. Everything is fail-open: unreachable host,
+timeout, unresolvable executor, or `SPARKRUN_NO_IMAGE_PROBE=1` all read as
+"proceed". The base implementation returns `None`, so container-less (`local`)
+and provider executors never block a launch.
+
 ### NVIDIA GPU access mode
 
 There are two ways to ask Docker for NVIDIA GPUs and neither works everywhere,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkrun"
-version = "0.3.3"
+version = "0.3.4"
 description = "Launch and manage Docker-based inference workloads on NVIDIA DGX Spark systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sparkrun/api/__init__.py
+++ b/src/sparkrun/api/__init__.py
@@ -3,7 +3,7 @@
 This package is the contract that non-CLI Python callers (tests, third-
 party automation, the CLI itself) depend on.  Surfaces:
 
-- **Data models** — :class:`RunOptions`, :class:`RunResult`,
+- **Data models** — :class:`RunOptions`, :class:`RunPlan`, :class:`RunResult`,
   :class:`StopResult`, :class:`LogLine`, :class:`JobInfo`,
   :class:`RecipeSummary`, :class:`BenchmarkOptions`,
   :class:`BenchmarkResult`, :class:`ProgressEvent`, :class:`ResumeMode`.
@@ -15,7 +15,7 @@ party automation, the CLI itself) depend on.  Surfaces:
   :class:`NoResumableState`, :class:`CategoryNotFound`,
   :class:`AmbiguousCategoryError`,
   :class:`FrameworkCategoryMismatch`).
-- **Functions** — ``run``, ``stop``, ``logs``, ``status``,
+- **Functions** — ``plan``, ``run``, ``stop``, ``logs``, ``status``,
   ``schedule``, ``list_jobs``, ``search_recipes``, ``benchmark``
   (added incrementally in subsequent tasks; this module re-exports
   them as they land).
@@ -60,6 +60,7 @@ from sparkrun.api._errors import (
     TrustRejected,
 )
 from sparkrun.core.context import SparkrunContext
+from sparkrun.api._intent import IntentMatch, find_running_intent
 from sparkrun.api._jobs import list_jobs
 from sparkrun.api._logs import logs
 from sparkrun.api._models import (
@@ -68,12 +69,13 @@ from sparkrun.api._models import (
     LogSource,
     RecipeSummary,
     RunOptions,
+    RunPlan,
     RunResult,
     StopAllResult,
     StopResult,
 )
 from sparkrun.api._recipes import resolve_recipe_filter, search_recipes
-from sparkrun.api._run import run
+from sparkrun.api._run import plan, run
 from sparkrun.api._schedule import schedule
 from sparkrun.api._status import status, status_report
 from sparkrun.api._stop import stop
@@ -91,12 +93,14 @@ __all__ = [
     "default_sctx",
     # Data models
     "RunOptions",
+    "RunPlan",
     "RunResult",
     "StopResult",
     "StopAllResult",
     "LogLine",
     "LogSource",
     "JobInfo",
+    "IntentMatch",
     "RecipeSummary",
     # Benchmark data models
     "BenchmarkOptions",
@@ -120,6 +124,7 @@ __all__ = [
     "AmbiguousCategoryError",
     "FrameworkCategoryMismatch",
     # Functions
+    "plan",
     "run",
     "stop",
     "stop_all",
@@ -132,6 +137,7 @@ __all__ = [
     "live_monitor",
     "LiveMonitorSession",
     "list_jobs",
+    "find_running_intent",
     "search_recipes",
     "resolve_recipe_filter",
     "benchmark",

--- a/src/sparkrun/api/_benchmark.py
+++ b/src/sparkrun/api/_benchmark.py
@@ -7,6 +7,7 @@ callers get the full flow with no Click / sys.exit coupling.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import os
@@ -214,7 +215,7 @@ def _execute_benchmark(
     )
     from sparkrun.core.cluster_manager import resolve_cluster_config
     from sparkrun.core.resolve import apply_recipe_overrides as _apply_recipe_overrides, load_recipe as _load_recipe
-    from sparkrun.api._hosts import resolve_effective_hosts, resolve_host_list
+    from sparkrun.api._hosts import resolve_host_list
     from sparkrun.api._errors import (
         NoResumableState,
         FrameworkCategoryMismatch,
@@ -430,32 +431,52 @@ def _execute_benchmark(
         raise BenchmarkFailed("Error: %s" % e, exit_code=1) from e
     cluster_mgr = sctx.cluster_manager
 
+    cluster_cfg = resolve_cluster_config(cluster_name, hosts, None, cluster_mgr)
+    local_cache_dir, remote_cache_dir, effective_transfer_mode, effective_transfer_interface = cluster_cfg.resolve_transfer_config(config)
+
+    run_options: "api.RunOptions | None" = None
+    run_plan: "api.RunPlan | None" = None
     if skip_run:
+        # No launch, so nothing to plan — just honour solo.
         is_solo = bool(solo) or recipe.mode == "solo" or len(host_list) <= 1
         if is_solo and len(host_list) > 1:
             host_list = host_list[:1]
     else:
-        # Mirror the inputs ``api.run`` will use below (anonymous cluster from the
-        # host list → default hardware) and pass the same ``exclude_intent_id`` so
-        # this pre-launch estimate places identically to the authoritative
-        # scheduling pass inside ``api.run`` — otherwise the banner host list could
-        # disagree with what actually launches.
-        from sparkrun.orchestration.job_metadata import generate_intent_id
-
-        host_list, is_solo, _notes, _placement = resolve_effective_hosts(
-            host_list,
-            recipe,
-            overrides,
-            cluster_def=None,
-            runtime=runtime,
-            sctx=sctx,
+        # Plan the launch now so the banner below can name the target hosts,
+        # then hand the same plan to ``api.run``.  The alternative — placing
+        # here and passing the winners as ``hosts`` — would narrow the
+        # candidate set, leaving ``api.run`` unable to reach any host this
+        # pass discarded, and would sweep the cluster's occupancy twice.
+        run_options = api.RunOptions(
+            recipe=recipe,
+            hosts=tuple(host_list),
+            overrides=dict(overrides),
             solo=solo,
+            dry_run=dry_run,
+            follow=False,
+            detached=True,
+            trust=None,
             scheduler=scheduler_name,
-            exclude_intent_id=generate_intent_id(recipe, overrides),
+            transfer_mode=effective_transfer_mode,
+            transfer_interface=effective_transfer_interface,
+            cache_dir=remote_cache_dir,
+            local_cache_dir=local_cache_dir,
+            # Pass the cluster's shared-cache prefs explicitly: this launch
+            # uses explicit hosts and so loses the named-cluster identity
+            # that launch_inference would otherwise read them from.
+            preserve_model_perms=cluster_cfg.preserve_model_perms,
+            skip_model_fan_out=cluster_cfg.skip_model_fan_out,
+            rootful=rootful,
+            sync_tuning=sync_tuning,
+            extra_docker_opts=tuple(executor_args) if executor_args else None,
+            recipe_ref=recipe_ref,
         )
-
-    cluster_cfg = resolve_cluster_config(cluster_name, hosts, None, cluster_mgr)
-    local_cache_dir, remote_cache_dir, effective_transfer_mode, effective_transfer_interface = cluster_cfg.resolve_transfer_config(config)
+        try:
+            run_plan = api.plan(run_options, sctx=sctx)
+        except api.SparkrunError as e:
+            raise BenchmarkFailed("Error: inference launch failed: %s" % e, exit_code=1) from e
+        host_list = list(run_plan.host_list)
+        is_solo = run_plan.is_solo
 
     # Notify the emitter that the recipe is fully resolved so it can render
     # presentation-only artifacts (e.g. the CLI's VRAM estimate) without
@@ -663,32 +684,16 @@ def _execute_benchmark(
         if not skip_run:
             logger.log(_PROGRESS_LEVEL, "Step 1/3: Launching inference...")
 
-            run_options = api.RunOptions(
-                recipe=recipe,
-                hosts=tuple(host_list),
-                overrides=dict(overrides),
-                solo=is_solo,
-                dry_run=dry_run,
-                follow=False,
-                detached=True,
-                trust=None,
-                scheduler=scheduler_name,
-                transfer_mode=effective_transfer_mode,
-                transfer_interface=effective_transfer_interface,
-                cache_dir=remote_cache_dir,
-                local_cache_dir=local_cache_dir,
-                # Pass the cluster's shared-cache prefs explicitly: this launch
-                # uses explicit hosts and so loses the named-cluster identity
-                # that launch_inference would otherwise read them from.
-                preserve_model_perms=cluster_cfg.preserve_model_perms,
-                skip_model_fan_out=cluster_cfg.skip_model_fan_out,
-                rootful=rootful,
-                sync_tuning=sync_tuning,
-                extra_docker_opts=tuple(executor_args) if executor_args else None,
-                recipe_ref=recipe_ref,
-            )
+            # ``run_options`` / ``run_plan`` were built together above.  A
+            # resumed benchmark may have pinned a container image SHA into
+            # ``overrides`` since then; refresh the options so the launch uses
+            # it.  The plan stays valid — the image is an input to neither
+            # placement (which reads parallelism + VRAM) nor the intent id
+            # (runtime + model + port + parallelism).
+            assert run_options is not None and run_plan is not None  # not skip_run
+            run_options = dataclasses.replace(run_options, overrides=dict(overrides))
             try:
-                run_result = api.run(run_options, sctx=sctx)
+                run_result = api.run(run_options, sctx=sctx, plan=run_plan)
             except api.SparkrunError as e:
                 raise BenchmarkFailed("Error: inference launch failed: %s" % e, exit_code=1) from e
 

--- a/src/sparkrun/api/_hosts.py
+++ b/src/sparkrun/api/_hosts.py
@@ -442,16 +442,10 @@ def _status_excluding_intent(status, intent_id: str):
     """
     import dataclasses
 
-    def _intent_of(cluster_id: str) -> str | None:
-        try:
-            from sparkrun.orchestration.job_metadata import parse_cluster_id
-
-            return parse_cluster_id(cluster_id)[0]
-        except Exception:
-            return None
+    from sparkrun.core.cluster_status import workload_matches_intent
 
     def _matches(w) -> bool:
-        return (w.intent_id == intent_id) or (_intent_of(w.cluster_id) == intent_id)
+        return workload_matches_intent(w, intent_id)
 
     new_hosts = []
     changed = False

--- a/src/sparkrun/api/_intent.py
+++ b/src/sparkrun/api/_intent.py
@@ -1,0 +1,130 @@
+"""``sparkrun.api.find_running_intent`` — "is this workload already up?"
+
+The question ``--ensure`` asks.  It is deliberately keyed on the **intent**
+(recipe + parallelism + port) rather than on a ``cluster_id``, because a
+cluster_id also encodes *placement* — and placement is not stable:
+
+* Under a status-aware scheduler (``occupancy-*``) each launch gets a random
+  placement token, so no host-derived cluster_id can ever match a running job.
+* Even under the deterministic (greedy) scheduler the token is a hash of a
+  host set, so asking with a different host list than the launch used misses.
+
+``--ensure`` previously derived a cluster_id from ``(recipe, hosts)`` and so
+inherited both failure modes: on an occupancy cluster it *always* reported
+"not running" and launched a duplicate.  Matching the intent instead answers
+the question the flag is actually asking — "is this workload already serving,
+wherever it happens to be?" — and gives the same answer regardless of which
+scheduler placed it.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sparkrun.core.cluster_status import ClusterStatus
+    from sparkrun.core.context import SparkrunContext
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class IntentMatch:
+    """A running deployment of a given launch intent."""
+
+    intent_id: str
+    cluster_id: str
+    """The running deployment's full ``sparkrun_<intent>_<placement>`` id."""
+    hosts: tuple[str, ...] = ()
+    """Hosts carrying at least one of its workloads, in query order."""
+    recipe: str | None = None
+    runtime: str | None = None
+    started_at: float | None = None
+    other_cluster_ids: tuple[str, ...] = field(default_factory=tuple)
+    """Additional deployments of the same intent, if the cluster somehow holds
+    more than one.  Normally empty — ``api.run`` evicts superseded deployments
+    of an intent — but reported rather than hidden, since it means the cluster
+    is in a state the launch path tries to avoid."""
+
+
+def find_running_intent(
+    intent_id: str,
+    hosts: list[str] | tuple[str, ...],
+    *,
+    cluster=None,
+    sctx: "SparkrunContext | None" = None,
+    status: "ClusterStatus | None" = None,
+) -> IntentMatch | None:
+    """Return the deployment of *intent_id* running on *hosts*, or ``None``.
+
+    Args:
+        intent_id: Intent to look for (``RunPlan.intent_id`` /
+            :func:`~sparkrun.orchestration.job_metadata.generate_intent_id`).
+        hosts: Hosts to inspect — pass the cluster's **full** host list, not a
+            placement's subset, or a deployment that landed elsewhere is
+            missed.
+        cluster: Optional :class:`ClusterDefinition` (selects the status
+            substrate / executor).
+        sctx: Optional shared :class:`SparkrunContext`.
+        status: Pre-fetched snapshot to inspect instead of querying.  Must be
+            a **raw** snapshot — one with this intent's workloads subtracted
+            (as placement uses, see ``resolve_effective_hosts``'s
+            ``exclude_intent_id``) would report nothing running by
+            construction.
+
+    Returns:
+        The matching deployment with the most hosts (ties broken by
+        ``cluster_id`` for determinism), or ``None`` when the intent isn't
+        running.  A failed status query also yields ``None`` — the caller
+        should treat "couldn't tell" as "not running" and launch, since
+        refusing to launch on an unreachable cluster is the worse failure.
+    """
+    from sparkrun.core.cluster_status import workload_matches_intent
+
+    if not intent_id or not hosts:
+        return None
+
+    if status is None:
+        import sparkrun.api as api
+
+        try:
+            status = api.status(list(hosts), cluster=cluster, sctx=sctx)
+        except Exception as e:
+            logger.debug("find_running_intent: status query failed, assuming not running: %s", e)
+            return None
+    if status is None:
+        return None
+
+    # cluster_id -> (hosts in query order, representative workload)
+    by_cluster: dict[str, list] = {}
+    meta: dict[str, object] = {}
+    for occ in status.hosts:
+        for w in occ.workloads:
+            if not workload_matches_intent(w, intent_id):
+                continue
+            entry = by_cluster.setdefault(w.cluster_id, [])
+            if occ.host not in entry:
+                entry.append(occ.host)
+            meta.setdefault(w.cluster_id, w)
+
+    if not by_cluster:
+        return None
+
+    ranked = sorted(by_cluster.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    cluster_id, match_hosts = ranked[0]
+    w = meta[cluster_id]
+
+    return IntentMatch(
+        intent_id=intent_id,
+        cluster_id=cluster_id,
+        hosts=tuple(match_hosts),
+        recipe=getattr(w, "recipe_name", None),
+        runtime=getattr(w, "runtime_name", None),
+        started_at=getattr(w, "started_at", None),
+        other_cluster_ids=tuple(cid for cid, _ in ranked[1:]),
+    )
+
+
+__all__ = ["IntentMatch", "find_running_intent"]

--- a/src/sparkrun/api/_models.py
+++ b/src/sparkrun/api/_models.py
@@ -62,8 +62,16 @@ class RunOptions:
     prompt interactively (CLI default), ``True`` = auto-trust,
     ``False`` = refuse to run untrusted hooks."""
     ensure: bool = False
-    """If True, return existing RunResult when an identical job is already
-    running rather than launching a duplicate."""
+    """If True, skip the launch when this workload is already serving.
+
+    "Already serving" is matched on the launch **intent** (recipe +
+    parallelism + port), not on a cluster_id — so it holds regardless of which
+    hosts the running deployment landed on or which scheduler placed it (see
+    :func:`sparkrun.api.find_running_intent`).  On a hit, ``run`` returns a
+    :class:`RunResult` with ``already_running=True`` describing the
+    *pre-existing* deployment.  A cluster that can't be queried counts as "not
+    running" — refusing to launch because a status probe failed is the worse
+    outcome."""
 
     # Scheduler selection.
     scheduler: str | None = None
@@ -132,6 +140,77 @@ class RunOptions:
 
 
 @dataclass(frozen=True)
+class RunPlan:
+    """Everything :func:`sparkrun.api.run` decides *before* it touches the cluster.
+
+    Produced by :func:`sparkrun.api.plan` and consumed by
+    :func:`sparkrun.api.run` via its ``plan=`` argument.  The split exists
+    because placement is not free and must not be computed twice: a caller
+    that needs to *show* the target hosts before launching (the CLI banner,
+    the desktop app's pre-launch preview) would otherwise have to run the
+    scheduler itself, narrow the host list, and hand the survivors to
+    ``run`` — which then re-schedules over that narrowed set and can no
+    longer reach the hosts the first pass discarded.  Planning once and
+    threading the result removes that whole failure mode: what is displayed
+    and what is launched are the same object.
+
+    Building a plan performs the cluster-facing work that placement needs —
+    transport preparation and one occupancy query — but changes no cluster
+    state.  It is safe to build a plan and never launch it.
+    """
+
+    recipe: "Recipe"
+    """Resolved recipe (runtime selection finalized, overrides applied)."""
+    runtime: Any
+    """Resolved :class:`~sparkrun.runtimes.base.RuntimePlugin`."""
+    cluster: "ClusterDefinition"
+    """Resolved cluster, after transport preparation.  For provider-backed
+    transports this carries the refreshed connection details, so ``run``
+    must reuse it rather than preparing again."""
+
+    candidate_hosts: tuple[str, ...]
+    """Every host placement was allowed to choose from.
+
+    Distinct from :attr:`host_list`, and both are load-bearing: the
+    deterministic (greedy) placement token and the superseded-deployment
+    sweep are derived from the *candidates*, so that ``stop`` / ``status``
+    — which only know the cluster's full host list — compute the same
+    cluster_id the launch used."""
+    host_list: tuple[str, ...]
+    """Hosts the workload will actually run on (the scheduler's
+    ``hosts_used``, after solo / ``max_nodes`` constraints)."""
+    is_solo: bool
+    """``True`` when the launch resolved to single-host mode."""
+    placement: "RankAssignment | None"
+    """Concrete rank → (host, GPU) assignment.  ``None`` in solo mode or
+    when the scheduler was bypassed (single host / no parallelism)."""
+    notes: tuple[str, ...] = ()
+    """Human-readable placement notes (e.g. ``"Note: 2 nodes required,
+    using 2 of 4 hosts"``).  The library never prints; renderers echo these
+    verbatim."""
+
+    scheduler_selector: str | None = None
+    """Scheduler name as selected (CLI → recipe → cluster).  ``None`` means
+    nothing in the chain named one and the default applies."""
+    scheduler: str = ""
+    """Resolved scheduler name — what actually produced :attr:`placement`."""
+    scheduler_defaulted: bool = False
+    """``True`` when :attr:`scheduler_selector` was ``None``, so callers can
+    surface the "consider occupancy-aware placement" hint."""
+
+    intent_id: str = ""
+    """Deterministic hex identifier for (recipe + parallelism + port)."""
+    placement_token: str = ""
+    """Token disambiguating this launch from other instances of the intent.
+    Derived from :attr:`candidate_hosts` under a deterministic scheduler,
+    random under a status-aware one."""
+    cluster_id: str = ""
+    """``sparkrun_<intent_id>_<placement_token>`` — the id the launch will
+    use, so a renderer can show it (and ``--ensure`` can look it up) before
+    anything starts."""
+
+
+@dataclass(frozen=True)
 class RunResult:
     """Outputs of a successful :func:`sparkrun.api.run`."""
 
@@ -181,6 +260,11 @@ class RunResult:
     """Random hex token disambiguating this specific launch from other
     instances of the same intent.  Empty string only when the caller
     supplied a non-canonical ``cluster_id_override``."""
+    already_running: bool = False
+    """``True`` when :attr:`RunOptions.ensure` found this intent already
+    serving, so nothing was launched.  :attr:`cluster_id` / :attr:`host_list`
+    then describe the **pre-existing** deployment, and
+    :attr:`launch_result` is ``None`` (there was no launch)."""
 
 
 # --------------------------------------------------------------------------

--- a/src/sparkrun/api/_run.py
+++ b/src/sparkrun/api/_run.py
@@ -301,7 +301,16 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None, plan: Run
     # It is a no-op on the deterministic (greedy) path, where the relaunch
     # reuses the prior cluster_id and the runtime's step-1 cleanup already
     # removes those containers by name.
-    if not options.dry_run:
+    #
+    # Deferred to ``launch_inference``'s ``before_start`` hook rather than run
+    # here: this tears down a *serving* workload, and everything between here
+    # and the container start — image distribution, a multi-hundred-GB model
+    # download, tuning sync — can take minutes and fail or be interrupted.
+    # Evicting up front meant a `sparkrun run` killed with Ctrl-C during
+    # distribution left the cluster with neither the old deployment nor the
+    # new one.  By the time the hook fires, the only remaining step is
+    # starting containers.
+    def _evict_before_start() -> None:
         _evict_superseded_deployments(
             intent_id=intent_id,
             cluster_id_for_launch=cluster_id_for_launch,
@@ -332,6 +341,14 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None, plan: Run
             _executor_name = None
         if _executor_name == "k8s":
             from sparkrun.api._run_k8s import run_k8s
+
+            # This path returns without going through ``launch_inference``, so
+            # it never reaches the ``before_start`` hook — evict here to keep
+            # replace-my-own-deployment semantics.  It does not get the SSH
+            # path's "only after distribution succeeded" guarantee; the k8s
+            # launcher owns its own image/volume staging.
+            if not options.dry_run:
+                _evict_before_start()
 
             return run_k8s(
                 options,
@@ -383,6 +400,9 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None, plan: Run
         "recipe_ref": options.recipe_ref,
         "preserve_model_perms": options.preserve_model_perms,
         "skip_model_fan_out": options.skip_model_fan_out,
+        # ``None`` under --dry-run: the launcher also guards, but a dry run
+        # must not depend on a callee honouring the contract to stay read-only.
+        "before_start": None if options.dry_run else _evict_before_start,
     }
 
     # 5. Launch.

--- a/src/sparkrun/api/_run.py
+++ b/src/sparkrun/api/_run.py
@@ -1,17 +1,30 @@
-"""``sparkrun.api.run`` — launch an inference workload from the library API.
+"""``sparkrun.api.plan`` / ``sparkrun.api.run`` — launch an inference workload.
 
-Orchestrates the full launch path:
+The launch path is split at the point where it stops deciding and starts
+acting:
 
-1. Resolve recipe / cluster / hosts / runtime.
-2. Apply overrides; resolve recipe (runtime selection finalized).
-3. Run the scheduler via :func:`sparkrun.api.schedule` to compute placement.
-4. Apply orthogonal constraints (solo, ``max_nodes``).
-5. Delegate to :func:`sparkrun.core.launcher.launch_inference`.
-6. Translate the launcher's :class:`LaunchResult` into :class:`RunResult`.
+:func:`plan` — **decide** (no cluster state changes)
+  1. Resolve recipe / cluster / hosts / runtime; prepare the transport.
+  2. Run the scheduler once via :func:`sparkrun.api.schedule`, against live
+     occupancy, applying the orthogonal constraints (solo, ``max_nodes``).
+  3. Compose intent_id / placement_token / cluster_id.
+  → :class:`RunPlan`
 
-The function raises :class:`~sparkrun.api.SparkrunError` (or a
-subclass) for any failure; on success it returns a populated
-:class:`RunResult`.
+:func:`run` — **act**
+  4. Evict this intent's superseded deployments.
+  5. Delegate to :func:`sparkrun.core.launcher.launch_inference`.
+  6. Translate the launcher's :class:`LaunchResult` into :class:`RunResult`.
+
+``run(options)`` plans internally, so the split is invisible to callers
+that don't need it.  It exists for the ones that do: anything rendering a
+pre-launch summary needs the target hosts *before* launching, and the only
+other way to get them is to schedule separately and pass the winners in as
+``options.hosts`` — which silently makes the display pass authoritative
+over which hosts ``run`` may still consider.  ``run(options, plan=plan)``
+lets the decision be made exactly once.
+
+Both functions raise :class:`~sparkrun.api.SparkrunError` (or a subclass)
+for any failure.
 """
 
 from __future__ import annotations
@@ -26,7 +39,7 @@ from sparkrun.api._errors import (
     LayoutRequired,
     SparkrunError,
 )
-from sparkrun.api._models import RunOptions, RunResult
+from sparkrun.api._models import RunOptions, RunPlan, RunResult
 
 if TYPE_CHECKING:
     from sparkrun.core.context import SparkrunContext
@@ -35,30 +48,37 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None) -> RunResult:
-    """Launch the workload described by *options* and return a :class:`RunResult`.
+def plan(options: RunOptions, *, sctx: "SparkrunContext | None" = None) -> RunPlan:
+    """Decide *what* the launch described by *options* would do, without doing it.
+
+    Resolves recipe / cluster / runtime, prepares the transport, runs the
+    scheduler once against live occupancy, and composes the launch's
+    identifiers.  Returns a :class:`RunPlan`; changes no cluster state.
+
+    Hand the result to :func:`run` (``run(options, plan=plan)``) to launch
+    it.  That is the *only* correct way to render a pre-launch summary: a
+    caller that instead narrows ``options.hosts`` to its own placement and
+    calls ``run`` leaves ``run`` re-scheduling over the survivors, unable
+    to reach any host the first pass dropped — which turns a mere
+    scheduler disagreement into a launch failure on a cluster with free
+    capacity.
 
     Args:
-        options: Inputs for the launch.
-        sctx: Optional shared :class:`SparkrunContext`.  When omitted a
-            fresh session is built; callers chaining multiple ``api.*``
-            calls can construct one ``sctx`` and pass it to share
-            config / registry-manager / cluster-manager state.
+        options: Inputs for the launch (same struct :func:`run` takes).
+        sctx: Optional shared :class:`SparkrunContext`.
 
     Raises:
         :class:`InsufficientCapacity`: Scheduler can't fit the workload.
         :class:`LayoutRequired`: Cluster needs an explicit ``recipe.layout``.
         :class:`~sparkrun.api.RecipeNotFound`: Recipe lookup failed.
         :class:`~sparkrun.api.HostsUnreachable`: No usable host source.
-        :class:`~sparkrun.api.TrustRejected`: Recipe hooks rejected.
-        :class:`SparkrunError`: For other launch failures.
+        :class:`SparkrunError`: For other resolution failures.
     """
     from sparkrun.api._resolve import (
         resolve_cluster,
         resolve_recipe,
         resolve_runtime,
     )
-    from sparkrun.core.launcher import launch_inference
     from sparkrun.orchestration.job_metadata import (
         derive_placement_token_from_hosts,
         generate_cluster_id,
@@ -68,7 +88,6 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None) -> RunRes
     )
 
     sctx = resolve_sctx(sctx)
-    started_at = time.time()
     config = sctx.config
 
     # 1. Resolve inputs.  `resolve_cluster` always returns a populated
@@ -117,8 +136,8 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None) -> RunRes
     # three place identically — the scheduler's ``hosts_used`` IS the
     # effective host list, ``runtime.world_size()`` is baked into the
     # request, and ``max_nodes`` / solo are applied as orthogonal
-    # constraints.  ``notes`` (human-readable trim messages) are rendered
-    # by the CLI shell, not the library, so the API discards them.
+    # constraints.  ``notes`` (human-readable trim messages) are carried on
+    # the plan for renderers to echo; the library itself never prints.
     from sparkrun.api._hosts import resolve_effective_hosts
 
     # Deterministic intent for this launch (recipe + overrides).  Passed to the
@@ -129,7 +148,7 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None) -> RunRes
 
     placement: "RankAssignment | None"
     is_solo_request = bool(options.solo) or recipe.mode == "solo"
-    host_list, is_solo, _notes, placement = resolve_effective_hosts(
+    host_list, is_solo, notes, placement = resolve_effective_hosts(
         list(hosts),
         recipe,
         options.overrides,
@@ -183,12 +202,105 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None) -> RunRes
             # downstream consumers don't surface a fake one.
             placement_token = ""
 
+    return RunPlan(
+        recipe=recipe,
+        runtime=runtime,
+        cluster=cluster_def,
+        candidate_hosts=tuple(hosts),
+        host_list=tuple(host_list),
+        is_solo=is_solo,
+        placement=placement,
+        notes=tuple(notes),
+        scheduler_selector=effective_scheduler,
+        scheduler=_resolve_scheduler_name(effective_scheduler, sctx),
+        scheduler_defaulted=_scheduler_defaulted,
+        intent_id=intent_id,
+        placement_token=placement_token,
+        cluster_id=cluster_id_for_launch,
+    )
+
+
+def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None, plan: RunPlan | None = None) -> RunResult:
+    """Launch the workload described by *options* and return a :class:`RunResult`.
+
+    Args:
+        options: Inputs for the launch.
+        sctx: Optional shared :class:`SparkrunContext`.  When omitted a
+            fresh session is built; callers chaining multiple ``api.*``
+            calls can construct one ``sctx`` and pass it to share
+            config / registry-manager / cluster-manager state.
+        plan: Pre-computed :class:`RunPlan` from :func:`plan`.  When given,
+            resolution / transport preparation / placement are **not**
+            repeated — this launches exactly what the plan describes.  Pass
+            it whenever the target hosts were shown to a user first, so the
+            summary and the launch cannot diverge.  ``None`` (the default)
+            plans internally, which is what a caller that renders nothing
+            should do.  It must have been built from the same *options* and
+            *sctx*; a mismatched plan launches the plan's decisions.
+
+    Raises:
+        :class:`InsufficientCapacity`: Scheduler can't fit the workload.
+        :class:`LayoutRequired`: Cluster needs an explicit ``recipe.layout``.
+        :class:`~sparkrun.api.RecipeNotFound`: Recipe lookup failed.
+        :class:`~sparkrun.api.HostsUnreachable`: No usable host source.
+        :class:`~sparkrun.api.TrustRejected`: Recipe hooks rejected.
+        :class:`SparkrunError`: For other launch failures.
+    """
+    from sparkrun.core.launcher import launch_inference
+    from sparkrun.orchestration.job_metadata import parse_cluster_id
+
+    sctx = resolve_sctx(sctx)
+    started_at = time.time()
+    config = sctx.config
+
+    # ``_build_plan`` is a module-level alias for :func:`plan`, needed because
+    # the ``plan`` parameter shadows the function name in this scope.
+    if plan is None:
+        plan = _build_plan(options, sctx=sctx)
+
+    recipe = plan.recipe
+    runtime = plan.runtime
+    cluster_def = plan.cluster
+    hosts = list(plan.candidate_hosts)
+    host_list = list(plan.host_list)
+    is_solo = plan.is_solo
+    placement = plan.placement
+    effective_scheduler = plan.scheduler_selector
+    intent_id = plan.intent_id
+    placement_token = plan.placement_token
+    cluster_id_for_launch = plan.cluster_id
+
+    # ``ensure``: don't launch a duplicate of a workload that's already
+    # serving.  Matched on the *intent*, so the answer doesn't depend on which
+    # scheduler placed the running deployment (see ``api.find_running_intent``).
+    # Callers that need to skip *before* paying for a plan — the CLI's
+    # ``--ensure``, which short-circuits ahead of the banner — call
+    # ``find_running_intent`` themselves and leave this flag off; the query is
+    # the same one either way.
+    if options.ensure:
+        from sparkrun.api._intent import find_running_intent
+
+        match = find_running_intent(intent_id, hosts, cluster=cluster_def, sctx=sctx)
+        if match is not None:
+            logger.info("ensure: intent %s already running as %s; skipping launch", intent_id, match.cluster_id)
+            return _already_running_result(match, plan=plan, options=options, started_at=started_at, sctx=sctx)
+
+    # Re-apply the cluster's SSH user: a plan built against a different
+    # ``sctx`` (or a config reset in between) would otherwise leave the
+    # launch's SSH operations logging in as the wrong user.  Idempotent when
+    # the plan was built from this same context.
+    if getattr(cluster_def, "user", None):
+        try:
+            config.ssh_user = cluster_def.user
+        except Exception:
+            logger.debug("Failed to apply cluster SSH user to config", exc_info=True)
+
     # 3a-bis. Evict this intent's superseded deployments.  ``exclude_intent_id``
-    # above told the scheduler "my own containers aren't foreign load, I'm
-    # replacing them" — this is the half that actually replaces them.  It is a
-    # no-op on the deterministic (greedy) path, where the relaunch reuses the
-    # prior cluster_id and the runtime's step-1 cleanup already removes those
-    # containers by name.
+    # in the planning pass told the scheduler "my own containers aren't foreign
+    # load, I'm replacing them" — this is the half that actually replaces them.
+    # It is a no-op on the deterministic (greedy) path, where the relaunch
+    # reuses the prior cluster_id and the runtime's step-1 cleanup already
+    # removes those containers by name.
     if not options.dry_run:
         _evict_superseded_deployments(
             intent_id=intent_id,
@@ -319,7 +431,7 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None) -> RunRes
         placement_token=final_placement_token,
         host_list=tuple(result.host_list),
         placement=placement,
-        scheduler=_resolve_scheduler_name(effective_scheduler, sctx),
+        scheduler=plan.scheduler or _resolve_scheduler_name(effective_scheduler, sctx),
         runtime=runtime.runtime_name,
         executor=_executor_name_from_result(result),
         started_at=started_at,
@@ -338,6 +450,51 @@ def run(options: RunOptions, *, sctx: "SparkrunContext | None" = None) -> RunRes
 
     emit_run_telemetry(config, result=run_result, recipe=recipe, cluster=cluster_def, options=options)
     return run_result
+
+
+#: Module-level alias so :func:`run` can call :func:`plan` despite its own
+#: ``plan`` parameter shadowing the name inside that function's scope.
+_build_plan = plan
+
+
+def _already_running_result(match, *, plan: RunPlan, options: RunOptions, started_at: float, sctx) -> RunResult:
+    """Build the :class:`RunResult` for an ``ensure`` skip.
+
+    Describes the deployment that is *already* running, not the one the plan
+    would have launched — so ``cluster_id`` / ``host_list`` / ``placement_token``
+    come from *match*.  ``placement`` is ``None`` and ``launch_result`` is
+    ``None``: no launch happened, and reporting the plan's intended placement
+    would claim a rank layout that was never applied.
+    """
+    from sparkrun.orchestration.job_metadata import parse_cluster_id
+
+    try:
+        _, matched_token = parse_cluster_id(match.cluster_id)
+    except ValueError:
+        matched_token = ""
+
+    return RunResult(
+        cluster_id=match.cluster_id,
+        intent_id=match.intent_id,
+        placement_token=matched_token,
+        host_list=tuple(match.hosts),
+        placement=None,
+        scheduler=plan.scheduler or _resolve_scheduler_name(plan.scheduler_selector, sctx),
+        runtime=match.runtime or plan.runtime.runtime_name,
+        executor="",
+        started_at=started_at,
+        dry_run=options.dry_run,
+        is_solo=len(match.hosts) <= 1,
+        rc=0,
+        already_running=True,
+        metadata={
+            "recipe": match.recipe or getattr(plan.recipe, "qualified_name", None),
+            "model": getattr(plan.recipe, "model", None),
+            "ensure_skipped_launch": True,
+            "other_cluster_ids": list(match.other_cluster_ids),
+        },
+        launch_result=None,
+    )
 
 
 def _evict_superseded_deployments(

--- a/src/sparkrun/cli/_cluster.py
+++ b/src/sparkrun/cli/_cluster.py
@@ -653,9 +653,20 @@ def cluster_show(ctx, name, output_json):
 
     default_name = mgr.get_default()
 
+    # Resolve the scheduler the cluster would actually launch with.  A cluster
+    # predating the ``scheduler`` field stores ``None`` and falls back to
+    # greedy; showing only the stored value (the old behavior) printed nothing
+    # at all in that case, so there was no way to tell a greedy cluster from an
+    # occupancy-aware one without launching something.
+    from sparkrun.core.scheduler import describe_effective_scheduler
+
+    effective_scheduler, scheduler_defaulted = describe_effective_scheduler(cluster=c.scheduler, v=_get_context(ctx).variables)
+
     if output_json:
         data = c.to_dict()
         data["default"] = c.name == default_name
+        data["effective_scheduler"] = effective_scheduler
+        data["scheduler_defaulted"] = scheduler_defaulted
         print_json(data)
         return
 
@@ -681,8 +692,10 @@ def cluster_show(ctx, name, output_json):
         click.echo("Executor config:")
         for k, v in sorted(c.executor_config.items()):
             click.echo(f"  {k}: {v}")
-    if c.scheduler:
-        click.echo(f"Scheduler:   {c.scheduler}")
+    if scheduler_defaulted:
+        click.echo(f"Scheduler:   {effective_scheduler} (default — not set on this cluster)")
+    else:
+        click.echo(f"Scheduler:   {effective_scheduler}")
     click.echo(f"Default:     {'yes' if c.name == default_name else 'no'}")
     click.echo(f"Hosts ({len(c.hosts)}):")
     for h in c.hosts:
@@ -1271,12 +1284,24 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
         sparkrun_cache_dir=local_sparkrun,
     )
 
+    # Scheduler the cluster would launch with.  ``inspect`` reports *effective*
+    # configuration, and an unset cluster scheduler still resolves to one — so
+    # reporting the raw ``None`` would hide the thing most likely to explain a
+    # surprising placement.
+    from sparkrun.core.scheduler import describe_effective_scheduler
+
+    effective_scheduler, scheduler_defaulted = describe_effective_scheduler(cluster=cluster_cfg.scheduler, v=_get_context(ctx).variables)
+
     # Collect effective config summary
     effective_config = {
         "cluster": cluster_cfg.name,
         "ssh_user": config.ssh_user,
         "transport": cluster_cfg.transport,
         "provider_ref": cluster_cfg.provider_ref,
+        "scheduler": cluster_cfg.scheduler,
+        "scheduler_resolved": effective_scheduler,
+        "scheduler_defaulted": scheduler_defaulted,
+        "executor": cluster_cfg.executor,
         "transfer_mode": xfer_mode,
         "transfer_mode_resolved": resolved_mode,
         "transfer_interface": xfer_iface or "auto",
@@ -1338,6 +1363,12 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
     cfg_iface = xfer_iface or "auto"
     click.echo("  transfer_interface: %s" % _fmt_resolved(cfg_iface, resolved_iface))
     click.echo("  topology:           %s" % (cluster_cfg.topology or "(none)"))
+    if scheduler_defaulted:
+        click.echo("  scheduler:          %s (default — not set on this cluster)" % effective_scheduler)
+    else:
+        click.echo("  scheduler:          %s" % effective_scheduler)
+    if cluster_cfg.executor:
+        click.echo("  executor:           %s" % cluster_cfg.executor)
     click.echo("  hosts:              %s" % ", ".join(host_list))
     click.echo()
 

--- a/src/sparkrun/cli/_common.py
+++ b/src/sparkrun/cli/_common.py
@@ -251,6 +251,8 @@ def resolve_effective_hosts_for_recipe(
     runtime=None,
     sctx: SparkrunContext | None = None,
     solo: bool = False,
+    scheduler: str | None = None,
+    exclude_intent_id: str | None = None,
 ) -> tuple[list[str], bool]:
     """CLI-layer adapter around :func:`sparkrun.api._hosts.resolve_effective_hosts`.
 
@@ -280,6 +282,19 @@ def resolve_effective_hosts_for_recipe(
             placement).
         sctx: Optional shared :class:`SparkrunContext`.
         solo: ``--solo`` flag value.
+        scheduler: Resolved scheduler name (CLI flag → recipe → cluster).
+            **Must be the same selector the launch will use.**  This trim
+            narrows the candidate host list *before* ``api.run`` re-schedules
+            over the survivors, so a different scheduler here picks a
+            different subset and ``api.run`` is then locked out of the hosts
+            this pass discarded — e.g. defaulting to greedy while the cluster
+            runs ``occupancy-sparse`` hands ``api.run`` the first N hosts
+            regardless of load, and the launch fails with "insufficient free
+            capacity" while idle hosts sit unused.
+        exclude_intent_id: Intent whose own still-running workloads are
+            subtracted from the occupancy snapshot, for the same reason:
+            ``api.run`` excludes them, so this pass must too or the two
+            passes disagree on a relaunch.
 
     Returns:
         ``(effective_host_list, is_solo)``.
@@ -303,6 +318,8 @@ def resolve_effective_hosts_for_recipe(
             runtime=runtime,
             sctx=sctx,
             solo=solo,
+            scheduler=scheduler,
+            exclude_intent_id=exclude_intent_id,
         )
     except api.InsufficientCapacity as e:
         # ``resolve_effective_hosts`` already shaped the message (host-count

--- a/src/sparkrun/cli/_proxy.py
+++ b/src/sparkrun/cli/_proxy.py
@@ -613,20 +613,57 @@ def load_cmd(
         # Try to register with a running proxy.
         from sparkrun import api
 
-        if api.proxy.status(sctx=sctx).running:
-            click.echo("Registering with proxy...")
-            import time
+        proxy_status = api.proxy.status(sctx=sctx)
+        if proxy_status.running:
+            # Discovery's liveness test is an HTTP probe of /v1/models, so
+            # syncing before the server is actually serving finds nothing.
+            # The launch above is detached — it returned when the containers
+            # came up, which for a large model is minutes early.
+            from sparkrun.core.launcher import wait_for_serve_ready
+            from sparkrun.orchestration.primitives import build_ssh_kwargs
 
-            time.sleep(2)  # Brief delay for server startup
-            try:
-                synced = api.proxy.sync(require_running=True, sctx=sctx)
-            except api.proxy.ProxyUpdateFailed as exc:
-                click.echo("Error: %s" % exc, err=True)
-                sys.exit(1)
-            if synced.added:
-                click.echo("Registered %d model(s) with proxy (restarted)." % synced.added)
+            click.echo("Waiting for server to become ready...")
+            readiness = wait_for_serve_ready(result, ssh_kwargs=build_ssh_kwargs(config))
+
+            if not readiness.ready:
+                _warn_not_registered(readiness, proxy_status)
             else:
-                click.echo("Warning: model did not appear in proxy discovery.", err=True)
+                click.echo("Registering with proxy...")
+                try:
+                    synced = api.proxy.sync(require_running=True, sctx=sctx)
+                except api.proxy.ProxyUpdateFailed as exc:
+                    click.echo("Error: %s" % exc, err=True)
+                    sys.exit(1)
+                if synced.added:
+                    click.echo("Registered %d model(s) with proxy (restarted)." % synced.added)
+                else:
+                    click.echo(
+                        "Note: proxy already served this endpoint; no config change needed.",
+                    )
+
+
+def _warn_not_registered(readiness, proxy_status) -> None:
+    """Explain why a loaded model was not registered with the proxy.
+
+    Not an error: the workload is running either way, and the
+    auto-discover daemon registers it as soon as it answers.
+    """
+    if readiness.reason == "port":
+        click.echo(
+            "Warning: server port %d never started listening on %s (container may have exited)." % (readiness.port, readiness.head_host),
+            err=True,
+        )
+        click.echo("  Check the logs: sparkrun logs <cluster-id>", err=True)
+        return
+
+    click.echo(
+        "Warning: server at %s is still not answering — it may need longer to load." % readiness.health_url,
+        err=True,
+    )
+    if proxy_status.autodiscover_running:
+        click.echo("  The proxy's auto-discover will register it once it responds.", err=True)
+    else:
+        click.echo("  Register it once it responds with: sparkrun proxy sync", err=True)
 
 
 @proxy.command("unload")

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -57,6 +57,12 @@ _EXECUTOR_OVERRIDE_KEYS = frozenset(
         "ulimit",
         "devices",
         "memory_limit",
+        # ``-o entrypoint=''`` clears a consuming image ENTRYPOINT (one that
+        # parses sparkrun's appended ``bash -c`` as its own flags) without
+        # having to fork a third-party recipe just to add two lines of
+        # executor_config.  Empty string is the meaningful value here and
+        # survives ``coerce_value``; see ExecutorConfig.entrypoint.
+        "entrypoint",
     }
 )
 

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -29,14 +29,36 @@ from ._common import (
     _simplify_recipe_ref,
     dry_run_option,
     host_options,
+    _render_capacity_diagnostics,
     recipe_override_options,
     resolve_cluster_config,
-    resolve_effective_hosts_for_recipe,
     with_host_context,
     HIDE_ADVANCED_OPTIONS,
 )
 
 logger = logging.getLogger(__name__)
+
+#: ``-o key=value`` keys that configure the *executor* rather than the serve
+#: command.  They are lifted out of ``overrides`` into ``executor_config``
+#: before placement, so the intent id the CLI derives matches the one
+#: ``api.run`` derives from the same (already-stripped) override dict.
+_EXECUTOR_OVERRIDE_KEYS = frozenset(
+    {
+        "auto_remove",
+        "restart_policy",
+        "privileged",
+        "gpus",
+        "ipc",
+        "shm_size",
+        "network",
+        "user",
+        "security_opt",
+        "cap_add",
+        "ulimit",
+        "devices",
+        "memory_limit",
+    }
+)
 
 
 def _summarize_platforms(
@@ -353,68 +375,133 @@ def run(
         else:
             host_source = "localhost"
 
-    # Resolve the effective host list via the scheduler (single source of
-    # truth): ``hosts_used`` IS the list run/stop/logs all share.  Applies
-    # solo / max_nodes as orthogonal constraints; multi-GPU hosts and
-    # explicit ``recipe.layout`` are honoured when ``cluster_def`` carries
-    # per-host hardware.
-    host_list, is_solo = resolve_effective_hosts_for_recipe(
-        host_list,
-        recipe,
-        overrides,
-        cluster_def=cluster_def,
-        runtime=runtime,
-        sctx=sctx,
-        solo=solo,
-    )
-    if recipe.mode == "cluster" and is_solo and not solo:
-        click.echo("Warning: Recipe requires cluster mode but only one host specified", err=True)
+    # Extract executor-specific keys from -o/--option overrides.  Done before
+    # the RunOptions build below so ``overrides`` and ``executor_config`` are
+    # already separated when the plan is computed — the plan's intent id and
+    # config chain must be the ones the launch uses.
+    option_executor_opts: dict[str, Any] = {}
+    for key in list(overrides.keys()):
+        if key in _EXECUTOR_OVERRIDE_KEYS:
+            option_executor_opts[key] = overrides.pop(key)
 
-    # --ensure: check if job is already running, exit 0 if so
-    if ensure:
-        from sparkrun.orchestration.job_metadata import check_job_running as _check_job, derive_cluster_id
-        from sparkrun.orchestration.primitives import build_ssh_kwargs
-
-        _cid = derive_cluster_id(recipe, host_list, overrides=overrides or None)
-        _ssh_kw = build_ssh_kwargs(config)
-        _status = _check_job(cluster_id=_cid, hosts=host_list, ssh_kwargs=_ssh_kw, cache_dir=str(config.cache_dir))
-        if _status.running:
-            click.echo("Job already running (cluster_id: %s)" % _cid)
-            if _status.metadata:
-                click.echo("  Recipe: %s" % _status.metadata.get("recipe", "unknown"))
-                click.echo("  Hosts:  %s" % ", ".join(_status.hosts))
-            sys.exit(0)
-
-    # Resolve cache dir, transfer mode, and transfer interface from cluster config
+    # Resolve cache dir, transfer mode, and transfer interface from cluster
+    # config.  Independent of placement, so it can precede the plan.
     cluster_cfg = resolve_cluster_config(cluster_name, hosts, hosts_file, cluster_mgr)
     local_cache_dir, remote_cache_dir, effective_transfer_mode, effective_transfer_interface = cluster_cfg.resolve_transfer_config(
         config, transfer_mode_override=transfer_mode
     )
 
-    # Resolve effective scheduler name for display + downstream RunOptions.
-    # Scheduler selection chain: CLI flag → recipe.scheduler → cluster.scheduler
-    # → greedy default (FALLBACK_DEFAULT_SCHEDULER).  Look up the plugin so the
-    # banner reflects the *actually-resolved* name rather than a possibly-``None``
-    # selector — matches what ``api.run`` stamps on ``RunResult.scheduler``.
-    from sparkrun.core.scheduler import (
-        FALLBACK_DEFAULT_SCHEDULER,
-        default_scheduler_upgrade_hint,
-        get_scheduler,
-        resolve_scheduler_selector,
+    # Build executor config from CLI flags, then layer the -o/--option-sourced
+    # keys on top — preserving the precedence where -o wins over the flag.
+    cli_executor_opts: dict[str, Any] = {}
+    if no_rm:
+        cli_executor_opts["auto_remove"] = False
+    if memory:
+        cli_executor_opts["memory_limit"] = memory
+    if restart_policy:
+        cli_executor_opts["restart_policy"] = restart_policy
+    if labels_override:
+        cli_executor_opts["labels"] = list(labels_override)
+    cli_executor_opts.update(option_executor_opts)
+
+    # Build the typed RunOptions for the library API.  The CLI already
+    # resolved the recipe, host list, cluster_def, and overrides above (so the
+    # banner / VRAM block can render those before launch); passing the loaded
+    # objects through avoids re-resolution inside the API and preserves the
+    # cwd-recipe discovery the CLI does through ``_load_recipe``.
+    #
+    # ``hosts`` is the **candidate** list — every host placement may choose
+    # from — not a pre-trimmed selection.  Narrowing it here would make this
+    # command's own placement authoritative over the launch's, leaving
+    # ``api.run`` unable to reach any host we discarded.
+    run_options = api.RunOptions(
+        recipe=recipe,
+        hosts=tuple(host_list),
+        cluster=cluster_def,
+        overrides=dict(overrides),
+        scheduler=scheduler_name,
+        solo=solo,
+        dry_run=dry_run,
+        follow=not no_follow,
+        detached=not foreground,
+        trust=trust,
+        transfer_mode=effective_transfer_mode,
+        transfer_interface=effective_transfer_interface,
+        cache_dir=remote_cache_dir,
+        local_cache_dir=local_cache_dir,
+        port=port,
+        ray_port=ray_port,
+        dashboard_port=dashboard_port,
+        dashboard=dashboard,
+        init_port=init_port,
+        executor_config=cli_executor_opts or None,
+        rootful=rootful,
+        diagnostics_path=diagnostics_path,
+        cluster_id_override=cluster_id_override,
+        sync_tuning=not no_sync_tuning,
+        extra_docker_opts=tuple(executor_args) if executor_args else None,
+        topology=cluster_cfg.topology,
+        recipe_ref=recipe_ref,
     )
 
-    effective_scheduler, scheduler_defaulted = resolve_scheduler_selector(
-        cli=scheduler_name,
-        recipe=getattr(recipe, "scheduler", None),
-        cluster=getattr(cluster_def, "scheduler", None),
-    )
+    # --ensure: if this workload is already serving, don't launch — and don't
+    # schedule either, which is why this runs before the plan.
+    #
+    # Keyed on the *intent* (recipe + parallelism + port), never on a
+    # host-derived cluster_id: a cluster_id also encodes placement, so the old
+    # lookup could not match a job placed by a status-aware scheduler (random
+    # placement token) and would launch a duplicate every time.  The intent is
+    # placement-independent, so the answer no longer depends on which scheduler
+    # is configured.  Hosts are the full candidate list — a deployment that
+    # landed on hosts this launch wouldn't pick still counts as running.
+    if ensure:
+        from sparkrun.orchestration.job_metadata import generate_intent_id
+
+        _match = api.find_running_intent(
+            generate_intent_id(recipe, overrides),
+            host_list,
+            cluster=cluster_def,
+            sctx=sctx,
+        )
+        if _match is not None:
+            click.echo("Job already running (cluster_id: %s)" % _match.cluster_id)
+            click.echo("  Recipe: %s" % (_match.recipe or recipe.qualified_name or "unknown"))
+            click.echo("  Hosts:  %s" % ", ".join(_match.hosts))
+            if _match.other_cluster_ids:
+                click.echo(
+                    "  Warning: %d other deployment(s) of this workload are also running: %s"
+                    % (len(_match.other_cluster_ids), ", ".join(_match.other_cluster_ids)),
+                    err=True,
+                )
+            sys.exit(0)
+
+    # Decide the launch ONCE.  Everything below renders from this plan, and the
+    # plan is handed back to ``api.run`` — so what is displayed is exactly what
+    # is launched.  Scheduling here and passing the winners as ``hosts`` instead
+    # would re-narrow the candidate set and reintroduce the class of failure
+    # where a launch reports "insufficient free capacity" while idle hosts sit
+    # unused because this pass already discarded them.
     try:
-        display_scheduler = get_scheduler(effective_scheduler, v=v).scheduler_name
-    except Exception:
-        display_scheduler = effective_scheduler or FALLBACK_DEFAULT_SCHEDULER
+        run_plan = api.plan(run_options, sctx=sctx)
+    except api.InsufficientCapacity as e:
+        click.echo("Error: %s" % e, err=True)
+        _render_capacity_diagnostics(getattr(e, "status", None), list(getattr(e, "host_list", ()) or host_list))
+        sys.exit(1)
+    except api.SparkrunError as e:
+        click.echo("Error: %s" % e, err=True)
+        sys.exit(1)
+
+    for _note in run_plan.notes:
+        click.echo(_note)
+
+    host_list = list(run_plan.host_list)
+    is_solo = run_plan.is_solo
+    if recipe.mode == "cluster" and is_solo and not solo:
+        click.echo("Warning: Recipe requires cluster mode but only one host specified", err=True)
 
     # Display summary before launch
     from sparkrun.core.config import SparkrunConfig
+    from sparkrun.core.scheduler import default_scheduler_upgrade_hint
     from sparkrun.core.version import display_version
 
     container_image = runtime.resolve_container(recipe, overrides)
@@ -427,47 +514,24 @@ def run(
         click.echo("Mode:      solo")
     else:
         click.echo("Mode:      cluster (%d nodes)" % len(host_list))
-    _platform_summary, _per_host = _summarize_platforms(host_list, cluster_def)
+    _platform_summary, _per_host = _summarize_platforms(host_list, run_plan.cluster)
     click.echo("Platform:  %s" % _platform_summary)
     if _per_host is not None:
         for _h, _line in _per_host:
             click.echo("  %-8s %s" % (_h + ":", _line))
-    click.echo("Scheduler: %s" % display_scheduler)
+    click.echo("Scheduler: %s" % run_plan.scheduler)
     # When nothing in the chain selected a scheduler we fell back to the 0.2.x
     # greedy default; recommend opting the cluster into occupancy-aware spreading.
-    if scheduler_defaulted and not is_solo:
+    if run_plan.scheduler_defaulted and not is_solo:
         click.echo(default_scheduler_upgrade_hint())
     if effective_transfer_mode not in ("auto", "local"):
         click.echo("Transfer:  %s" % effective_transfer_mode)
 
-    # Compute placement up-front when we have a cluster definition + multi-host
-    # workload, so the VRAM display can render per-host fit alongside the
-    # legacy DGX-Spark single-line summary.  Failures fall back silently —
-    # the legacy single-line fit always renders regardless.
-    display_placement = None
-    if cluster_def is not None and not is_solo:
-        try:
-            from sparkrun.core.limits import resolved_hardware_for_scheduling
-            from sparkrun.core.parallelism import extract_parallelism
-            from sparkrun.core.scheduler import SchedulingRequest
-
-            # Route through the *resolved* scheduler (not a bare greedy
-            # ``pack``) so the displayed per-host fit matches
-            # the scheduler the launch will actually use.  Pack against capped
-            # usable memory — the same caps the scheduler applies — and skip the
-            # live status query (display only): occupancy-aware schedulers then
-            # degrade to their greedy whole-GPU pack, which is the right shape for
-            # a pre-launch fit preview.
-            display_request = SchedulingRequest(
-                parallelism=extract_parallelism(recipe.build_config_chain(overrides)),
-                hosts=tuple(host_list),
-                host_hardware=resolved_hardware_for_scheduling(cluster_def, list(host_list)),
-                layout=recipe.layout,
-            )
-            display_placement = api.schedule(display_request, scheduler=effective_scheduler, sctx=sctx).assignment
-        except Exception:
-            display_placement = None
-
+    # The per-host fit table renders the plan's own placement.  It used to be
+    # a third scheduling call, deliberately made *without* live occupancy —
+    # which is how a capacity failure could print a table showing every target
+    # host as [OK] directly above the error that rejected them.
+    #
     # A local (absolute-path) model has no HuggingFace repo id to auto-detect
     # params from, so skip the HF lookup — the estimate falls back to recipe
     # defaults rather than erroring on a bogus repo id.
@@ -478,8 +542,8 @@ def run(
         cli_overrides=overrides,
         auto_detect=not is_local_model_path(recipe.model),
         cache_dir=local_cache_dir,
-        cluster=cluster_def,
-        placement=display_placement,
+        cluster=run_plan.cluster,
+        placement=run_plan.placement,
     )
 
     click.echo()
@@ -493,36 +557,6 @@ def run(
             click.echo("  Workers: %s" % ", ".join(host_list[1:]))
     click.echo()
 
-    # Build executor config from CLI flags
-    cli_executor_opts: dict[str, Any] = {}
-    if no_rm:
-        cli_executor_opts["auto_remove"] = False
-    if memory:
-        cli_executor_opts["memory_limit"] = memory
-    if restart_policy:
-        cli_executor_opts["restart_policy"] = restart_policy
-    if labels_override:
-        cli_executor_opts["labels"] = list(labels_override)
-
-    # Also extract executor-specific keys from -o/--option overrides
-    executor_keys = {
-        "auto_remove",
-        "restart_policy",
-        "privileged",
-        "gpus",
-        "ipc",
-        "shm_size",
-        "network",
-        "user",
-        "security_opt",
-        "cap_add",
-        "ulimit",
-        "devices",
-        "memory_limit",
-    }
-    for key in list(overrides.keys()):
-        if key in executor_keys:
-            cli_executor_opts[key] = overrides.pop(key)
     # --- Diagnostics setup ---
     diag = None
     if diagnostics_path:
@@ -549,52 +583,19 @@ def run(
             diag.phase_end("spark_diagnostics", error=str(e))
             logger.warning("Spark diagnostics collection failed: %s", e)
 
-    # Build the typed RunOptions for the library API.  The CLI already
-    # resolved the recipe, host list, cluster_def, and overrides above
-    # (so the banner / VRAM block could render those before launch);
-    # passing the loaded objects through avoids re-resolution inside
-    # ``api.run`` and preserves the cwd-recipe discovery the CLI does
-    # through ``_load_recipe``.  ``effective_scheduler`` was resolved
-    # above so the banner could display the actually-used name.
-
-    run_options = api.RunOptions(
-        recipe=recipe,
-        hosts=tuple(host_list),
-        cluster=cluster_def,
-        overrides=dict(overrides),
-        scheduler=effective_scheduler,
-        solo=is_solo,
-        dry_run=dry_run,
-        follow=not no_follow,
-        detached=not foreground,
-        trust=trust,
-        transfer_mode=effective_transfer_mode,
-        transfer_interface=effective_transfer_interface,
-        cache_dir=remote_cache_dir,
-        local_cache_dir=local_cache_dir,
-        port=port,
-        ray_port=ray_port,
-        dashboard_port=dashboard_port,
-        dashboard=dashboard,
-        init_port=init_port,
-        executor_config=cli_executor_opts or None,
-        rootful=rootful,
-        diagnostics_path=diagnostics_path,
-        cluster_id_override=cluster_id_override,
-        sync_tuning=not no_sync_tuning,
-        extra_docker_opts=tuple(executor_args) if executor_args else None,
-        topology=cluster_cfg.topology,
-        recipe_ref=recipe_ref,
-    )
-
     # Launch via the library API; the API call internally drives
     # ``launch_inference`` (which calls ``runtime.run``).  Tests that
     # mock ``runtime.run`` still observe the call because the runtime
     # layer is unchanged.
+    #
+    # ``plan=run_plan`` launches exactly what was displayed above — no
+    # second resolution, no second transport prepare, no second occupancy
+    # sweep, and no chance of the launch landing somewhere other than the
+    # hosts named in the banner.
     if diag:
         diag.phase_start("launch")
     try:
-        run_result = api.run(run_options, sctx=sctx)
+        run_result = api.run(run_options, sctx=sctx, plan=run_plan)
     except TransferError as e:
         if diag:
             diag.phase_end("launch", error=str(e))

--- a/src/sparkrun/containers/entrypoint.py
+++ b/src/sparkrun/containers/entrypoint.py
@@ -1,0 +1,157 @@
+"""Preflight: does an image's ENTRYPOINT pass sparkrun's command through?
+
+sparkrun composes every workload as ``docker run <opts> <image> bash -c
+<b64 command>`` — the command is always appended as **CMD arguments**.  Docker
+hands those arguments to the image's ENTRYPOINT, so what happens next depends
+entirely on which of two opposite idioms the image uses:
+
+- **Passthrough** — the ENTRYPOINT is a wrapper that does setup and ends in
+  ``exec "$@"``.  ``/opt/nvidia/nvidia_entrypoint.sh``, which nearly every
+  NGC-derived image inherits, is this.  sparkrun's command runs normally and
+  clearing the ENTRYPOINT would *skip* the wrapper's setup.
+- **Consuming** — the ENTRYPOINT names a binary plus subcommand, e.g.
+  ``ENTRYPOINT ["vllm","serve"]``.  sparkrun's ``bash -c <cmd>`` is parsed as
+  *that program's flags*, so the workload never starts.
+
+``docker image inspect`` cannot tell them apart — both are simply a non-empty
+ENTRYPOINT — so this module settles it empirically by running the real argv
+shape and checking for a sentinel.  The failure it prevents is otherwise close
+to undiagnosable: the consumed launcher surfaces as an error about whatever
+flag the consuming program happened to mis-parse, and the container's own serve
+log is destroyed with the container on exit.
+
+Called through :meth:`~sparkrun.orchestration.executors._base.Executor.verify_command_passthrough`
+so the question stays substrate-dispatched, and best-effort throughout — only a
+*confirmed* consuming entrypoint is reported.  Kill switch:
+``SPARKRUN_NO_IMAGE_PROBE=1``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from sparkrun.scripts import read_script
+from sparkrun.utils.shell import quote
+
+logger = logging.getLogger(__name__)
+
+#: Env kill switch, mirroring ``SPARKRUN_NO_SESSION_GUARD``.
+NO_PROBE_ENV = "SPARKRUN_NO_IMAGE_PROBE"
+
+#: Command run inside the probe container.  The sentinel is *computed* rather
+#: than literal so that an entrypoint which echoes its rejected argv back
+#: cannot accidentally satisfy the match — only a shell that really executed
+#: the command can print the evaluated form.
+PROBE_COMMAND = 'printf "sparkrun_probe_%s\\n" "$((21*2))"'
+
+#: What :data:`PROBE_COMMAND` prints when it actually runs.
+PROBE_TOKEN = "sparkrun_probe_42"
+
+#: Verdicts.  Only :data:`VERDICT_CONSUMES` is actionable; everything else
+#: (including "could not tell") lets the launch proceed.
+VERDICT_ABSENT = "absent"
+"""Image declares no ENTRYPOINT — the appended CMD is the argv."""
+VERDICT_PASSTHROUGH = "pass"
+"""ENTRYPOINT is present but ran sparkrun's command (``exec "$@"`` wrapper)."""
+VERDICT_CONSUMES = "fail"
+"""ENTRYPOINT swallowed sparkrun's command — this launch cannot work."""
+VERDICT_UNKNOWN = "unknown"
+"""Probe did not complete (unreachable host, timeout, no docker, disabled)."""
+
+
+@dataclass(frozen=True)
+class EntrypointProbe:
+    """Outcome of one image probe on one host."""
+
+    image: str
+    host: str
+    verdict: str
+    entrypoint: str = ""
+
+    @property
+    def consumes_command(self) -> bool:
+        """True only for a *confirmed* consuming ENTRYPOINT."""
+        return self.verdict == VERDICT_CONSUMES
+
+
+def probe_disabled() -> bool:
+    """True when the ``SPARKRUN_NO_IMAGE_PROBE`` kill switch is set."""
+    return os.environ.get(NO_PROBE_ENV, "").strip().lower() in ("1", "true", "yes")
+
+
+def build_probe_script(image: str, accel_opts: list[str] | None = None) -> str:
+    """Render the remote probe script for *image*.
+
+    *accel_opts* are the executor's own accelerator flags (``--gpus all`` /
+    CDI ``--device``), passed so the probe container starts under the same
+    device conditions as the real launch.  Without them, an entrypoint that
+    hard-fails on a missing GPU *before* reaching ``exec "$@"`` would be
+    misreported as consuming.
+    """
+    return read_script("image_entrypoint_probe.sh").format(
+        image=quote(image),
+        accel_opts=" ".join(accel_opts or []),
+        probe_command=PROBE_COMMAND,
+        probe_token=PROBE_TOKEN,
+    )
+
+
+def parse_probe_output(output: str) -> tuple[str, str]:
+    """Parse the script's ``key=value`` output into ``(verdict, entrypoint)``."""
+    from sparkrun.utils import parse_kv_output
+
+    parsed = parse_kv_output(output or "")
+    verdict = parsed.get("SPARKRUN_PROBE", VERDICT_UNKNOWN)
+    if verdict not in (VERDICT_ABSENT, VERDICT_PASSTHROUGH, VERDICT_CONSUMES):
+        verdict = VERDICT_UNKNOWN
+    entrypoint = parsed.get("SPARKRUN_ENTRYPOINT", "")
+    if entrypoint in ("null", "[]"):
+        entrypoint = ""
+    return verdict, entrypoint
+
+
+def probe_image_entrypoint(
+    image: str,
+    host: str,
+    *,
+    ssh_kwargs: dict | None = None,
+    accel_opts: list[str] | None = None,
+    timeout: int = 300,
+) -> EntrypointProbe:
+    """Run the ENTRYPOINT probe for *image* on *host*.
+
+    Never raises: any failure to reach a verdict degrades to
+    :data:`VERDICT_UNKNOWN`, which callers treat as "proceed".  Refusing a
+    launch because we could not tell is strictly worse than the status quo.
+
+    The generous *timeout* is deliberate — the passthrough case answers in
+    well under a second (the container starts and immediately exits), but a
+    consuming entrypoint pays for however much the program loads before it
+    parses argv, which for a vLLM image means importing torch first.
+    """
+    from sparkrun.orchestration.ssh import run_remote_script
+
+    if probe_disabled():
+        logger.debug("Image entrypoint probe disabled via %s", NO_PROBE_ENV)
+        return EntrypointProbe(image=image, host=host, verdict=VERDICT_UNKNOWN)
+
+    try:
+        result = run_remote_script(
+            host,
+            build_probe_script(image, accel_opts),
+            timeout=timeout,
+            **(ssh_kwargs or {}),
+        )
+    except Exception:
+        logger.debug("Image entrypoint probe errored on %s; skipping", host, exc_info=True)
+        return EntrypointProbe(image=image, host=host, verdict=VERDICT_UNKNOWN)
+
+    if not result.success:
+        logger.debug("Image entrypoint probe failed on %s (rc=%s); skipping", host, result.returncode)
+        return EntrypointProbe(image=image, host=host, verdict=VERDICT_UNKNOWN)
+
+    verdict, entrypoint = parse_probe_output(result.stdout)
+    logger.debug("Image entrypoint probe on %s: image=%s verdict=%s entrypoint=%s", host, image, verdict, entrypoint or "(none)")
+    return EntrypointProbe(image=image, host=host, verdict=verdict, entrypoint=entrypoint)

--- a/src/sparkrun/core/cluster_status.py
+++ b/src/sparkrun/core/cluster_status.py
@@ -268,6 +268,35 @@ def _union_containers(
     return primary + tuple(extra)
 
 
+def workload_matches_intent(workload: RunningWorkload, intent_id: str) -> bool:
+    """``True`` when *workload* belongs to the launch intent *intent_id*.
+
+    The one answer to "is this workload mine?", shared by the two callers that
+    ask it for opposite reasons: placement subtracts its own intent's
+    workloads from the occupancy snapshot (so a relaunch doesn't treat its own
+    containers as foreign load), while ``--ensure`` looks for exactly those
+    workloads to decide there is nothing to launch.  They must agree, or
+    ``--ensure`` would decline to launch something placement had already
+    decided to replace.
+
+    Matches on :attr:`RunningWorkload.intent_id` when the executor could
+    recover it (container label / cached job metadata), else on the intent
+    prefix parsed out of the ``cluster_id``.  A workload whose name is not a
+    canonical sparkrun identifier matches nothing — deliberately: an
+    unidentifiable container is not evidence that *this* intent is running.
+    """
+    if not intent_id:
+        return False
+    if workload.intent_id == intent_id:
+        return True
+    try:
+        from sparkrun.orchestration.job_metadata import parse_cluster_id
+
+        return parse_cluster_id(workload.cluster_id)[0] == intent_id
+    except Exception:
+        return False
+
+
 def empty_status(hosts: list[str], executor: str = "") -> ClusterStatus:
     """Build a zero-occupancy snapshot — every host fully free, no workloads.
 

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -12,7 +12,7 @@ import copy
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from sparkrun.core.backend_select import BackendBundle
@@ -490,6 +490,13 @@ def launch_inference(
     # post_launch_lifecycle).  CLI flag --trust + local/official-registry
     # recipes set this to True via resolve_recipe_trust().
     trust: bool = False,
+    # Called once, immediately before the runtime starts containers — after
+    # every step that can fail cheaply (distribution, model download, tuning)
+    # has succeeded.  ``sparkrun.api.run`` uses it to evict the deployments
+    # this launch supersedes, so an interrupted or failed launch cannot tear
+    # down a running workload it never got close to replacing.  Not called on
+    # ``dry_run``.
+    before_start: "Callable[[], None] | None" = None,
 ) -> LaunchResult:
     """Launch an inference workload.
 
@@ -1024,6 +1031,14 @@ def launch_inference(
 
         _rt_display = RUNTIME_DISPLAY.get(runtime.runtime_name, runtime.runtime_name)
         p.phase(5, "Launching %s runtime" % _rt_display)
+
+    # Last point before containers start.  Everything that can fail slowly and
+    # cheaply — image distribution, model download, tuning sync — is behind us,
+    # so a caller can safely tear down the deployment this launch replaces.
+    # Doing it any earlier means an interrupted `sparkrun run` leaves the
+    # cluster with neither the old workload nor the new one.
+    if before_start is not None and not dry_run:
+        before_start()
 
     # Build runtime.run() kwargs — include runtime-specific options only
     # when they were explicitly provided.

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -1186,6 +1186,112 @@ def launch_inference(
     )
 
 
+@dataclass(frozen=True)
+class ServeReadiness:
+    """Outcome of waiting for a launched workload's head endpoint.
+
+    ``reason`` is empty when ready, else ``"port"`` (never started
+    listening / container exited) or ``"health"`` (listening but never
+    returned HTTP 200).
+    """
+
+    ready: bool
+    head_host: str
+    head_ip: str
+    port: int
+    container: str
+    reason: str = ""
+
+    @property
+    def health_url(self) -> str:
+        return "http://%s:%d/v1/models" % (self.head_ip, self.port)
+
+
+def wait_for_serve_ready(
+    result: LaunchResult,
+    *,
+    ssh_kwargs: dict | None = None,
+    dry_run: bool = False,
+    port_max_retries: int = 120,
+    port_retry_interval: int = 2,
+    health_max_retries: int = 120,
+    health_retry_interval: int = 5,
+) -> ServeReadiness:
+    """Wait for a detached launch's head endpoint to answer ``/v1/models``.
+
+    ``launch_inference(detached=True)`` returns once the *containers* are
+    up, which for a large model is minutes before the server accepts a
+    request.  Callers that need to act on a serving endpoint must wait
+    for it explicitly.
+
+    Two stages, and the order matters: an inference server refuses
+    connections outright until its engine has finished initializing, so
+    the entire startup is indistinguishable from a crash when probing
+    the URL alone.  :func:`wait_for_port` polls the head *host* for a
+    listening socket and aborts early if the head container has exited;
+    only then is :func:`wait_for_healthy`'s connection-refused-means-dead
+    heuristic sound.
+
+    Args:
+        result: The :class:`LaunchResult` to wait on.
+        ssh_kwargs: SSH parameters for probing the head host.
+        dry_run: Report ready without waiting.
+        port_max_retries: Port-poll attempts (``port_retry_interval`` apart).
+        port_retry_interval: Seconds between port polls.
+        health_max_retries: Health-poll attempts (``health_retry_interval`` apart).
+        health_retry_interval: Seconds between health polls.
+
+    Returns:
+        A :class:`ServeReadiness` describing the head endpoint and
+        whether it became ready.
+    """
+    from sparkrun.orchestration.docker import generate_container_name, generate_node_container_name
+    from sparkrun.orchestration.health import wait_for_healthy, wait_for_port
+    from sparkrun.orchestration.primitives import detect_host_ip
+    from sparkrun.utils import is_local_host
+
+    head_host = result.host_list[0] if result.host_list else "localhost"
+
+    if result.is_solo:
+        container = generate_container_name(result.cluster_id, "solo")
+    else:
+        container = generate_node_container_name(result.cluster_id, 0)
+
+    if is_local_host(head_host):
+        head_ip = "127.0.0.1"
+    else:
+        try:
+            head_ip = detect_host_ip(head_host, ssh_kwargs=ssh_kwargs, dry_run=dry_run)
+        except RuntimeError:
+            head_ip = head_host
+
+    port = result.serve_port
+    base = ServeReadiness(True, head_host, head_ip, port, container)
+    if dry_run:
+        return base
+
+    if not wait_for_port(
+        head_host,
+        port,
+        max_retries=port_max_retries,
+        retry_interval=port_retry_interval,
+        ssh_kwargs=ssh_kwargs,
+        dry_run=dry_run,
+        container_name=container,
+    ):
+        return ServeReadiness(False, head_host, head_ip, port, container, reason="port")
+
+    if not wait_for_healthy(
+        base.health_url,
+        max_retries=health_max_retries,
+        retry_interval=health_retry_interval,
+        dry_run=dry_run,
+    ):
+        return ServeReadiness(False, head_host, head_ip, port, container, reason="health")
+
+    return base
+
+
 def post_launch_lifecycle(
     result: LaunchResult,
     remote_cache_dir: str,
@@ -1219,10 +1325,7 @@ def post_launch_lifecycle(
         run_post_commands,
         run_post_exec,
     )
-    from sparkrun.orchestration.health import wait_for_healthy, wait_for_port
-    from sparkrun.orchestration.primitives import build_ssh_kwargs, detect_host_ip
-    from sparkrun.orchestration.docker import generate_container_name, generate_node_container_name
-    from sparkrun.utils import is_local_host
+    from sparkrun.orchestration.primitives import build_ssh_kwargs
 
     p = progress  # short alias
     if p:
@@ -1233,52 +1336,24 @@ def post_launch_lifecycle(
     host_list = result.host_list
     overrides = result.overrides
     config = result.config
-    is_solo = result.is_solo
 
-    head_host = host_list[0] if host_list else "localhost"
     _ssh_kw = build_ssh_kwargs(config)
 
-    # Determine head container name
-    if is_solo:
-        head_container = generate_container_name(result.cluster_id, "solo")
-    else:
-        head_container = generate_node_container_name(result.cluster_id, 0)
-
-    # Detect head IP for health checks
-    if is_local_host(head_host):
-        head_ip = "127.0.0.1"
-    else:
-        try:
-            head_ip = detect_host_ip(head_host, ssh_kwargs=_ssh_kw, dry_run=dry_run)
-        except RuntimeError:
-            head_ip = head_host
-
-    # Determine effective port
-    config_chain = recipe.build_config_chain(overrides)
-    effective_port = config_chain.get("port", 8000)
-
     click.echo("Waiting for server to become ready...")
-    if not dry_run:
-        # Wait for port to be listening
-        port_ready = wait_for_port(
-            head_host,
-            effective_port,
-            max_retries=120,
-            retry_interval=2,
-            ssh_kwargs=_ssh_kw,
-            dry_run=dry_run,
-            container_name=head_container,
-        )
-        if not port_ready:
-            click.echo("Error: Server port %d never became ready" % effective_port, err=True)
-            sys.exit(1)
+    readiness = wait_for_serve_ready(result, ssh_kwargs=_ssh_kw, dry_run=dry_run)
+    head_host = readiness.head_host
+    head_ip = readiness.head_ip
+    effective_port = readiness.port
+    head_container = readiness.container
 
-        # Wait for HTTP 200 on /v1/models
-        health_url = "http://%s:%s/v1/models" % (head_ip, effective_port)
-        healthy = wait_for_healthy(health_url, max_retries=120, retry_interval=5, dry_run=dry_run)
-        if not healthy:
-            click.echo("Error: Server health check never passed at %s" % health_url, err=True)
-            sys.exit(1)
+    if not readiness.ready:
+        if readiness.reason == "port":
+            click.echo("Error: Server port %d never became ready" % effective_port, err=True)
+        else:
+            click.echo("Error: Server health check never passed at %s" % readiness.health_url, err=True)
+        sys.exit(1)
+
+    config_chain = recipe.build_config_chain(overrides)
 
     # Build hook context with extended variables
     hook_context = build_hook_context(

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -281,6 +281,89 @@ def _verify_pre_placed_model(recipe, hosts, ssh_kwargs, *, runtime, cluster, con
         )
 
 
+def _verify_image_command_passthrough(
+    recipe,
+    image,
+    hosts,
+    ssh_kwargs,
+    *,
+    runtime,
+    cluster,
+    config,
+    executor_config,
+    rootless,
+    auto_user,
+    host_hardware,
+    v,
+) -> None:
+    """Fail fast when the image's ENTRYPOINT would swallow sparkrun's command.
+
+    sparkrun appends its launcher as CMD *arguments*, so an image whose
+    ENTRYPOINT consumes them (``ENTRYPOINT ["vllm","serve"]``) runs a different
+    program than intended — while the passthrough wrappers most NGC images ship
+    (``/opt/nvidia/nvidia_entrypoint.sh``, ending in ``exec "$@"``) are fine and
+    must be left alone.  Only a probe can tell them apart; see
+    :meth:`~sparkrun.orchestration.executors._base.Executor.verify_command_passthrough`.
+
+    Fails closed rather than auto-clearing the ENTRYPOINT.  The probe does
+    establish that clearing it *works*, but not that clearing it is *harmless* —
+    a consuming entrypoint may also perform setup the workload needs — so this
+    names both supported fixes and leaves the choice to the operator.
+
+    The executor is resolved with the same arguments the launch itself uses
+    below, so the probe container starts under the launch's own accelerator
+    flags (``host_hardware`` is what pins DGX Spark to ``--gpus`` over CDI).
+
+    Best-effort, matching :func:`_verify_pre_placed_model`: an unresolvable
+    executor, an unreachable host, or any probe error is skipped rather than
+    blocking.  Only a *confirmed* consuming entrypoint raises.
+    """
+    from sparkrun.core.recipe import RecipeError
+    from sparkrun.orchestration.executor import resolve_executor
+
+    if not image or not hosts:
+        return
+
+    try:
+        executor = resolve_executor(
+            recipe=recipe,
+            cluster=cluster,
+            runtime=runtime,
+            config=config,
+            cli_overrides=executor_config if isinstance(executor_config, dict) else None,
+            rootless=rootless,
+            auto_user=auto_user,
+            host_hardware=host_hardware,
+            v=v,
+        )
+    except Exception:
+        logger.debug("image entrypoint preflight: executor unresolvable; skipping probe", exc_info=True)
+        return
+
+    try:
+        probe = executor.verify_command_passthrough(image, hosts, ssh_kwargs=ssh_kwargs)
+    except Exception:
+        logger.debug("image entrypoint preflight: probe failed; skipping", exc_info=True)
+        return
+
+    if probe is None or not probe.consumes_command:
+        return
+
+    raise RecipeError(
+        "Container image %s declares ENTRYPOINT %s, which consumes the command sparkrun "
+        "appends rather than running it, so the workload would never start — the image's "
+        "own program parses sparkrun's launcher as its flags. Verified on %s: the same "
+        "command runs correctly once the entrypoint is cleared.\n"
+        "\n"
+        "Fix it in the recipe:\n"
+        "\n"
+        "    executor_config:\n"
+        '      entrypoint: ""\n'
+        "\n"
+        "or for a one-off run, pass:  -o entrypoint=''" % (image, probe.entrypoint or "(unknown)", probe.host)
+    )
+
+
 def resolve_effective_cache_dir(
     cache_dir: str | None,
     host_list: list[str],
@@ -889,6 +972,30 @@ def launch_inference(
             logger.debug("Could not resolve executor for image-skip decision; distributing image", exc_info=True)
             _skip_container = False
 
+        # Preflight: does this image actually run the command sparkrun appends?
+        # Runs from the distribution hook — i.e. once the image is resident on
+        # every target but *before* the model sync — because that is the only
+        # point where the image can be probed on the substrate and the launch
+        # has not yet paid for the long, routinely-interrupted transfer.
+        # Skipped on dry-run (no SSH) and for container-less executors.
+        def _probe_image_entrypoint() -> None:
+            if dry_run or _skip_container:
+                return
+            _verify_image_command_passthrough(
+                recipe,
+                container_image,
+                host_list,
+                ssh_kwargs,
+                runtime=runtime,
+                cluster=cluster,
+                config=config,
+                executor_config=executor_config,
+                rootless=rootless,
+                auto_user=auto_user,
+                host_hardware=_head_hw,
+                v=v,
+            )
+
         comm_env, ib_ip_map, mgmt_ip_map, ib_iface_map = distribute_from_config(
             recipe,
             container_image,
@@ -906,6 +1013,7 @@ def launch_inference(
             prefs=_model_prefs,
             skip_model=_skip_model,
             skip_container=_skip_container,
+            after_container_sync=_probe_image_entrypoint,
         )
         # Re-save job metadata with IP maps from IB detection
         if not dry_run and (ib_ip_map or mgmt_ip_map):

--- a/src/sparkrun/core/scheduler.py
+++ b/src/sparkrun/core/scheduler.py
@@ -78,6 +78,38 @@ def resolve_scheduler_selector(
     return selector, selector is None
 
 
+def describe_effective_scheduler(
+    cli: str | None = None,
+    recipe: str | None = None,
+    cluster: str | None = None,
+    *,
+    v=None,
+) -> tuple[str, bool]:
+    """Return ``(resolved_name, defaulted)`` for the same chain launches use.
+
+    The display peer of :func:`resolve_scheduler_selector`: where that returns
+    the *selector* (``None`` when nothing named one), this resolves it to the
+    scheduler that would actually run, so ``cluster show`` / ``cluster
+    inspect`` / the ``run`` banner can never disagree with the launch about
+    which scheduler is in effect.
+
+    Answering this is not optional cosmetics.  A cluster created before the
+    ``scheduler`` field existed stores ``None`` and silently resolves to
+    :data:`FALLBACK_DEFAULT_SCHEDULER` — printing nothing (the old behavior)
+    left no way to tell a greedy cluster from an occupancy-aware one short of
+    launching something.
+
+    An unresolvable selector (e.g. a typo, or a plugin that failed to load) is
+    returned verbatim rather than raising: the caller is describing config, and
+    "what you configured, which does not resolve" is the useful answer.
+    """
+    selector, defaulted = resolve_scheduler_selector(cli=cli, recipe=recipe, cluster=cluster)
+    try:
+        return get_scheduler(selector, v=v).scheduler_name, defaulted
+    except Exception:
+        return selector or FALLBACK_DEFAULT_SCHEDULER, defaulted
+
+
 def new_cluster_scheduler_notice(scheduler: str = NEW_CLUSTER_DEFAULT_SCHEDULER) -> str:
     """Human-readable explanation shown when a new cluster opts into *scheduler*."""
     return (

--- a/src/sparkrun/orchestration/distribution.py
+++ b/src/sparkrun/orchestration/distribution.py
@@ -16,6 +16,8 @@ from sparkrun.orchestration.transfer import TransferError
 from sparkrun.core.cluster_manager import ModelDistributionPrefs
 
 if TYPE_CHECKING:
+    from typing import Callable
+
     from sparkrun.core.config import SparkrunConfig
     from sparkrun.orchestration.comm_env import ClusterCommEnv
     from sparkrun.orchestration.infiniband import IBDetectionResult
@@ -720,6 +722,7 @@ def distribute_from_config(
     prefs: ModelDistributionPrefs | None = None,
     skip_model: bool = False,
     skip_container: bool = False,
+    after_container_sync: "Callable[[], None] | None" = None,
 ) -> tuple["ClusterCommEnv | None", dict[str, str], dict[str, str]]:
     """Distribute resources based on recipe ``distribution_config``.
 
@@ -741,6 +744,13 @@ def distribute_from_config(
         transfer_interface: Network interface for transfers.
         local_cache_dir: Control-machine cache dir for model downloads.
         pre_ib: Pre-computed IB detection results.
+        after_container_sync: Optional hook invoked once the container image is
+            resident on every target, *before* model download/distribution
+            starts.  This is the only point where the image can be inspected on
+            the substrate but the expensive, routinely-interrupted model sync
+            has not been paid for yet, so image-level preflights (see
+            ``launcher._verify_image_command_passthrough``) run here rather than
+            after Phase 3.  Raising from the hook aborts the launch.
 
     Returns:
         Tuple of (comm_env, ib_ip_map, mgmt_ip_map, ib_iface_map).
@@ -774,6 +784,8 @@ def distribute_from_config(
                 logger.info("Ensuring container image is available locally...")
                 if ensure_image(image, dry_run=dry_run) != 0:
                     raise DistributionError(f"Failed to pull or locate image: {image}")
+        if after_container_sync is not None:
+            after_container_sync()
         if _model_names:
             with pending_op(_lock_id, "model_download", **_pop_kw):
                 for mn in _model_names:
@@ -862,6 +874,11 @@ def distribute_from_config(
                 )
             if img_failed:
                 raise DistributionError("Image distribution failed on: %s" % ", ".join(img_failed))
+
+    # Image is resident everywhere and the model sync has not started: the one
+    # window where an image-level preflight is both possible and still cheap.
+    if after_container_sync is not None:
+        after_container_sync()
 
     # Distribute models (skipped entirely when skip_model — e.g. a
     # cluster_config.resolved_model_path points at pre-placed shared weights).

--- a/src/sparkrun/orchestration/executors/_base.py
+++ b/src/sparkrun/orchestration/executors/_base.py
@@ -23,6 +23,7 @@ from sparkrun.utils import merge_env
 from sparkrun.utils.shell import b64_encode_cmd, quote
 
 if TYPE_CHECKING:
+    from sparkrun.containers.entrypoint import EntrypointProbe
     from sparkrun.core.cluster_status import ClusterStatus
     from sparkrun.core.hardware import HostHardware
     from sparkrun.core.log_source import LogSource
@@ -544,6 +545,42 @@ class Executor(Plugin):
         """
         del paths, hosts, ssh_kwargs  # base is a no-op; substrate-aware executors override
         return {}
+
+    def verify_command_passthrough(
+        self,
+        image: str,
+        hosts: list[str],
+        *,
+        ssh_kwargs: dict | None = None,
+    ) -> "EntrypointProbe | None":
+        """Report whether *image* would swallow the command sparkrun appends.
+
+        Second preflight peer of :meth:`query_status`, alongside
+        :meth:`verify_mount_sources`: that one asks "do the paths I will mount
+        exist on this substrate?", this one asks "will the command I append
+        actually run on this image?".
+
+        sparkrun always emits its launcher as CMD *arguments*, so an image whose
+        ENTRYPOINT consumes them (``ENTRYPOINT ["vllm","serve"]``) runs
+        something else entirely — while a passthrough wrapper ending in
+        ``exec "$@"`` (``/opt/nvidia/nvidia_entrypoint.sh``, inherited by most
+        NGC images) is harmless and must *not* be cleared.  The two are
+        indistinguishable by inspection, so substrate-aware executors settle it
+        empirically; see :mod:`sparkrun.containers.entrypoint`.
+
+        Returns the probe result, or ``None`` when this executor has no opinion.
+        The default is the safe no-op — container-less (``local``) and provider
+        executors that don't compose a Docker-style argv never block a launch.
+        Best-effort like :meth:`verify_mount_sources`: only a *confirmed*
+        consuming entrypoint is reported; "could not tell" reads as fine.
+
+        Args:
+            image: Resolved container image reference.
+            hosts: Target hosts for the launch.
+            ssh_kwargs: Connection settings for host-substrate probes.
+        """
+        del image, hosts, ssh_kwargs  # base is a no-op; substrate-aware executors override
+        return None
 
     @classmethod
     def workload_labels_for_cluster(

--- a/src/sparkrun/orchestration/executors/docker.py
+++ b/src/sparkrun/orchestration/executors/docker.py
@@ -27,6 +27,7 @@ from sparkrun.orchestration.job_metadata import INTENT_ID_LEN, PLACEMENT_TOKEN_L
 from sparkrun.utils.shell import args_list_to_shell_str, assert_safe_mount_source, b64_wrap_bash, quote
 
 if TYPE_CHECKING:
+    from sparkrun.containers.entrypoint import EntrypointProbe
     from sparkrun.core.cluster_status import ClusterStatus
     from sparkrun.core.hardware import HostHardware
     from sparkrun.core.log_source import LogSource
@@ -470,6 +471,46 @@ class DockerExecutor(Executor):
         inner.extend(["-n", str(int(tail)) if tail is not None else "+1"])
         inner.append(path)
         return "docker exec %s %s" % (quote(source.container), " ".join(quote(part) for part in inner))
+
+    def verify_command_passthrough(
+        self,
+        image: str,
+        hosts: list[str],
+        *,
+        ssh_kwargs: dict | None = None,
+    ) -> "EntrypointProbe | None":
+        """Probe whether *image*'s ENTRYPOINT swallows the appended ``bash -c``.
+
+        Only one host is probed.  Image distribution has already established
+        that every host carries the same image (by Id or RepoDigest), and the
+        verdict is a property of the image, not of the host — so a second probe
+        would spend another container start to re-derive the same answer.
+
+        The executor's own :meth:`_accelerator_opts` are forwarded so the probe
+        container starts under the same device conditions the real launch will
+        use.  Without them an entrypoint that hard-fails on a missing GPU
+        *before* reaching ``exec "$@"`` would look indistinguishable from one
+        that consumed the command.
+
+        A resolved ``entrypoint`` override short-circuits the probe: the launch
+        will emit ``--entrypoint`` and the image's own ENTRYPOINT never runs, so
+        there is nothing left to consume the command.  Without this the probe
+        would reject the very fix it recommends — ``entrypoint: ""`` — since the
+        image keeps declaring a consuming ENTRYPOINT either way.
+        """
+        from sparkrun.containers.entrypoint import probe_image_entrypoint
+
+        if not image or not hosts:
+            return None
+        if self.config.entrypoint is not None:
+            logger.debug("Skipping entrypoint probe for %s: launch overrides entrypoint to %r", image, self.config.entrypoint)
+            return None
+        return probe_image_entrypoint(
+            image,
+            hosts[0],
+            ssh_kwargs=ssh_kwargs,
+            accel_opts=self._accelerator_opts(),
+        )
 
     def status_cmd(self, container_name: str) -> str:
         """Exit 0 iff a container named *container_name* is currently running."""

--- a/src/sparkrun/orchestration/job_metadata.py
+++ b/src/sparkrun/orchestration/job_metadata.py
@@ -233,11 +233,25 @@ _CONTAINER_NAME_RE = re.compile(
 def generate_intent_id(recipe: "Recipe", overrides: dict | None = None) -> str:
     """Deterministic :data:`INTENT_ID_LEN`-char hex *intent* identifier (no ``sparkrun_`` prefix).
 
-    Hashes ``recipe.runtime`` + ``recipe.model`` + port + served-model-name
-    + every non-default parallelism dimension in
+    Hashes ``recipe.runtime`` + ``recipe.model`` + ``recipe.container`` + port
+    + served-model-name + every non-default parallelism dimension in
     :data:`sparkrun.core.parallelism.PARALLELISM_KEYS` (tp, pp, dp, ep,
     cp).  Hosts are **not** hashed — same recipe + parallelism + port
     always yields the same intent_id regardless of scheduler placement.
+
+    The container image is included because the intent_id is not only a
+    discovery key: ``api.run`` treats a matching intent as *this launch's own
+    workload*, subtracting it from the occupancy snapshot and then evicting
+    it.  Two recipes serving the same model on the same port through
+    different images — say a stable build and a nightly — are different
+    workloads a user will reasonably want side by side, and without the image
+    in the hash, launching the second silently destroyed the first.  (``--image``
+    writes through to ``recipe.container``, so an image override is covered.)
+
+    It remains deliberately narrow otherwise: serve arguments are *not*
+    hashed, so ``stop`` / ``status`` / ``logs`` keep finding a live workload
+    after a relaunch that only tweaked a flag.  Callers that must distinguish
+    those hash :func:`derive_recipe_fingerprint` alongside this.
 
     Use :func:`generate_cluster_id` to compose this with a fresh
     placement token at launch time.
@@ -248,6 +262,11 @@ def generate_intent_id(recipe: "Recipe", overrides: dict | None = None) -> str:
     served_name = _resolve_override("served_model_name", overrides, recipe.defaults)
 
     parts: list[str] = [recipe.runtime, recipe.model]
+    # Empty/unset container (recipe relies on the runtime's default image)
+    # contributes nothing, so recipes that predate an explicit container keep
+    # hashing as before rather than all colliding on a placeholder.
+    if getattr(recipe, "container", None):
+        parts.append("image=%s" % recipe.container)
     if port is not None:
         parts.append("port=%s" % port)
     if served_name is not None:

--- a/src/sparkrun/scripts/image_entrypoint_probe.sh
+++ b/src/sparkrun/scripts/image_entrypoint_probe.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Probe whether an image's ENTRYPOINT passes sparkrun's command through.
+#
+# sparkrun always appends its launcher as CMD *arguments*
+# (`docker run <image> bash -c <b64 cmd>`), never as the entrypoint.  An image
+# whose ENTRYPOINT consumes its args -- e.g. ENTRYPOINT ["vllm","serve"] --
+# therefore eats the launcher and runs something else entirely, while a
+# passthrough wrapper that ends in `exec "$@"` -- e.g.
+# /opt/nvidia/nvidia_entrypoint.sh, which nearly every NGC-derived image ships
+# -- is completely harmless.  The two are indistinguishable by inspection, so
+# this runs the *real* argv shape and looks for a sentinel.
+set -uo pipefail
+
+ENTRYPOINT=$(docker image inspect --format '{{{{json .Config.Entrypoint}}}}' {image} 2>/dev/null || true)
+echo "SPARKRUN_ENTRYPOINT=$ENTRYPOINT"
+
+case "$ENTRYPOINT" in
+    ''|null|'[]')
+        # No ENTRYPOINT at all: the appended CMD *is* the argv, so there is
+        # nothing that could consume it.  Skip the container start entirely --
+        # this is the cheap exit for the majority of images.
+        echo "SPARKRUN_PROBE=absent"
+        exit 0
+        ;;
+esac
+
+# Two deliberate choices guard against a false "pass":
+#   * stdout only (2>/dev/null) -- a consuming entrypoint frequently echoes the
+#     argv it rejected back on stderr, which would match a literal sentinel.
+#   * the sentinel is *computed*, not literal, so even an echoed-back argv
+#     cannot produce it -- only a shell that actually ran the command can.
+OUTPUT=$(docker run --rm {accel_opts} {image} bash -c '{probe_command}' 2>/dev/null || true)
+case "$OUTPUT" in
+    *{probe_token}*)
+        echo "SPARKRUN_PROBE=pass"
+        exit 0
+        ;;
+esac
+
+# The command did not run -- but "the entrypoint ate it" is only one of the
+# reasons why.  A stale CDI spec, an unavailable GPU, a missing bash, or any
+# other broken-container-start looks identical from here, and reporting those
+# as an entrypoint problem would block launches over an unrelated fault.
+# Re-run byte-identically except with the ENTRYPOINT cleared: only if *that*
+# succeeds is the entrypoint provably the cause -- which also makes the fix
+# sparkrun recommends a verified one rather than an inferred one.
+CLEARED=$(docker run --rm --entrypoint '' {accel_opts} {image} bash -c '{probe_command}' 2>/dev/null || true)
+case "$CLEARED" in
+    *{probe_token}*) echo "SPARKRUN_PROBE=fail" ;;
+    *) echo "SPARKRUN_PROBE=unknown" ;;
+esac
+exit 0

--- a/src/sparkrun/telemetry/config.py
+++ b/src/sparkrun/telemetry/config.py
@@ -55,7 +55,24 @@ def env_telemetry_override() -> bool | None:
 
 
 def telemetry_enabled(config: SparkrunConfig) -> bool:
-    """Return whether telemetry should be emitted for this process."""
+    """Return whether telemetry should be emitted for this process.
+
+    Anything that is not a real :class:`SparkrunConfig` fails closed, ahead of
+    every other layer.  No production path can reach that branch — each caller
+    sources the config from ``SparkrunContext.config`` or constructs one
+    directly, and the class has no subclasses — but a *test double* does, and
+    the resolution below fails open for it: ``parse_bool()`` on a mock yields an
+    unrecognized string, returns None, and falls through to the unset default of
+    True.  A mock config therefore used to *enable* telemetry, which is how mock
+    objects were posted to the live collector on three separate occasions.
+
+    Checked before the environment override deliberately: ``SPARKRUN_NO_TELEMETRY=0``
+    forces telemetry on, and must not be able to resurrect this case.
+    """
+    if not isinstance(config, SparkrunConfig):
+        logger.debug("Telemetry disabled: config is a %s, not a SparkrunConfig", type(config).__name__)
+        return False
+
     env_override = env_telemetry_override()
     if env_override is not None:
         return env_override

--- a/src/sparkrun/telemetry/util.py
+++ b/src/sparkrun/telemetry/util.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from enum import Enum
+import logging
+from pathlib import PurePath
 import platform
 
 from sparkrun.core.parallelism import PARALLELISM_KEYS, extract_parallelism
 from sparkrun.core.registry import BOOTSTRAP_REGISTRY_URLS, FALLBACK_DEFAULT_REGISTRIES
 
 from .types import TelemetryEvent
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_url(url: str) -> str:
@@ -22,11 +27,40 @@ _DEFAULT_REGISTRY_URLS = {normalize_url(url) for url in BOOTSTRAP_REGISTRY_URLS}
 }
 
 
-def string_value(value) -> str | None:
-    """Return a non-empty stripped string for telemetry dimensions."""
-    if value is None:
+#: The only types a telemetry dimension may be rendered from.  Deliberately a
+#: closed list: every value here is read off a loosely typed domain object with
+#: ``getattr``, so an unconditional ``str()`` renders whatever the caller
+#: happened to be holding — which is how ``"<MagicMock name='mock.category'
+#: id=...>"`` once reached the collector as a benchmark's category.  A dimension
+#: that goes missing is a far cheaper failure than one carrying an object repr.
+#:
+#: ``os.PathLike`` is *not* used for the path case: it is a runtime protocol
+#: satisfied by anything with ``__fspath__``, which ``MagicMock`` synthesizes —
+#: it would readmit exactly what this excludes.
+_SCALAR_TYPES = (str, bool, int, float, PurePath, Enum)
+
+
+def _scalar(value):
+    """Return *value* narrowed to a JSON-safe scalar, or None if it is not one."""
+    if value is None or not isinstance(value, _SCALAR_TYPES):
         return None
-    text = str(value).strip()
+    if isinstance(value, Enum):
+        inner = value.value
+        return inner if isinstance(inner, (str, bool, int, float)) else None
+    return value
+
+
+def string_value(value) -> str | None:
+    """Return a non-empty stripped string for telemetry dimensions.
+
+    Anything that is not a plain scalar yields ``None`` rather than its repr.
+    """
+    scalar = _scalar(value)
+    if scalar is None:
+        if value is not None:
+            logger.debug("Dropping non-scalar telemetry value of type %s", type(value).__name__)
+        return None
+    text = str(scalar).strip()
     return text or None
 
 
@@ -112,9 +146,15 @@ def attr_bool(source, name: str) -> bool:
 
 
 def int_value(value, *, default: int | None = None) -> int | None:
-    """Parse an integer telemetry value, returning the provided default on failure."""
+    """Parse an integer telemetry value, returning the provided default on failure.
+
+    Narrowed to scalars first, for the reason :data:`_SCALAR_TYPES` documents:
+    ``int()`` on an arbitrary object invokes ``__int__``, which ``MagicMock``
+    synthesizes — so an unnarrowed conversion reports a confident ``1`` for a
+    test double.
+    """
     try:
-        return int(value)
+        return int(_scalar(value))  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return default
 

--- a/tests/_telemetry_guard.py
+++ b/tests/_telemetry_guard.py
@@ -1,0 +1,49 @@
+"""Hard stop on outbound telemetry from the test suite.
+
+``isolate_stateful`` sets ``SPARKRUN_NO_TELEMETRY=1``, but that is *policy*: it
+is one environment variable, any test may drop it with ``monkeypatch.delenv``
+(several do, deliberately), and a branch or sibling repo whose conftest predates
+it has no protection at all.  This is the *mechanism* — the HTTP call itself is
+replaced, so nothing the suite does can reach the collector.
+
+Real leaks this backstops (observed in collected data, 2026-07-31 / 08-05 /
+08-07): a ``MagicMock`` config makes ``telemetry_enabled`` fail open, so mock
+objects were posted to the production endpoint as a benchmark's category,
+framework and profile.
+"""
+
+from __future__ import annotations
+
+#: Patch target — the single ``urlopen`` every telemetry send funnels through.
+TELEMETRY_URLOPEN = "sparkrun.telemetry.client.urlopen"
+
+
+def install_telemetry_blocker(monkeypatch) -> list[str]:
+    """Replace the telemetry HTTP call and return the list of attempted URLs.
+
+    Recording is the load-bearing half.  Raising alone would not fail anything:
+    every ``sparkrun.telemetry.emit_*`` helper wraps its send in
+    ``except Exception`` and logs at DEBUG, which is precisely the silence that
+    let mock objects reach the real collector unnoticed.  Callers assert the
+    returned list is empty at teardown.
+    """
+    attempts: list[str] = []
+
+    def _blocked(request, timeout=None):
+        attempts.append(str(getattr(request, "full_url", request)))
+        raise AssertionError("telemetry POST blocked: the test suite must never send telemetry")
+
+    monkeypatch.setattr(TELEMETRY_URLOPEN, _blocked)
+    return attempts
+
+
+def describe_escapes(attempts: list[str]) -> str:
+    """Render the teardown failure message for a non-empty attempt list."""
+    return (
+        "telemetry escaped the test suite: %d POST(s) to %s. Telemetry must be disabled in tests -- if this test needs the enabled path, patch %s itself."
+        % (
+            len(attempts),
+            ", ".join(sorted(set(attempts))),
+            TELEMETRY_URLOPEN,
+        )
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 import yaml
 
+from _telemetry_guard import describe_escapes, install_telemetry_blocker
 from sparkrun.core.bootstrap import init_sparkrun
 from sparkrun.core.registry import RegistryManager
 
@@ -25,6 +26,12 @@ def isolate_stateful(tmp_path: Path, monkeypatch):
     """
     monkeypatch.setenv("STATEFUL_ROOT", str(tmp_path / "stateful"))
     monkeypatch.setenv("SPARKRUN_NO_TELEMETRY", "1")
+    # ...and block the send itself, because the env var above is only policy.
+    # Any test can drop it (test_telemetry.py does, on purpose), and telemetry
+    # fails *open*: a MagicMock config makes `telemetry_enabled` return True,
+    # which is how mock objects reached the production collector as a
+    # benchmark's category/framework/profile. Checked at teardown below.
+    telemetry_attempts = install_telemetry_blocker(monkeypatch)
     # Hard-disable external-plugin auto-loading during tests. The feature flag
     # alone is not enough: pytest reads the developer's REAL ~/.config/sparkrun
     # (the SAF stateful root isn't "ready"), so a developer who enabled
@@ -100,6 +107,9 @@ def isolate_stateful(tmp_path: Path, monkeypatch):
     sparkrun.core.bootstrap._variables = None
     yield
     sparkrun.core.bootstrap._variables = None
+
+    if telemetry_attempts:
+        pytest.fail(describe_escapes(telemetry_attempts), pytrace=False)
 
 
 @pytest.fixture

--- a/tests/test_api_intent.py
+++ b/tests/test_api_intent.py
@@ -1,0 +1,127 @@
+"""``sparkrun.api.find_running_intent`` — placement-independent "is it up?".
+
+``--ensure`` used to derive a cluster_id from ``(recipe, hosts)`` and look for
+*that*.  A cluster_id encodes placement as well as intent, so the lookup only
+ever matched a job the greedy scheduler had put on exactly the host set being
+asked about.  Under an ``occupancy-*`` scheduler (random placement token) it
+matched nothing, ever — ``--ensure`` launched a duplicate every time.
+
+These tests pin the replacement property: the answer depends on the intent and
+not on where the deployment landed or which scheduler placed it.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import sparkrun.api as api
+from sparkrun.core.cluster_status import ClusterStatus, HostOccupancy, RunningWorkload, workload_matches_intent
+
+_INTENT = "0123456789abcdef"
+_HOSTS = ["h1", "h2", "h3"]
+
+
+def _status(*entries: tuple[str, tuple[RunningWorkload, ...]]) -> ClusterStatus:
+    return ClusterStatus(
+        hosts=tuple(HostOccupancy(host=h, workloads=w, used_slots=len(w)) for h, w in entries),
+        executor="docker",
+    )
+
+
+def _workload(cluster_id: str, *, intent_id: str | None = None, **kw) -> RunningWorkload:
+    return RunningWorkload(cluster_id=cluster_id, intent_id=intent_id, **kw)
+
+
+def test_matches_regardless_of_placement_token():
+    """A random (occupancy-scheduler) token doesn't hide the deployment."""
+    snap = _status(("h2", (_workload("sparkrun_%s_ffff00001111" % _INTENT, intent_id=_INTENT),)))
+
+    match = api.find_running_intent(_INTENT, _HOSTS, status=snap)
+
+    assert match is not None
+    assert match.cluster_id == "sparkrun_%s_ffff00001111" % _INTENT
+    assert match.hosts == ("h2",)
+
+
+def test_matches_on_cluster_id_prefix_without_a_label():
+    """Falls back to the cluster_id's intent prefix when no label was recovered."""
+    snap = _status(("h1", (_workload("sparkrun_%s_abcd12340000" % _INTENT, intent_id=None),)))
+
+    assert api.find_running_intent(_INTENT, _HOSTS, status=snap) is not None
+
+
+def test_ignores_other_intents():
+    """A different workload on the cluster is not this one."""
+    snap = _status(("h1", (_workload("sparkrun_fedcba9876543210_abcd12340000", intent_id="fedcba9876543210"),)))
+
+    assert api.find_running_intent(_INTENT, _HOSTS, status=snap) is None
+
+
+def test_ignores_unidentifiable_containers():
+    """A non-canonical container name is not evidence this intent is running."""
+    snap = _status(("h1", (_workload("some-unrelated-container", intent_id=None),)))
+
+    assert api.find_running_intent(_INTENT, _HOSTS, status=snap) is None
+
+
+def test_collects_every_host_of_a_multi_node_deployment():
+    w = _workload("sparkrun_%s_aaaa11112222" % _INTENT, intent_id=_INTENT, recipe_name="r", runtime_name="sglang")
+    snap = _status(("h1", (w,)), ("h2", ()), ("h3", (w,)))
+
+    match = api.find_running_intent(_INTENT, _HOSTS, status=snap)
+
+    assert match.hosts == ("h1", "h3")
+    assert match.recipe == "r"
+    assert match.runtime == "sglang"
+
+
+def test_reports_duplicate_deployments_of_one_intent():
+    """Two deployments of one intent is a state the launch path avoids — say so.
+
+    The widest one wins so the report describes the primary deployment, but
+    the others are surfaced rather than silently dropped.
+    """
+    big = _workload("sparkrun_%s_bbbb22223333" % _INTENT, intent_id=_INTENT)
+    small = _workload("sparkrun_%s_cccc33334444" % _INTENT, intent_id=_INTENT)
+    snap = _status(("h1", (big,)), ("h2", (big,)), ("h3", (small,)))
+
+    match = api.find_running_intent(_INTENT, _HOSTS, status=snap)
+
+    assert match.cluster_id == "sparkrun_%s_bbbb22223333" % _INTENT
+    assert match.other_cluster_ids == ("sparkrun_%s_cccc33334444" % _INTENT,)
+
+
+def test_empty_inputs_are_not_a_match():
+    assert api.find_running_intent("", _HOSTS, status=_status()) is None
+    assert api.find_running_intent(_INTENT, [], status=_status()) is None
+
+
+def test_unreachable_cluster_counts_as_not_running():
+    """Better to launch than to refuse because a probe failed."""
+
+    def _boom(hosts, **kwargs):
+        raise OSError("connection refused")
+
+    with mock.patch.object(api, "status", _boom):
+        assert api.find_running_intent(_INTENT, _HOSTS) is None
+
+
+@pytest.mark.parametrize(
+    "workload,expected",
+    [
+        (_workload("sparkrun_%s_111122223333" % _INTENT, intent_id=_INTENT), True),
+        (_workload("sparkrun_%s_111122223333" % _INTENT), True),
+        (_workload("sparkrun_ffffffffffffffff_111122223333", intent_id="ffffffffffffffff"), False),
+        (_workload("not-a-sparkrun-name"), False),
+    ],
+)
+def test_workload_matches_intent_predicate(workload, expected):
+    """The shared predicate placement-exclusion and --ensure both depend on.
+
+    They must agree: placement subtracts its own intent's workloads while
+    ``--ensure`` looks for them.  A divergence would make ``--ensure`` decline
+    to launch something placement had already decided to replace.
+    """
+    assert workload_matches_intent(workload, _INTENT) is expected

--- a/tests/test_api_plan.py
+++ b/tests/test_api_plan.py
@@ -1,0 +1,226 @@
+"""``sparkrun.api.plan`` — the decide half of the launch path.
+
+``run`` used to do everything, which forced any caller that needed to *show*
+the target hosts before launching to schedule separately and hand the winners
+back as ``options.hosts``.  That silently made the display pass authoritative
+over placement.  ``plan`` exists so the decision can be made once and reused:
+``run(options, plan=plan)`` launches exactly what the plan describes.
+
+These tests pin the contract that makes that safe — ``run`` must not
+re-resolve, re-prepare, or re-place when a plan is supplied.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import yaml
+
+import sparkrun.api as api
+from sparkrun.core.cluster_manager import ClusterDefinition
+from sparkrun.core.cluster_status import ClusterStatus, HostOccupancy, RunningWorkload
+
+_HOSTS = ["h1", "h2", "h3", "h4"]
+
+_RECIPE_DATA = {
+    "sparkrun_version": "2",
+    "name": "api.plan test recipe",
+    "model": "Qwen/Qwen3-1.7B",
+    "runtime": "sglang",
+    "mode": "cluster",
+    "container": "scitrera/dgx-spark-sglang:latest",
+    "defaults": {"port": 30000, "tensor_parallel": 2},
+}
+
+
+@pytest.fixture
+def recipe(tmp_path):
+    from sparkrun.core.recipe import Recipe
+
+    path = tmp_path / "plan-test.yaml"
+    path.write_text(yaml.safe_dump(_RECIPE_DATA))
+    return Recipe.load(str(path), resolve=False)
+
+
+@pytest.fixture
+def idle_cluster(monkeypatch):
+    """A 4-host cluster where h1/h2 are busy and h3/h4 are idle."""
+    busy = set(_HOSTS[:2])
+
+    def _stub_status(hosts, **kwargs):
+        return ClusterStatus(
+            hosts=tuple(
+                HostOccupancy(
+                    host=h,
+                    workloads=(RunningWorkload(cluster_id="sparkrun_aaaa_bbbb"),) if h in busy else (),
+                    used_slots=1 if h in busy else 0,
+                    free_slots=0 if h in busy else 1,
+                )
+                for h in hosts
+            ),
+            executor="docker",
+        )
+
+    monkeypatch.setattr("sparkrun.api._status.status", _stub_status)
+    monkeypatch.setattr("sparkrun.api.status", _stub_status)
+
+
+def _options(recipe, **kw):
+    return api.RunOptions(
+        recipe=recipe,
+        cluster=ClusterDefinition(name="c", hosts=list(_HOSTS), scheduler="occupancy-sparse"),
+        hosts=tuple(_HOSTS),
+        dry_run=True,
+        **kw,
+    )
+
+
+def test_plan_separates_candidates_from_targets(recipe, idle_cluster, v):
+    """The plan keeps both host sets: what it could pick and what it picked."""
+    plan = api.plan(_options(recipe))
+
+    assert list(plan.candidate_hosts) == _HOSTS
+    assert list(plan.host_list) == ["h3", "h4"]
+    assert plan.scheduler == "occupancy-sparse"
+    assert plan.scheduler_defaulted is False
+    assert plan.cluster_id.startswith("sparkrun_")
+    assert plan.notes  # "N nodes required, using N of M hosts"
+
+
+def test_plan_changes_no_cluster_state(recipe, idle_cluster, v):
+    """Planning is safe to do and throw away — it must not launch anything."""
+    with mock.patch("sparkrun.core.launcher.launch_inference") as launch:
+        with mock.patch("sparkrun.api._run._evict_superseded_deployments") as evict:
+            api.plan(_options(recipe))
+
+    launch.assert_not_called()
+    evict.assert_not_called()
+
+
+def test_run_with_plan_does_not_replace(recipe, idle_cluster, v):
+    """``run(plan=…)`` reuses the decision instead of scheduling again.
+
+    This is the whole point of the split: a second placement pass over the
+    first pass's survivors is what turned a scheduler disagreement into a
+    launch failure on a cluster with free capacity.
+    """
+    plan = api.plan(_options(recipe))
+
+    with mock.patch("sparkrun.api._hosts.resolve_effective_hosts") as replace:
+        with mock.patch("sparkrun.core.launcher.launch_inference") as launch:
+            launch.return_value = mock.MagicMock(
+                cluster_id=plan.cluster_id,
+                host_list=list(plan.host_list),
+                rc=0,
+                is_solo=False,
+                runtime_info={},
+                recipe_ref=None,
+                serve_command="",
+                container_image="",
+                serve_port=0,
+                effective_cache_dir="",
+            )
+            api.run(_options(recipe), plan=plan)
+
+    replace.assert_not_called()
+    assert list(launch.call_args.kwargs["host_list"]) == ["h3", "h4"]
+
+
+def test_run_without_plan_still_places(recipe, idle_cluster, v):
+    """``run(options)`` alone is unchanged — it plans internally.
+
+    Library callers that render nothing should keep calling it this way.
+    """
+    with mock.patch("sparkrun.core.launcher.launch_inference") as launch:
+        launch.return_value = mock.MagicMock(
+            cluster_id="sparkrun_aaaa_bbbb",
+            host_list=["h3", "h4"],
+            rc=0,
+            is_solo=False,
+            runtime_info={},
+            recipe_ref=None,
+            serve_command="",
+            container_image="",
+            serve_port=0,
+            effective_cache_dir="",
+        )
+        result = api.run(_options(recipe))
+
+    assert list(launch.call_args.kwargs["host_list"]) == ["h3", "h4"]
+    assert result.scheduler == "occupancy-sparse"
+
+
+def test_run_ensure_skips_launch_when_intent_is_up(recipe, idle_cluster, v):
+    """``RunOptions.ensure`` is honoured — it used to be documented but dead."""
+    from sparkrun.api._intent import IntentMatch
+
+    match = IntentMatch(
+        intent_id="0123456789abcdef",
+        cluster_id="sparkrun_0123456789abcdef_aabbccddeeff",
+        hosts=("h3", "h4"),
+        recipe="test-recipe",
+        runtime="sglang",
+    )
+
+    with mock.patch("sparkrun.api._intent.find_running_intent", return_value=match):
+        with mock.patch("sparkrun.core.launcher.launch_inference") as launch:
+            result = api.run(_options(recipe, ensure=True))
+
+    launch.assert_not_called()
+    assert result.already_running is True
+    assert result.cluster_id == match.cluster_id
+    assert result.host_list == ("h3", "h4")
+    assert result.launch_result is None
+    assert result.rc == 0
+
+
+def test_run_ensure_launches_when_intent_is_not_up(recipe, idle_cluster, v):
+    """No match → ``ensure`` is a no-op and the launch proceeds normally."""
+    with mock.patch("sparkrun.api._intent.find_running_intent", return_value=None):
+        with mock.patch("sparkrun.core.launcher.launch_inference") as launch:
+            launch.return_value = mock.MagicMock(
+                cluster_id="sparkrun_aaaa_bbbb",
+                host_list=["h3", "h4"],
+                rc=0,
+                is_solo=False,
+                runtime_info={},
+                recipe_ref=None,
+                serve_command="",
+                container_image="",
+                serve_port=0,
+                effective_cache_dir="",
+            )
+            result = api.run(_options(recipe, ensure=True))
+
+    launch.assert_called_once()
+    assert result.already_running is False
+
+
+def test_plan_prepares_transport_once(recipe, idle_cluster, v):
+    """Transport preparation belongs to planning, not to every pass.
+
+    A provider transport refreshes ephemeral connection details on prepare,
+    so preparing again after the plan was built could hand the launch a
+    different endpoint than the one the plan was computed against.
+    """
+    with mock.patch("sparkrun.api._resolve.prepare_transport") as prepare:
+        plan = api.plan(_options(recipe))
+        assert prepare.call_count == 1
+
+        with mock.patch("sparkrun.core.launcher.launch_inference") as launch:
+            launch.return_value = mock.MagicMock(
+                cluster_id=plan.cluster_id,
+                host_list=list(plan.host_list),
+                rc=0,
+                is_solo=False,
+                runtime_info={},
+                recipe_ref=None,
+                serve_command="",
+                container_image="",
+                serve_port=0,
+                effective_cache_dir="",
+            )
+            api.run(_options(recipe), plan=plan)
+
+    assert prepare.call_count == 1, "run() re-prepared a transport the plan already prepared"

--- a/tests/test_api_run_eviction.py
+++ b/tests/test_api_run_eviction.py
@@ -248,6 +248,13 @@ def _run_with_stubbed_launcher(opts):
     """``api.run(opts)`` with a hermetic launcher, returning the eviction mock."""
 
     def _fake_launch(**kwargs):
+        # Honour the real launcher's contract: ``before_start`` fires once,
+        # immediately before containers start — i.e. after every step that can
+        # fail slowly (distribution, model download).  A fake that skipped it
+        # would let the eviction move back to the top of ``api.run`` unnoticed.
+        hook = kwargs.get("before_start")
+        if hook is not None and not kwargs.get("dry_run"):
+            hook()
         return type(
             "FakeLaunchResult",
             (),
@@ -294,7 +301,7 @@ def test_dry_run_never_evicts():
     _run_with_stubbed_launcher(_run_options(dry_run=True)).assert_not_called()
 
 
-def test_real_run_evicts_before_launching():
+def test_real_run_evicts_before_starting_containers():
     """Positive control for the test above: a non-dry-run reaches the
     eviction step, and hands it the launch's own cluster_id so it can't tear
     down the deployment it is creating."""
@@ -304,3 +311,30 @@ def test_real_run_evicts_before_launching():
     kwargs = evict.call_args.kwargs
     assert kwargs["target_hosts"] == ["h1"]
     assert kwargs["cluster_id_for_launch"].startswith("sparkrun_%s_" % kwargs["intent_id"])
+
+
+def test_launch_that_dies_before_starting_containers_evicts_nothing():
+    """An interrupted launch must leave the running deployment alone.
+
+    Eviction used to run at the top of ``api.run``, before image distribution
+    and the model download — steps that take minutes and are routinely
+    Ctrl-C'd.  A launch killed there tore down the serving workload it was
+    replacing and then died without replacing it, leaving the cluster empty.
+    Now the teardown is the last thing before containers start, so anything
+    that fails earlier is harmless.
+    """
+
+    def _die_before_start(**kwargs):
+        # Model a Ctrl-C during "Distributing resources": the launcher raises
+        # without ever reaching its ``before_start`` hook.
+        raise KeyboardInterrupt
+
+    with (
+        patch("sparkrun.core.launcher.launch_inference", side_effect=_die_before_start),
+        patch("sparkrun.api._resolve.resolve_runtime", return_value=_FakeRuntime()),
+        patch("sparkrun.api._run._evict_superseded_deployments", return_value=[]) as evict,
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            api.run(_run_options(dry_run=False, follow=False))
+
+    evict.assert_not_called()

--- a/tests/test_benchmark_api_migration.py
+++ b/tests/test_benchmark_api_migration.py
@@ -146,7 +146,7 @@ def test_benchmark_run_uses_api_run_and_threads_scheduler_flag(fake_recipe_env, 
     """
     captured_options: list[Any] = []
 
-    def _fake_run(options, *, sctx=None):
+    def _fake_run(options, *, sctx=None, plan=None):
         captured_options.append(options)
         return _make_fake_run_result()
 
@@ -204,7 +204,7 @@ def test_benchmark_dry_run_does_not_require_the_execution_toolchain(fake_recipe_
     """
     captured_options: list[Any] = []
 
-    def _fake_run(options, *, sctx=None):
+    def _fake_run(options, *, sctx=None, plan=None):
         captured_options.append(options)
         return _make_fake_run_result()
 
@@ -230,7 +230,7 @@ def test_benchmark_run_scheduler_flag_defaults_to_none(fake_recipe_env):
     """
     captured_options: list[Any] = []
 
-    def _fake_run(options, *, sctx=None):
+    def _fake_run(options, *, sctx=None, plan=None):
         captured_options.append(options)
         return _make_fake_run_result()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ with the main group command.
 
 from __future__ import annotations
 
+import json
 from unittest import mock
 
 import pytest
@@ -1988,13 +1989,41 @@ class TestClusterCommands:
         assert "Scheduler:   greedy" in result.output
 
     def test_cluster_update_clear_scheduler(self, runner, cluster_setup):
-        """Test clearing scheduler selector with empty string."""
-        runner.invoke(main, ["cluster", "update", "test-cluster", "--scheduler", "greedy"])
+        """Clearing the selector unsets it — and ``show`` says what now applies.
+
+        The stored value is gone (``scheduler`` is absent from the JSON), but
+        the cluster still *launches* with something, so ``show`` reports the
+        resolved fallback and flags it as a default rather than printing
+        nothing (which left no way to tell a greedy cluster from an
+        occupancy-aware one).
+        """
+        runner.invoke(main, ["cluster", "update", "test-cluster", "--scheduler", "occupancy-sparse"])
         result = runner.invoke(main, ["cluster", "update", "test-cluster", "--scheduler", ""])
         assert result.exit_code == 0, result.output
 
+        result = runner.invoke(main, ["cluster", "show", "test-cluster", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert not data.get("scheduler")
+        assert data["effective_scheduler"] == "greedy"
+        assert data["scheduler_defaulted"] is True
+
         result = runner.invoke(main, ["cluster", "show", "test-cluster"])
-        assert "Scheduler:" not in result.output
+        assert "Scheduler:   greedy (default — not set on this cluster)" in result.output
+
+    def test_cluster_show_reports_configured_scheduler(self, runner, cluster_setup):
+        """An explicitly-set scheduler shows without the "(default)" caveat."""
+        runner.invoke(main, ["cluster", "update", "test-cluster", "--scheduler", "occupancy-sparse"])
+
+        result = runner.invoke(main, ["cluster", "show", "test-cluster"])
+        assert result.exit_code == 0, result.output
+        assert "Scheduler:   occupancy-sparse" in result.output
+        assert "default —" not in result.output
+
+        result = runner.invoke(main, ["cluster", "show", "test-cluster", "--json"])
+        data = json.loads(result.output)
+        assert data["effective_scheduler"] == "occupancy-sparse"
+        assert data["scheduler_defaulted"] is False
 
 
 class TestClusterMonitor:
@@ -6067,73 +6096,111 @@ class TestCheckJobCommand:
 
 
 class TestRunEnsureFlag:
-    """Test the --ensure flag on the run command."""
+    """``--ensure`` — skip the launch when this workload is already serving.
+
+    Matching is on the launch *intent*, not on a host-derived cluster_id, so
+    these drive the real :func:`sparkrun.api.find_running_intent` over a
+    synthetic occupancy snapshot rather than stubbing the lookup out.
+    """
+
+    @staticmethod
+    def _running_intent_patch(*, hosts=("localhost",), placement_token="deadbeef0000"):
+        """Patch ``api.find_running_intent`` to see a deployment of whatever
+        intent the CLI asks about, placed on *hosts*.
+
+        The wrapper only *builds* the snapshot — matching and grouping run for
+        real, so a regression in either still fails the test.
+        """
+        import sparkrun.api as api
+        from sparkrun.core.cluster_status import ClusterStatus, HostOccupancy, RunningWorkload
+
+        real = api.find_running_intent
+
+        def _spy(intent_id, query_hosts, **kwargs):
+            workload = RunningWorkload(
+                cluster_id="sparkrun_%s_%s" % (intent_id, placement_token),
+                intent_id=intent_id,
+                recipe_name=_TEST_RECIPE_NAME,
+                runtime_name="sglang",
+            )
+            snapshot = ClusterStatus(
+                hosts=tuple(HostOccupancy(host=h, workloads=(workload,), used_slots=1) for h in hosts),
+                executor="docker",
+            )
+            return real(intent_id, query_hosts, status=snapshot)
+
+        return mock.patch.object(api, "find_running_intent", _spy)
 
     def test_run_ensure_already_running(self, runner, reset_bootstrap):
-        """--ensure with running job exits 0 without launching."""
-        from sparkrun.orchestration.job_metadata import JobStatus
-
-        status = JobStatus(
-            running=True,
-            cluster_id="sparkrun_aabbccdd0011",
-            metadata={"recipe": _TEST_RECIPE_NAME},
-            hosts=["localhost"],
-        )
+        """--ensure with a running job exits 0 without launching."""
         with (
-            mock.patch(
-                "sparkrun.orchestration.job_metadata.check_job_running",
-                return_value=status,
-            ),
-            mock.patch(
-                "sparkrun.core.launcher.launch_inference",
-            ) as mock_launch,
+            self._running_intent_patch(),
+            mock.patch("sparkrun.core.launcher.launch_inference") as mock_launch,
         ):
             result = runner.invoke(
                 main,
-                [
-                    "run",
-                    _TEST_RECIPE_NAME,
-                    "--hosts",
-                    "localhost",
-                    "--ensure",
-                    "--solo",
-                ],
+                ["run", _TEST_RECIPE_NAME, "--hosts", "localhost", "--ensure", "--solo"],
             )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "already running" in result.output
         mock_launch.assert_not_called()
 
-    def test_run_ensure_not_running(self, runner, reset_bootstrap):
-        """--ensure with no running job proceeds to launch."""
-        from sparkrun.orchestration.job_metadata import JobStatus
+    def test_run_ensure_matches_job_placed_on_other_hosts(self, runner, reset_bootstrap):
+        """A deployment on hosts this launch wouldn't pick still counts.
 
-        status = JobStatus(
-            running=False,
-            cluster_id="sparkrun_aabbccdd0011",
-            metadata=None,
-            hosts=["localhost"],
-        )
+        The old cluster_id-based lookup hashed the host list, so a job placed
+        anywhere else — which is the normal case under an occupancy-aware
+        scheduler — was invisible and ``--ensure`` launched a duplicate.
+        """
         with (
-            mock.patch(
-                "sparkrun.orchestration.job_metadata.check_job_running",
-                return_value=status,
-            ),
+            self._running_intent_patch(hosts=("10.0.0.9",)),
+            mock.patch("sparkrun.core.launcher.launch_inference") as mock_launch,
+        ):
+            result = runner.invoke(
+                main,
+                ["run", _TEST_RECIPE_NAME, "--hosts", "localhost", "--ensure", "--solo"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "already running" in result.output
+        assert "10.0.0.9" in result.output
+        mock_launch.assert_not_called()
+
+    def test_run_ensure_not_running(self, runner, reset_bootstrap):
+        """--ensure with no running job proceeds to launch.
+
+        The autouse status stub reports an idle cluster, so the real lookup
+        finds nothing — no patching needed.
+        """
+        with mock.patch.object(SglangRuntime, "run", return_value=0):
+            result = runner.invoke(
+                main,
+                ["run", _TEST_RECIPE_NAME, "--hosts", "localhost", "--ensure", "--solo", "--dry-run"],
+            )
+        assert result.exit_code == 0, result.output
+        # Should proceed to launch — shows runtime info
+        assert "Runtime:" in result.output
+        assert "already running" not in result.output
+
+    def test_run_ensure_launches_when_cluster_unreachable(self, runner, reset_bootstrap):
+        """A failed status probe means "not running", so the launch proceeds.
+
+        Declining to launch because we couldn't tell is the worse failure —
+        ``--ensure`` exists to avoid duplicates, not to gate on reachability.
+        """
+
+        def _boom(hosts, **kwargs):
+            raise OSError("ssh: connect to host localhost port 22: Connection refused")
+
+        with (
+            mock.patch("sparkrun.api.status", _boom),
+            mock.patch("sparkrun.api._status.status", _boom),
             mock.patch.object(SglangRuntime, "run", return_value=0),
         ):
             result = runner.invoke(
                 main,
-                [
-                    "run",
-                    _TEST_RECIPE_NAME,
-                    "--hosts",
-                    "localhost",
-                    "--ensure",
-                    "--solo",
-                    "--dry-run",
-                ],
+                ["run", _TEST_RECIPE_NAME, "--hosts", "localhost", "--ensure", "--solo", "--dry-run"],
             )
-        assert result.exit_code == 0
-        # Should proceed to launch — shows runtime info
+        assert result.exit_code == 0, result.output
         assert "Runtime:" in result.output
 
 

--- a/tests/test_cli_run_single_placement.py
+++ b/tests/test_cli_run_single_placement.py
@@ -1,0 +1,247 @@
+"""Regression tests: ``sparkrun run`` decides its placement exactly once.
+
+``sparkrun run`` used to place *twice* — once in the CLI (so the banner, the
+per-host VRAM fit block and diagnostics could name the target hosts) and again
+inside :func:`sparkrun.api.run`.  The CLI pass **narrowed** the candidate host
+list, so the second pass could only choose among the survivors.
+
+That made the two passes' inputs load-bearing, and they diverged: the CLI
+helper never forwarded the resolved scheduler, so the first pass ran the
+``None`` → greedy default while the launch used the cluster's
+``occupancy-sparse``.  On a 4-host cluster with two busy hosts, greedy handed
+``api.run`` the leading two hosts regardless of load; ``occupancy-sparse`` then
+found one occupied, had no other candidates left, and the launch died with::
+
+    Error: cluster has insufficient free capacity for 2 node(s): Cluster cannot
+    satisfy 2 ranks under current occupancy: only placed 1 of 2 ranks across 2 host(s)
+
+…while two idle hosts sat unused (reported against 0.3.3).
+
+The CLI now calls :func:`sparkrun.api.plan` once and hands the result to
+``api.run(plan=…)``, so the failure mode is structural rather than a matter of
+keeping two call sites in sync.  These tests pin both properties: the scenario
+above must launch, and there must remain only one placement pass.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from sparkrun.cli import main
+from sparkrun.core.cluster_status import ClusterStatus, HostOccupancy, RunningWorkload
+from sparkrun.runtimes.sglang import SglangRuntime
+
+_RECIPE_NAME = "test-sched-thread-cluster"
+
+_RECIPE_DATA = {
+    "sparkrun_version": "2",
+    "name": "Scheduler threading regression recipe",
+    "description": "tp=2 cluster recipe used to exercise the CLI host trim",
+    "model": "Qwen/Qwen3-1.7B",
+    "runtime": "sglang",
+    "mode": "cluster",
+    "min_nodes": 1,
+    "max_nodes": 8,
+    "container": "scitrera/dgx-spark-sglang:latest",
+    "defaults": {
+        "port": 30000,
+        "host": "0.0.0.0",
+        "tensor_parallel": 2,
+    },
+    "metadata": {
+        "model_params": 1700000000,
+        "model_dtype": "float16",
+    },
+}
+
+_HOSTS = ["10.0.4.30", "10.0.4.31", "10.0.4.32", "10.0.4.33"]
+#: The two hosts occupied in :func:`_busy_status` — the *leading* two, which is
+#: exactly the pair a greedy trim would pick.
+_BUSY = _HOSTS[:2]
+_FREE = _HOSTS[2:]
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def cluster_env(tmp_path, monkeypatch, v):
+    """A 4-host ``occupancy-sparse`` cluster plus a discoverable tp=2 recipe."""
+    import sparkrun.core.config
+    from sparkrun.core.cluster_manager import ClusterManager
+
+    config_root = tmp_path / "config"
+    config_root.mkdir()
+    monkeypatch.setattr(sparkrun.core.config, "DEFAULT_CONFIG_DIR", config_root)
+
+    mgr = ClusterManager(config_root)
+    mgr.create("wopr", list(_HOSTS), scheduler="occupancy-sparse")
+
+    recipe_dir = tmp_path / "recipes"
+    recipe_dir.mkdir()
+    recipe_file = recipe_dir / ("%s.yaml" % _RECIPE_NAME)
+    recipe_file.write_text(yaml.safe_dump(_RECIPE_DATA))
+
+    import sparkrun.core.recipe
+
+    original_discover = sparkrun.core.recipe.discover_cwd_recipes
+    monkeypatch.setattr(
+        sparkrun.core.recipe,
+        "discover_cwd_recipes",
+        lambda directory=None: [recipe_file] + original_discover(directory),
+    )
+    return config_root
+
+
+def _busy_status(hosts) -> ClusterStatus:
+    """Snapshot where :data:`_BUSY` are fully occupied and the rest are idle."""
+    return ClusterStatus(
+        hosts=tuple(
+            HostOccupancy(
+                host=h,
+                workloads=(RunningWorkload(cluster_id="sparkrun_deadbeef_cafe"),) if h in _BUSY else (),
+                used_slots=1 if h in _BUSY else 0,
+                free_slots=0 if h in _BUSY else 1,
+            )
+            for h in hosts
+        ),
+        executor="docker",
+    )
+
+
+@pytest.fixture
+def busy_cluster_status(monkeypatch):
+    """Point every ``api.status`` call site at :func:`_busy_status`."""
+    _stub = lambda hosts, **kwargs: _busy_status(list(hosts))  # noqa: E731
+    monkeypatch.setattr("sparkrun.api._status.status", _stub)
+    monkeypatch.setattr("sparkrun.api.status", _stub)
+
+
+def test_placement_uses_the_clusters_scheduler(runner, cluster_env, busy_cluster_status, monkeypatch):
+    """Every ``api.schedule`` call names the cluster's scheduler, not greedy.
+
+    This is the original root cause in isolation: a pass that scheduled with
+    ``scheduler=None`` fell back to greedy and ignored occupancy entirely.
+    """
+    import sparkrun.api as api
+
+    seen: list[str | None] = []
+    real_schedule = api.schedule
+
+    def _spy(request, *, scheduler=None, sctx=None):
+        seen.append(scheduler)
+        return real_schedule(request, scheduler=scheduler, sctx=sctx)
+
+    monkeypatch.setattr(api, "schedule", _spy)
+
+    with mock.patch.object(SglangRuntime, "run", return_value=0):
+        result = runner.invoke(main, ["run", _RECIPE_NAME, "--cluster", "wopr", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert seen, "the CLI never scheduled"
+    assert set(seen) == {"occupancy-sparse"}
+
+
+def test_reported_scenario_launches_on_the_idle_hosts(runner, cluster_env, busy_cluster_status):
+    """End-to-end reproduction: a tp=2 launch lands on the two idle hosts.
+
+    Before the fix the greedy pass selected ``_BUSY`` (the leading two hosts),
+    ``api.run`` re-scheduled over only those and raised "insufficient free
+    capacity" — with ``_FREE`` never considered.
+    """
+    with mock.patch.object(SglangRuntime, "run", return_value=0) as mock_run:
+        result = runner.invoke(main, ["run", _RECIPE_NAME, "--cluster", "wopr", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "insufficient free capacity" not in result.output
+
+    # Banner reflects the idle pair...
+    assert "Head:    %s" % _FREE[0] in result.output
+    assert "Workers: %s" % _FREE[1] in result.output
+    # ...and so does the placement actually handed to the runtime.
+    assert list(mock_run.call_args.kwargs["hosts"]) == _FREE
+
+
+def test_cli_places_exactly_once(runner, cluster_env, busy_cluster_status):
+    """A launch runs the placement authority once — not once per renderer.
+
+    The banner cannot disagree with the launch if there is only one decision.
+    This is the structural guarantee behind the fix: the CLI calls
+    ``api.plan`` and hands the result to ``api.run(plan=…)``, so no pass can
+    narrow the candidate set out from under a later one.
+    """
+    from sparkrun.api._hosts import resolve_effective_hosts as _real_resolve
+
+    calls: list[list[str]] = []
+
+    def _spy(host_list, *args, **kwargs):
+        out = _real_resolve(host_list, *args, **kwargs)
+        calls.append(list(out[0]))
+        return out
+
+    with mock.patch("sparkrun.api._hosts.resolve_effective_hosts", _spy):
+        with mock.patch.object(SglangRuntime, "run", return_value=0):
+            result = runner.invoke(main, ["run", _RECIPE_NAME, "--cluster", "wopr", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1, "placement ran %d times, expected exactly 1" % len(calls)
+    assert calls[0] == _FREE
+
+
+def test_cluster_occupancy_is_swept_once(runner, cluster_env, monkeypatch):
+    """One launch → one occupancy sweep.
+
+    Each placement pass queried live status over SSH, so the old two-pass
+    flow paid for the cluster round-trip twice — and a workload starting
+    between the two sweeps could make the second disagree with the first.
+    """
+    sweeps: list[list[str]] = []
+
+    def _stub(hosts, **kwargs):
+        sweeps.append(list(hosts))
+        return _busy_status(list(hosts))
+
+    monkeypatch.setattr("sparkrun.api._status.status", _stub)
+    monkeypatch.setattr("sparkrun.api.status", _stub)
+
+    with mock.patch.object(SglangRuntime, "run", return_value=0):
+        result = runner.invoke(main, ["run", _RECIPE_NAME, "--cluster", "wopr", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert len(sweeps) == 1, "occupancy swept %d times: %r" % (len(sweeps), sweeps)
+    assert sweeps[0] == _HOSTS
+
+
+def test_api_run_sees_full_candidate_set(runner, cluster_env, busy_cluster_status):
+    """``api.run`` is handed every host, not the CLI's chosen subset.
+
+    ``candidate_hosts`` feeds the deterministic placement token and the
+    superseded-deployment sweep, both of which must agree with ``stop`` /
+    ``status`` — which only ever know the cluster's full host list.
+    """
+    import sparkrun.api as api
+
+    seen: dict[str, object] = {}
+    real_plan = api.plan
+
+    def _spy(options, *, sctx=None):
+        plan = real_plan(options, sctx=sctx)
+        seen["options_hosts"] = list(options.hosts or ())
+        seen["candidates"] = list(plan.candidate_hosts)
+        seen["targets"] = list(plan.host_list)
+        return plan
+
+    with mock.patch.object(api, "plan", _spy):
+        with mock.patch.object(SglangRuntime, "run", return_value=0):
+            result = runner.invoke(main, ["run", _RECIPE_NAME, "--cluster", "wopr", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert seen["options_hosts"] == _HOSTS
+    assert seen["candidates"] == _HOSTS
+    assert seen["targets"] == _FREE

--- a/tests/test_image_entrypoint_probe.py
+++ b/tests/test_image_entrypoint_probe.py
@@ -1,0 +1,465 @@
+"""Tests for the image ENTRYPOINT passthrough preflight.
+
+sparkrun appends its launcher as CMD *arguments*, so an image whose ENTRYPOINT
+consumes them runs a different program than intended.  Inspection cannot
+distinguish that from the harmless passthrough wrappers most NGC images ship,
+so the probe settles it empirically — these tests pin both the bash semantics
+(against a fake ``docker``) and the Python plumbing around it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+
+import pytest
+
+from sparkrun.containers.entrypoint import (
+    NO_PROBE_ENV,
+    PROBE_TOKEN,
+    VERDICT_ABSENT,
+    VERDICT_CONSUMES,
+    VERDICT_PASSTHROUGH,
+    VERDICT_UNKNOWN,
+    EntrypointProbe,
+    build_probe_script,
+    parse_probe_output,
+    probe_image_entrypoint,
+)
+from sparkrun.orchestration.executors.docker import DockerExecutor
+from sparkrun.orchestration.ssh import RemoteResult
+
+
+# --------------------------------------------------------------------------
+# Script rendering
+# --------------------------------------------------------------------------
+
+
+def _code_lines(script: str) -> list[str]:
+    """Script lines with comments stripped — the probe's prose mentions the same tokens."""
+    return [line for line in script.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+
+def test_build_probe_script_renders_placeholders():
+    script = build_probe_script("ghcr.io/acme/img:1.0", ["--gpus", "all"])
+    code = _code_lines(script)
+
+    assert script.startswith("#!/bin/bash")
+    assert any("ghcr.io/acme/img:1.0" in line for line in code)
+    assert any("--gpus all" in line for line in code)
+    # Docker's Go template must survive .format() un-doubled.
+    assert "--format '{{json .Config.Entrypoint}}'" in script
+    # Both runs present: the real argv shape, then the cleared-entrypoint control.
+    assert sum(line.count("docker run") for line in code) == 2
+    assert sum(line.count("--entrypoint ''") for line in code) == 1
+
+
+def test_probe_sentinel_is_computed_not_literal():
+    """An entrypoint echoing its argv back must not be able to fake a pass.
+
+    The command embeds ``$((21*2))``; only a shell that actually *ran* it can
+    print the evaluated token.  If the literal token appeared in the command,
+    a consuming entrypoint that echoes the rejected argv would match.
+    """
+    run_lines = [line for line in _code_lines(build_probe_script("img", [])) if "docker run" in line]
+
+    assert run_lines, "expected the probe to start a container"
+    for line in run_lines:
+        assert PROBE_TOKEN not in line, "sentinel must never appear literally in the probed argv"
+        assert "$((21*2))" in line
+
+
+def test_build_probe_script_quotes_image():
+    script = build_probe_script("img; rm -rf /", [])
+    assert "'img; rm -rf /'" in script
+
+
+# --------------------------------------------------------------------------
+# Script semantics, executed against a fake docker
+# --------------------------------------------------------------------------
+
+_FAKE_DOCKER = r"""#!/bin/bash
+# Fake docker standing in for a %(mode)s image.
+last_arg() { for x in "$@"; do :; done; echo "$x"; }
+
+if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then
+    echo '%(entrypoint)s'
+    exit 0
+fi
+
+if [ "$1" = "run" ]; then
+    cleared=0
+    for a in "$@"; do
+        [ "$a" = "--entrypoint" ] && cleared=1
+    done
+    payload=$(last_arg "$@")
+%(run_body)s
+fi
+exit 0
+"""
+
+# A passthrough wrapper (`exec "$@"`) runs sparkrun's command either way.
+_RUN_PASSTHROUGH = '    exec bash -c "$payload"'
+
+# A consuming entrypoint eats the args -- and echoes the value it rejected back
+# on stderr, exactly as vLLM's argparse does.  Clearing the entrypoint fixes it.
+_RUN_CONSUMING = """    if [ "$cleared" = "1" ]; then
+        exec bash -c "$payload"
+    fi
+    echo "error: argument -cc: invalid JSON, input_value='$payload'" >&2
+    exit 2"""
+
+# Docker itself cannot start the container (stale CDI spec, GPU unavailable,
+# ...) -- fails identically with and without the entrypoint, so the entrypoint
+# is *not* provably the cause.
+_RUN_BROKEN = '    echo "docker: error response from daemon" >&2; exit 125'
+
+
+def _write_fake_docker(tmp_path, entrypoint: str, run_body: str, mode: str) -> dict:
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    script = bindir / "docker"
+    script.write_text(_FAKE_DOCKER % {"mode": mode, "entrypoint": entrypoint, "run_body": run_body})
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    env = dict(os.environ)
+    env["PATH"] = "%s%s%s" % (bindir, os.pathsep, env.get("PATH", ""))
+    return env
+
+
+def _run_script(script: str, env: dict) -> str:
+    proc = subprocess.run(["bash", "-s"], input=script, capture_output=True, text=True, env=env)
+    return proc.stdout
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+@pytest.mark.parametrize(
+    "entrypoint,run_body,expected",
+    [
+        ("null", _RUN_PASSTHROUGH, VERDICT_ABSENT),
+        ("[]", _RUN_PASSTHROUGH, VERDICT_ABSENT),
+        ('["/opt/nvidia/nvidia_entrypoint.sh"]', _RUN_PASSTHROUGH, VERDICT_PASSTHROUGH),
+        ('["vllm","serve"]', _RUN_CONSUMING, VERDICT_CONSUMES),
+        ('["vllm","serve"]', _RUN_BROKEN, VERDICT_UNKNOWN),
+    ],
+    ids=["no-entrypoint", "empty-entrypoint", "passthrough", "consuming", "docker-broken"],
+)
+def test_probe_script_semantics(tmp_path, entrypoint, run_body, expected):
+    """The bash itself classifies each idiom correctly."""
+    env = _write_fake_docker(tmp_path, entrypoint, run_body, expected)
+    out = _run_script(build_probe_script("img:tag", []), env)
+    assert parse_probe_output(out)[0] == expected
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+def test_computed_sentinel_defeats_echoed_argv(tmp_path):
+    """A consuming entrypoint that echoes the argv must not read as a pass.
+
+    This is the concrete regression that motivated the computed sentinel:
+    vLLM's argparse reports the value it rejected, so the probed argv comes
+    *back* in the output.  Because the argv carries ``$((21*2))`` unevaluated
+    and only a shell that ran it prints ``42``, the echo cannot match — proven
+    here by merging stderr into the capture and still getting ``fail``.
+    """
+    env = _write_fake_docker(tmp_path, '["vllm","serve"]', _RUN_CONSUMING, "consuming")
+    script = build_probe_script("img:tag", [])
+    merged = script.replace("2>/dev/null || true)", "2>&1 || true)")
+    assert merged != script, "probe no longer discards stderr — update this test"
+
+    for variant in (script, merged):
+        verdict, entrypoint = parse_probe_output(_run_script(variant, env))
+        assert verdict == VERDICT_CONSUMES
+        assert entrypoint == '["vllm","serve"]'
+
+
+def test_probe_captures_stdout_only():
+    """Defense in depth behind the computed sentinel; also keeps the probe quiet.
+
+    The sentinel alone already defeats an echoed argv (see above), but a
+    literal sentinel is an easy regression to introduce, and stderr is where
+    consuming entrypoints put the argv they rejected.
+    """
+    run_lines = [line for line in _code_lines(build_probe_script("img", [])) if "docker run" in line]
+
+    assert run_lines
+    for line in run_lines:
+        assert "2>/dev/null" in line
+
+
+# --------------------------------------------------------------------------
+# Output parsing
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("SPARKRUN_PROBE=pass", VERDICT_PASSTHROUGH),
+        ("SPARKRUN_PROBE=fail", VERDICT_CONSUMES),
+        ("SPARKRUN_PROBE=absent", VERDICT_ABSENT),
+        ("SPARKRUN_PROBE=unknown", VERDICT_UNKNOWN),
+        ("SPARKRUN_PROBE=garbage", VERDICT_UNKNOWN),
+        ("", VERDICT_UNKNOWN),
+    ],
+)
+def test_parse_probe_output_verdicts(raw, expected):
+    assert parse_probe_output(raw)[0] == expected
+
+
+def test_parse_probe_output_normalizes_absent_entrypoint():
+    assert parse_probe_output("SPARKRUN_ENTRYPOINT=null\nSPARKRUN_PROBE=absent")[1] == ""
+    assert parse_probe_output('SPARKRUN_ENTRYPOINT=["vllm","serve"]\nSPARKRUN_PROBE=fail')[1] == '["vllm","serve"]'
+
+
+# --------------------------------------------------------------------------
+# probe_image_entrypoint plumbing (fail-open contract)
+# --------------------------------------------------------------------------
+
+
+def _patch_remote(monkeypatch, result):
+    calls = {}
+
+    def fake_run_remote_script(host, script, **kwargs):
+        calls["host"] = host
+        calls["script"] = script
+        calls["kwargs"] = kwargs
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr("sparkrun.orchestration.ssh.run_remote_script", fake_run_remote_script)
+    return calls
+
+
+def test_probe_reports_consuming_entrypoint(monkeypatch):
+    _patch_remote(
+        monkeypatch, RemoteResult(host="h1", returncode=0, stdout='SPARKRUN_ENTRYPOINT=["vllm","serve"]\nSPARKRUN_PROBE=fail', stderr="")
+    )
+    probe = probe_image_entrypoint("img", "h1")
+    assert probe.consumes_command
+    assert probe.host == "h1"
+
+
+@pytest.mark.parametrize("stdout", ["SPARKRUN_PROBE=pass", "SPARKRUN_PROBE=absent", "SPARKRUN_PROBE=unknown"])
+def test_probe_non_consuming_verdicts_do_not_flag(monkeypatch, stdout):
+    _patch_remote(monkeypatch, RemoteResult(host="h1", returncode=0, stdout=stdout, stderr=""))
+    assert not probe_image_entrypoint("img", "h1").consumes_command
+
+
+def test_probe_failed_ssh_is_unknown_not_consuming(monkeypatch):
+    """Could-not-verify must never block a launch."""
+    _patch_remote(monkeypatch, RemoteResult(host="h1", returncode=255, stdout="", stderr="ssh: connect refused"))
+    probe = probe_image_entrypoint("img", "h1")
+    assert probe.verdict == VERDICT_UNKNOWN
+    assert not probe.consumes_command
+
+
+def test_probe_exception_is_unknown_not_consuming(monkeypatch):
+    _patch_remote(monkeypatch, RuntimeError("boom"))
+    assert probe_image_entrypoint("img", "h1").verdict == VERDICT_UNKNOWN
+
+
+def test_probe_kill_switch(monkeypatch):
+    calls = _patch_remote(monkeypatch, RemoteResult(host="h1", returncode=0, stdout="SPARKRUN_PROBE=fail", stderr=""))
+    monkeypatch.setenv(NO_PROBE_ENV, "1")
+    assert probe_image_entrypoint("img", "h1").verdict == VERDICT_UNKNOWN
+    assert not calls, "kill switch must short-circuit before any SSH"
+
+
+# --------------------------------------------------------------------------
+# Executor dispatch
+# --------------------------------------------------------------------------
+
+
+def test_docker_executor_probes_first_host_with_accel_opts(monkeypatch):
+    seen = {}
+
+    def fake_probe(image, host, *, ssh_kwargs=None, accel_opts=None):
+        seen.update(image=image, host=host, accel_opts=accel_opts, ssh_kwargs=ssh_kwargs)
+        return EntrypointProbe(image=image, host=host, verdict=VERDICT_PASSTHROUGH)
+
+    monkeypatch.setattr("sparkrun.containers.entrypoint.probe_image_entrypoint", fake_probe)
+
+    executor = DockerExecutor()
+    executor.config.gpu_access_mode = "gpus"
+    probe = executor.verify_command_passthrough("img", ["h1", "h2", "h3"], ssh_kwargs={"ssh_user": "u"})
+
+    assert probe is not None
+    assert seen["host"] == "h1", "one probe only — the verdict is a property of the image"
+    assert seen["accel_opts"] == ["--gpus", "all"]
+    assert seen["ssh_kwargs"] == {"ssh_user": "u"}
+
+
+@pytest.mark.parametrize("image,hosts", [("", ["h1"]), ("img", [])])
+def test_docker_executor_no_image_or_hosts_returns_none(image, hosts):
+    assert DockerExecutor().verify_command_passthrough(image, hosts) is None
+
+
+@pytest.mark.parametrize("override", ["", "/opt/custom.sh"], ids=["cleared", "custom"])
+def test_probe_skipped_when_launch_overrides_entrypoint(monkeypatch, override):
+    """The recommended fix must not be rejected by the check that recommends it.
+
+    ``entrypoint: ""`` / ``-o entrypoint=''`` makes the launch emit
+    ``--entrypoint``, so the image's own ENTRYPOINT never runs — but the image
+    still *declares* a consuming one, so a probe here would keep failing and the
+    documented fix would be unusable.
+    """
+
+    def boom(*args, **kwargs):
+        raise AssertionError("must not probe when the launch overrides the entrypoint")
+
+    monkeypatch.setattr("sparkrun.containers.entrypoint.probe_image_entrypoint", boom)
+
+    executor = DockerExecutor()
+    executor.config.entrypoint = override
+    assert executor.verify_command_passthrough("img", ["h1"]) is None
+
+
+def test_base_executor_default_is_noop():
+    """Container-less / provider executors have no opinion and never block."""
+    from sparkrun.orchestration.executors._base import Executor
+
+    assert Executor.verify_command_passthrough(DockerExecutor.__new__(DockerExecutor), "img", ["h1"]) is None
+
+
+# --------------------------------------------------------------------------
+# Launcher preflight
+# --------------------------------------------------------------------------
+
+
+def _call_preflight(monkeypatch, probe):
+    from sparkrun.core import launcher
+
+    class _FakeExecutor:
+        def verify_command_passthrough(self, image, hosts, *, ssh_kwargs=None):
+            return probe
+
+    monkeypatch.setattr("sparkrun.orchestration.executor.resolve_executor", lambda **kw: _FakeExecutor())
+    launcher._verify_image_command_passthrough(
+        None,
+        "img:tag",
+        ["h1"],
+        {},
+        runtime=None,
+        cluster=None,
+        config=None,
+        executor_config=None,
+        rootless=True,
+        auto_user=True,
+        host_hardware=None,
+        v=None,
+    )
+
+
+def test_preflight_raises_with_both_documented_fixes(monkeypatch):
+    from sparkrun.core.recipe import RecipeError
+
+    probe = EntrypointProbe(image="img:tag", host="h1", verdict=VERDICT_CONSUMES, entrypoint='["vllm","serve"]')
+    with pytest.raises(RecipeError) as exc:
+        _call_preflight(monkeypatch, probe)
+
+    msg = str(exc.value)
+    assert "img:tag" in msg
+    assert '["vllm","serve"]' in msg
+    assert 'entrypoint: ""' in msg, "recipe fix must be shown"
+    assert "-o entrypoint=''" in msg, "CLI one-off fix must be shown"
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [
+        None,
+        EntrypointProbe(image="img:tag", host="h1", verdict=VERDICT_PASSTHROUGH),
+        EntrypointProbe(image="img:tag", host="h1", verdict=VERDICT_ABSENT),
+        EntrypointProbe(image="img:tag", host="h1", verdict=VERDICT_UNKNOWN),
+    ],
+    ids=["no-opinion", "passthrough", "absent", "unknown"],
+)
+def test_preflight_allows_everything_but_confirmed_consuming(monkeypatch, probe):
+    _call_preflight(monkeypatch, probe)  # must not raise
+
+
+def test_preflight_skips_when_executor_unresolvable(monkeypatch):
+    from sparkrun.core import launcher
+
+    def boom(**kwargs):
+        raise RuntimeError("gated off")
+
+    monkeypatch.setattr("sparkrun.orchestration.executor.resolve_executor", boom)
+    launcher._verify_image_command_passthrough(
+        None,
+        "img:tag",
+        ["h1"],
+        {},
+        runtime=None,
+        cluster=None,
+        config=None,
+        executor_config=None,
+        rootless=True,
+        auto_user=True,
+        host_hardware=None,
+        v=None,
+    )
+
+
+def test_preflight_skips_without_image_or_hosts(monkeypatch):
+    from sparkrun.core import launcher
+
+    def boom(**kwargs):
+        raise AssertionError("must not resolve an executor with nothing to probe")
+
+    monkeypatch.setattr("sparkrun.orchestration.executor.resolve_executor", boom)
+    for image, hosts in (("", ["h1"]), ("img", [])):
+        launcher._verify_image_command_passthrough(
+            None,
+            image,
+            hosts,
+            {},
+            runtime=None,
+            cluster=None,
+            config=None,
+            executor_config=None,
+            rootless=True,
+            auto_user=True,
+            host_hardware=None,
+            v=None,
+        )
+
+
+# --------------------------------------------------------------------------
+# CLI override key
+# --------------------------------------------------------------------------
+
+
+def test_entrypoint_is_an_executor_override_key():
+    """``-o entrypoint=''`` must configure the executor, not the serve command."""
+    from sparkrun.cli._run import _EXECUTOR_OVERRIDE_KEYS
+
+    assert "entrypoint" in _EXECUTOR_OVERRIDE_KEYS
+
+
+def test_empty_entrypoint_survives_option_coercion():
+    """Empty string is the meaningful value and must not coerce to None/False."""
+    from sparkrun.cli._common import _parse_options
+
+    assert _parse_options(("entrypoint=",)) == {"entrypoint": ""}
+
+
+def test_empty_entrypoint_reaches_docker_run():
+    """The full chain: executor_config entrypoint "" → ``docker run --entrypoint ''``."""
+    from sparkrun.orchestration.executors._base import ExecutorConfig
+
+    cfg = ExecutorConfig.from_chain({"entrypoint": ""})
+    assert cfg.entrypoint == ""
+
+    cmd = DockerExecutor(config=cfg).run_cmd(image="img:tag", container_name="c", command="echo hi")
+    assert "--entrypoint ''" in cmd
+
+
+def test_unset_entrypoint_emits_no_flag():
+    from sparkrun.orchestration.executors._base import ExecutorConfig
+
+    cfg = ExecutorConfig.from_chain({})
+    assert cfg.entrypoint is None
+    assert "--entrypoint" not in DockerExecutor(config=cfg).run_cmd(image="img:tag", container_name="c", command="echo hi")

--- a/tests/test_intent_identity.py
+++ b/tests/test_intent_identity.py
@@ -1,0 +1,104 @@
+"""What counts as "the same workload" — ``generate_intent_id``.
+
+The intent_id is not only a discovery key.  ``api.run`` treats a *matching*
+intent as this launch's own workload: placement subtracts it from the
+occupancy snapshot (``exclude_intent_id``) and the launch then evicts it.  So
+whatever the intent conflates, ``sparkrun run`` is willing to destroy.
+
+Reported on a live 4-host cluster: two registry recipes serving
+``DeepSeek-V4-Flash-0731`` at tp=2 — one on a stable image, one on the nightly
+``…-b12x`` build — hashed to the *same* intent, because the container image
+was not part of it.  Launching the second placed onto the two hosts the first
+was serving from (their occupancy had been subtracted as "mine") and tore it
+down.  These tests pin the distinctions that must survive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sparkrun.core.recipe import Recipe
+from sparkrun.orchestration.job_metadata import generate_intent_id
+
+_BASE = {
+    "sparkrun_version": "2",
+    "runtime": "vllm-distributed",
+    "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "container": "ghcr.io/spark-arena/dgx-vllm:stable",
+    "defaults": {"port": 8000, "tensor_parallel": 2},
+}
+
+
+def _recipe(**changes):
+    data = {**_BASE, **{k: v for k, v in changes.items() if k != "defaults"}}
+    if "defaults" in changes:
+        data["defaults"] = {**_BASE["defaults"], **changes["defaults"]}
+    return Recipe(data)
+
+
+def test_container_image_distinguishes_intents():
+    """The reported bug: same model/runtime/port/tp, different image."""
+    stable = generate_intent_id(_recipe())
+    nightly = generate_intent_id(_recipe(container="ghcr.io/spark-arena/dgx-vllm-nightly-b12x:latest"))
+
+    assert stable != nightly, "two images = two workloads; conflating them makes `run` evict the other"
+
+
+def test_image_override_distinguishes_intents():
+    """``--image`` writes through to ``recipe.container``, so it counts too."""
+    base = _recipe()
+    overridden = _recipe()
+    overridden.container = "some/other:image"
+
+    assert generate_intent_id(base) != generate_intent_id(overridden)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"model": "meta-llama/Llama-3.1-8B"},
+        {"runtime": "sglang"},
+        {"defaults": {"port": 8001}},
+        {"defaults": {"tensor_parallel": 4}},
+        {"defaults": {"served_model_name": "custom"}},
+    ],
+    ids=["model", "runtime", "port", "tp", "served_model_name"],
+)
+def test_identity_dimensions_are_distinct(changes):
+    assert generate_intent_id(_recipe()) != generate_intent_id(_recipe(**changes))
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"defaults": {"gpu_memory_utilization": 0.75}},
+        {"defaults": {"max_model_len": 4096}},
+        {"command": "vllm serve --some-new-flag"},
+        {"env": {"VLLM_USE_V1": "1"}},
+        {"description": "a different description"},
+    ],
+    ids=["gpu_mem", "max_model_len", "command", "env", "description"],
+)
+def test_serve_configuration_does_not_change_identity(changes):
+    """The intent stays narrow on purpose.
+
+    ``stop`` / ``logs`` / ``status`` / ``--ensure`` recompute the intent from
+    the recipe *without* the flags the user typed at launch, so if a tweaked
+    serve argument produced a new intent they would stop finding the running
+    workload — and a relaunch would no longer evict the deployment it
+    replaces, leaving it holding the GPUs.  Callers that must tell these apart
+    hash ``derive_recipe_fingerprint`` alongside the intent.
+    """
+    assert generate_intent_id(_recipe()) == generate_intent_id(_recipe(**changes))
+
+
+def test_recipe_without_a_container_still_hashes():
+    """A recipe relying on the runtime's default image must not blow up."""
+    data = {k: v for k, v in _BASE.items() if k != "container"}
+    assert generate_intent_id(Recipe(data))
+
+
+def test_intent_is_independent_of_placement():
+    """Hosts are never hashed — that's what the placement token is for."""
+    r = _recipe()
+    assert generate_intent_id(r) == generate_intent_id(r)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -793,3 +793,136 @@ def test_launch_inference_save_job_metadata_failure_is_best_effort(monkeypatch, 
 
     assert result.rc == 0
     assert save_calls, "save_job_metadata should have been attempted"
+
+
+# ---------------------------------------------------------------------------
+# wait_for_serve_ready
+# ---------------------------------------------------------------------------
+
+
+def _patch_serve_ready(monkeypatch, *, port_ready=True, healthy=True):
+    """Patch the probes wait_for_serve_ready imports lazily, recording calls."""
+    calls: list[str] = []
+
+    def _port(*_a, **_k):
+        calls.append("port")
+        return port_ready
+
+    def _health(*_a, **_k):
+        calls.append("health")
+        return healthy
+
+    monkeypatch.setattr("sparkrun.utils.is_local_host", lambda host: True)
+    monkeypatch.setattr("sparkrun.orchestration.docker.generate_container_name", lambda cid, suffix: "%s_%s" % (cid, suffix))
+    monkeypatch.setattr("sparkrun.orchestration.docker.generate_node_container_name", lambda cid, rank: "%s_node_%d" % (cid, rank))
+    monkeypatch.setattr("sparkrun.orchestration.health.wait_for_port", _port)
+    monkeypatch.setattr("sparkrun.orchestration.health.wait_for_healthy", _health)
+    return calls
+
+
+def test_wait_for_serve_ready_ready(monkeypatch):
+    """Both probes passing -> ready, no reason, and a usable health URL."""
+    from sparkrun.core.launcher import wait_for_serve_ready
+
+    calls = _patch_serve_ready(monkeypatch)
+    result = _make_launch_result(_LifecycleRecipe(), _LifecycleRuntime())
+
+    readiness = wait_for_serve_ready(result)
+
+    assert readiness.ready is True
+    assert readiness.reason == ""
+    assert readiness.head_ip == "127.0.0.1"
+    assert readiness.health_url == "http://127.0.0.1:8000/v1/models"
+    assert readiness.container == "sparkrun_lifecyclecid_solo"
+    assert calls == ["port", "health"]
+
+
+def test_wait_for_serve_ready_port_failure_skips_health(monkeypatch):
+    """A dead port must short-circuit.
+
+    wait_for_healthy treats consecutive connection refusals as "the server
+    died", which is exactly what a still-initializing server looks like —
+    so it is only sound once the port is confirmed listening.
+    """
+    from sparkrun.core.launcher import wait_for_serve_ready
+
+    calls = _patch_serve_ready(monkeypatch, port_ready=False)
+    result = _make_launch_result(_LifecycleRecipe(), _LifecycleRuntime())
+
+    readiness = wait_for_serve_ready(result)
+
+    assert readiness.ready is False
+    assert readiness.reason == "port"
+    assert calls == ["port"], "wait_for_healthy must not run before the port is up"
+
+
+def test_wait_for_serve_ready_health_failure(monkeypatch):
+    """Port up but never HTTP 200 -> reason='health'."""
+    from sparkrun.core.launcher import wait_for_serve_ready
+
+    calls = _patch_serve_ready(monkeypatch, healthy=False)
+    result = _make_launch_result(_LifecycleRecipe(), _LifecycleRuntime())
+
+    readiness = wait_for_serve_ready(result)
+
+    assert readiness.ready is False
+    assert readiness.reason == "health"
+    assert calls == ["port", "health"]
+
+
+def test_wait_for_serve_ready_dry_run_probes_nothing(monkeypatch):
+    """--dry-run reports ready without touching the network."""
+    from sparkrun.core.launcher import wait_for_serve_ready
+
+    calls = _patch_serve_ready(monkeypatch, port_ready=False, healthy=False)
+    result = _make_launch_result(_LifecycleRecipe(), _LifecycleRuntime())
+
+    readiness = wait_for_serve_ready(result, dry_run=True)
+
+    assert readiness.ready is True
+    assert calls == []
+
+
+def test_wait_for_serve_ready_uses_serve_port_not_recipe_port(monkeypatch):
+    """The probed port is the *resolved* one.
+
+    ``auto_port=True`` (how ``proxy load`` launches) can move the server off
+    the recipe's declared port; probing the recipe value would poll a port
+    nothing is listening on.
+    """
+    import dataclasses
+
+    from sparkrun.core.launcher import wait_for_serve_ready
+
+    probed: list[int] = []
+
+    _patch_serve_ready(monkeypatch)
+    monkeypatch.setattr(
+        "sparkrun.orchestration.health.wait_for_port",
+        lambda host, port, **_k: (probed.append(port), True)[1],
+    )
+
+    # Recipe declares 8000; auto_port moved the server to 8001.
+    result = _make_launch_result(_LifecycleRecipe(port=8000), _LifecycleRuntime())
+    result = dataclasses.replace(result, serve_port=8001)
+
+    readiness = wait_for_serve_ready(result)
+
+    assert probed == [8001]
+    assert readiness.port == 8001
+
+
+def test_wait_for_serve_ready_multinode_uses_head_container(monkeypatch):
+    """A non-solo launch watches the rank-0 container, not the solo name."""
+    import dataclasses
+
+    from sparkrun.core.launcher import wait_for_serve_ready
+
+    _patch_serve_ready(monkeypatch)
+    result = _make_launch_result(_LifecycleRecipe(), _LifecycleRuntime())
+    result = dataclasses.replace(result, is_solo=False, host_list=["h1", "h2"])
+
+    readiness = wait_for_serve_ready(result)
+
+    assert readiness.container == "sparkrun_lifecyclecid_node_0"
+    assert readiness.head_host == "h1"

--- a/tests/test_name_alias.py
+++ b/tests/test_name_alias.py
@@ -45,7 +45,9 @@ def test_run_with_name_override(monkeypatch):
     mock_runtime.resolve_container.return_value = "img:latest"
     mock_runtime.validate_recipe.return_value = []
     monkeypatch.setattr("sparkrun.core.bootstrap.get_runtime", lambda *args, **kwargs: mock_runtime)
-    monkeypatch.setattr("sparkrun.cli._run.resolve_effective_hosts_for_recipe", lambda *args, **kwargs: (["localhost"], True))
+    # Placement is no longer stubbed: the CLI computes one ``api.plan`` and
+    # hands it to ``api.run``.  A ``mode="solo"`` single-host recipe
+    # short-circuits the scheduler, so the real plan runs without SSH.
     monkeypatch.setattr("sparkrun.cli._run._display_vram_estimate", lambda *args, **kwargs: None)
 
     result = runner.invoke(main, ["run", "test-recipe", "--container-name", "custom-cluster-id", "--solo"])

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -6,6 +6,7 @@ from enum import Enum
 import json
 from pathlib import Path
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import yaml
@@ -286,7 +287,32 @@ def test_run_event_drops_mock_dimensions():
     assert event["scheduler"] is None
 
 
-def test_test_suite_telemetry_blocker_records_despite_emit_swallowing(monkeypatch):
+def test_telemetry_fails_closed_on_anything_but_a_real_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("SPARKRUN_NO_TELEMETRY", raising=False)
+
+    assert telemetry_enabled(SparkrunConfig(tmp_path / "config.yaml")) is True
+    assert telemetry_enabled(MagicMock()) is False
+    assert telemetry_enabled(SimpleNamespace(get=lambda key, default=None: None)) is False
+    assert telemetry_enabled(None) is False
+
+    # Forcing telemetry on must not resurrect a config we do not recognize.
+    monkeypatch.setenv("SPARKRUN_NO_TELEMETRY", "0")
+    assert telemetry_enabled(MagicMock()) is False
+
+
+def test_emit_sends_nothing_when_handed_a_mock_config(tmp_path, monkeypatch):
+    """The vector behind every event that reached the live collector."""
+    from sparkrun.telemetry import emit_benchmark_telemetry
+
+    attempts = install_telemetry_blocker(monkeypatch)
+    monkeypatch.delenv("SPARKRUN_NO_TELEMETRY", raising=False)
+
+    emit_benchmark_telemetry(MagicMock(), result=MagicMock(), options=MagicMock())
+
+    assert attempts == []
+
+
+def test_test_suite_telemetry_blocker_records_despite_emit_swallowing(tmp_path, monkeypatch):
     """The suite-wide guard must survive ``emit_*``'s blanket ``except Exception``.
 
     Raising from the patched ``urlopen`` alone would be logged at DEBUG and
@@ -297,11 +323,10 @@ def test_test_suite_telemetry_blocker_records_despite_emit_swallowing(monkeypatc
     from sparkrun.telemetry import emit_benchmark_telemetry
 
     attempts = install_telemetry_blocker(monkeypatch)
-    # A MagicMock config makes ``telemetry_enabled`` fail open -- the exact
-    # condition under which the real leaks were sent.
     monkeypatch.delenv("SPARKRUN_NO_TELEMETRY", raising=False)
 
-    emit_benchmark_telemetry(MagicMock(), result=MagicMock(), options=MagicMock())
+    # A real config on the enabled path -- a mock one no longer sends at all.
+    emit_benchmark_telemetry(SparkrunConfig(tmp_path / "config.yaml"), result=MagicMock(), options=MagicMock())
 
     assert len(attempts) == 1, "the blocker must record the send emit_* swallowed"
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from enum import Enum
 import json
+from pathlib import Path
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import yaml
 from click.testing import CliRunner
@@ -23,6 +25,7 @@ from sparkrun.telemetry.config import (
     telemetry_enabled,
 )
 from sparkrun.telemetry.events import build_run_event, build_setup_wizard_event
+from sparkrun.telemetry.util import int_value, string_value
 
 
 class _FakeResponse:
@@ -209,6 +212,77 @@ def test_benchmark_event_is_anonymous_and_low_cardinality():
     payload = json.dumps(event, sort_keys=True)
     for private_value in ("host-a", "host-b", "bench_secret", "sparkrun_secret", "sub-secret", "/home/drew/private"):
         assert private_value not in payload
+
+
+class _Flavor(Enum):
+    PLAIN = "plain"
+
+
+class _Opaque:
+    def __str__(self):
+        return "leaked-repr"
+
+
+def test_string_value_renders_scalars_only():
+    assert string_value("  vllm  ") == "vllm"
+    assert string_value(4) == "4"
+    assert string_value(0.5) == "0.5"
+    assert string_value(True) == "True"
+    assert string_value(Path("/tmp/x")) == "/tmp/x"
+    assert string_value(_Flavor.PLAIN) == "plain"
+
+    assert string_value(None) is None
+    assert string_value("   ") is None
+    # Anything else is dropped rather than rendered through ``str()`` --
+    # including objects that define a perfectly innocent ``__str__``.
+    assert string_value(_Opaque()) is None
+    assert string_value(["a"]) is None
+    assert string_value({"a": 1}) is None
+    assert string_value(len) is None
+
+
+def test_string_value_never_renders_a_test_double():
+    """The regression: mock reprs reached the collector as event dimensions."""
+    mock = MagicMock()
+    assert string_value(mock) is None
+    assert string_value(mock.category) is None
+    # A Mock satisfies os.PathLike (it synthesizes __fspath__), so the path case
+    # must be typed on PurePath rather than the protocol.
+    assert string_value(mock.__fspath__) is None
+
+
+def test_int_value_does_not_coerce_arbitrary_objects():
+    assert int_value("4") == 4
+    assert int_value(4.9) == 4
+    assert int_value(True) == 1
+    assert int_value(None, default=7) == 7
+    assert int_value("nope", default=7) == 7
+    # ``int(MagicMock())`` is 1 -- a confident, entirely fabricated number.
+    assert int_value(MagicMock(), default=None) is None
+
+
+def test_benchmark_event_drops_mock_dimensions():
+    """Reproduces the shape of the events that reached the live collector."""
+    mock = MagicMock()
+
+    event = build_benchmark_event(result=mock, options=mock, recipe=mock)
+
+    assert "MagicMock" not in json.dumps(event, sort_keys=True, default=str)
+    assert event["category"] is None
+    assert event["framework"] is None
+    assert event["profile"] is None
+    assert event.get("model") is None
+
+
+def test_run_event_drops_mock_dimensions():
+    mock = MagicMock()
+
+    event = build_run_event(result=mock, recipe=mock, cluster=mock, options=mock)
+
+    assert "MagicMock" not in json.dumps(event, sort_keys=True, default=str)
+    assert event["runtime"] is None
+    assert event["executor"] is None
+    assert event["scheduler"] is None
 
 
 def test_setup_telemetry_command_persists_preference(tmp_path, monkeypatch):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import yaml
 from click.testing import CliRunner
 
+from _telemetry_guard import install_telemetry_blocker
 import sparkrun.api as api
 from sparkrun.cli import main
 from sparkrun.core.cluster_manager import ClusterDefinition
@@ -283,6 +284,26 @@ def test_run_event_drops_mock_dimensions():
     assert event["runtime"] is None
     assert event["executor"] is None
     assert event["scheduler"] is None
+
+
+def test_test_suite_telemetry_blocker_records_despite_emit_swallowing(monkeypatch):
+    """The suite-wide guard must survive ``emit_*``'s blanket ``except Exception``.
+
+    Raising from the patched ``urlopen`` alone would be logged at DEBUG and
+    forgotten; the recorded attempt is what fails the test in
+    ``isolate_stateful``'s teardown.  Installing a fresh blocker here shadows
+    that one, so this test does not trip its own guard.
+    """
+    from sparkrun.telemetry import emit_benchmark_telemetry
+
+    attempts = install_telemetry_blocker(monkeypatch)
+    # A MagicMock config makes ``telemetry_enabled`` fail open -- the exact
+    # condition under which the real leaks were sent.
+    monkeypatch.delenv("SPARKRUN_NO_TELEMETRY", raising=False)
+
+    emit_benchmark_telemetry(MagicMock(), result=MagicMock(), options=MagicMock())
+
+    assert len(attempts) == 1, "the blocker must record the send emit_* swallowed"
 
 
 def test_setup_telemetry_command_persists_preference(tmp_path, monkeypatch):

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,7 +2,7 @@
 # Run: python scripts/update-versions.py             to sync all files
 # Run: python scripts/update-versions.py --check     to verify (CI-friendly)
 
-sparkrun: 0.3.3
+sparkrun: 0.3.4
 sparkrun-cc-plugin: 0.0.4
 sparkrun-openclaw-plugin: 0.0.1
 


### PR DESCRIPTION
This pull request introduces several important changes to the `sparkrun` project, primarily focusing on improving launch planning, clarifying workload identity, and adding robust Docker ENTRYPOINT preflight checks. The API is updated to expose new planning functionality, and documentation is expanded to guide users through these new behaviors. Below are the most significant changes:

**Launch Planning and API Improvements**
- Split the launch process into explicit planning (`api.plan`) and execution (`api.run`), ensuring that placement decisions and host selection are consistent and visible to callers that need to display or reason about host selection before launching. The new `RunPlan` data model and `plan` function are now exported in the API, and the benchmark flow is updated to use this split for accurate host display and launch consistency. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R293-R413) [[2]](diffhunk://#diff-46d5cf143a5f293db110d4eeb9342bb52bd92beea7ddaaa19d1a2254d74b86beL6-R6) [[3]](diffhunk://#diff-46d5cf143a5f293db110d4eeb9342bb52bd92beea7ddaaa19d1a2254d74b86beL18-R18) [[4]](diffhunk://#diff-46d5cf143a5f293db110d4eeb9342bb52bd92beea7ddaaa19d1a2254d74b86beR72-R78) [[5]](diffhunk://#diff-46d5cf143a5f293db110d4eeb9342bb52bd92beea7ddaaa19d1a2254d74b86beR96-R103) [[6]](diffhunk://#diff-46d5cf143a5f293db110d4eeb9342bb52bd92beea7ddaaa19d1a2254d74b86beR127) [[7]](diffhunk://#diff-085f74182a8b4737fe28036a726585d82bb1814b0615872cd14c58d391111b2eR434-R479)

- The API now exports `IntentMatch` and `find_running_intent`, supporting the improved `--ensure` logic for detecting already-running workloads by intent rather than cluster ID, which is more robust across different schedulers and placement strategies. [[1]](diffhunk://#diff-46d5cf143a5f293db110d4eeb9342bb52bd92beea7ddaaa19d1a2254d74b86beR63) [[2]](diffhunk://#diff-46d5cf143a5f293db110d4eeb9342bb52bd92beea7ddaaa19d1a2254d74b86beR140)

**Workload Identity and Scheduling**
- Clarified and documented the distinction between workload "intent" and "fingerprint," ensuring that destructive operations (like eviction and replacement) are keyed on intent, not on full configuration fingerprint, preventing accidental evictions or missed matches.

**ENTRYPOINT Preflight and Image Handling**
- Added a robust ENTRYPOINT preflight check: during image distribution, sparkrun now empirically verifies whether the image's ENTRYPOINT allows the appended command to run, distinguishing between passthrough and consuming entrypoints. This prevents launches from failing due to misinterpreted ENTRYPOINTs and guides users to correct image overrides without auto-clearing potentially important setup scripts. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R467-R501) [[2]](diffhunk://#diff-5d212d961af70f70f74b55e25d054bf27dde13aa3f128866d046e7c7ecb8da1dR140-R184) [[3]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611R405-R424)

- Documentation for ENTRYPOINT handling is significantly expanded, including usage guidance for `entrypoint: ""` in recipes and one-off launches, a detailed table of ENTRYPOINT behaviors, and troubleshooting instructions. [[1]](diffhunk://#diff-5d212d961af70f70f74b55e25d054bf27dde13aa3f128866d046e7c7ecb8da1dR140-R184) [[2]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611R405-R424)

**Other Notable Updates**
- Bumped the project version to `0.3.4` to reflect these new features and improvements.
- Minor internal refactoring and import updates to support the new API surface and planning logic. [[1]](diffhunk://#diff-085f74182a8b4737fe28036a726585d82bb1814b0615872cd14c58d391111b2eR10) [[2]](diffhunk://#diff-085f74182a8b4737fe28036a726585d82bb1814b0615872cd14c58d391111b2eL217-R218)