### PR TITLE
fix(health): check LISTEN state in wait_for_port instead of nc -z

### DIFF
--- a/src/sparkrun/orchestration/health.py
+++ b/src/sparkrun/orchestration/health.py
@@ -69,7 +69,18 @@ def wait_for_port(
 
     from sparkrun.orchestration.primitives import run_command_on_host
 
-    check_cmd = "nc -z localhost %d" % port
+    # Check LISTEN state instead of `nc -z`: `nc -z` opens a real TCP
+    # connection, which consumes one-shot rendezvous accepts. Atlas's NCCL
+    # bootstrap (rank 0) accepts exactly world_size-1 connections, hands out
+    # its unique NCCL ID, then closes the listener — a probe connection steals
+    # that single accept, the real worker gets "Connection refused" forever,
+    # and the head spins in ncclCommInitRank. Checking the kernel socket table
+    # is side-effect free and matches "port is listening" for every runtime.
+    check_cmd = (
+        f"ss -tln 2>/dev/null | grep -qE ':{port}(\\s|$)' "
+        f"|| ss -tln6 2>/dev/null | grep -qE ':{port}(\\s|$)' "
+        f"|| grep -qE ':{port:04X} ' /proc/net/tcp"
+    )
     for attempt in range(1, max_retries + 1):
         # Check container liveness before polling the port
         if container_name and attempt > 1:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,58 @@
+"""Unit tests for sparkrun.orchestration.health module."""
+
+from unittest.mock import MagicMock, patch
+
+from sparkrun.orchestration.health import wait_for_port
+from sparkrun.orchestration.ssh import RemoteResult
+
+
+def _result(success: bool) -> RemoteResult:
+    return RemoteResult(host="testhost", returncode=0 if success else 1, stdout="", stderr="")
+
+
+def test_wait_for_port_uses_listen_state_check_not_nc():
+    """Port probe must not open a TCP connection.
+
+    `nc -z localhost <port>` opens a real connection, which consumes
+    one-shot rendezvous accepts (Atlas NCCL bootstrap hands its unique
+    NCCL ID to the probe instead of the real worker). The readiness
+    probe must check LISTEN state via `ss` and be side-effect free.
+    """
+    mock_run = MagicMock(return_value=_result(True))
+    with patch("sparkrun.orchestration.primitives.run_command_on_host", mock_run):
+        assert wait_for_port("testhost", 25000, max_retries=1, retry_interval=0) is True
+
+    cmd = mock_run.call_args.args[1]
+    assert "nc -z" not in cmd
+    assert "ss -tln" in cmd
+    assert "25000" in cmd
+
+
+def test_wait_for_port_returns_true_when_listening():
+    """A successful ss check reports the port ready."""
+    mock_run = MagicMock(return_value=_result(True))
+    with patch("sparkrun.orchestration.primitives.run_command_on_host", mock_run):
+        assert wait_for_port("testhost", 8000, max_retries=3, retry_interval=0) is True
+    assert mock_run.call_count == 1
+
+
+def test_wait_for_port_returns_false_after_retries():
+    """A port that never listens reports not ready after max_retries."""
+    mock_run = MagicMock(return_value=_result(False))
+    with patch("sparkrun.orchestration.primitives.run_command_on_host", mock_run):
+        assert wait_for_port("testhost", 8000, max_retries=3, retry_interval=0) is False
+    assert mock_run.call_count == 3
+
+
+def test_wait_for_port_aborts_when_container_exits():
+    """If the container stops while polling, abort early instead of retrying."""
+    mock_run = MagicMock(return_value=_result(False))
+    with (
+        patch("sparkrun.orchestration.primitives.run_command_on_host", mock_run),
+        patch("sparkrun.orchestration.health.is_container_running", return_value=False),
+    ):
+        assert wait_for_port(
+            "testhost", 8000, max_retries=5, retry_interval=0, container_name="srv"
+        ) is False
+    # Attempt 1 probes the port; attempt 2 aborts on the dead container before probing.
+    assert mock_run.call_count == 1


### PR DESCRIPTION
## Problem

Every multi-node Atlas launch hangs. The head node accepts the probe's connection, sends it the unique NCCL ID, and closes the listener — the real worker then gets `Connection refused` forever and the head spins in `ncclCommInitRank` at ~99% CPU.

## Root cause

`wait_for_port()` in `src/sparkrun/orchestration/health.py` probes readiness with `nc -z localhost <port>`, which opens a **real TCP connection**. Atlas's NCCL bootstrap (`spark-comm/nccl_backend.rs::distribute_id`) accepts exactly `world_size - 1` connections, writes the unique NCCL ID to each, then returns — dropping the listener.

In `run_native_cluster` (step 6), sparkrun calls `wait_for_port()` on the **NCCL init port** (`init_port`, default 25000) before launching the workers (step 7). The `nc -z` probe is that one connection: Atlas hands its unique ID to the probe, the listener closes, and when the real worker finally connects it gets `Connection refused (os error 111)` and retries 600 times while the head burns CPU waiting for a NCCL comm init that can never complete.

Observed:
```
22:06:09  Rank 0: waiting for 1 worker(s) on 0.0.0.0:25000
22:06:11  Rank 0: sent unique ID to worker 1 (127.0.0.1:39238)   <- nc -z probe
22:06:43  Rank N: Connect attempt 1/600: Connection refused (os error 111)
```

## Fix

Check the kernel socket table instead of opening a connection:

```python
check_cmd = (
    f"ss -tln 2>/dev/null | grep -qE ':{port}(\\s|$)' "
    f"|| ss -tln6 2>/dev/null | grep -qE ':{port}(\\s|$)' "
    f"|| grep -qE ':{port:04X} ' /proc/net/tcp"
)
```

This is side-effect free — no TCP connection is made — and matches "port is listening" for every runtime (vLLM, SGLang, llama.cpp, Atlas). `ss` is present on all Linux targets; `/proc/net/tcp` is a fallback for minimal images.

## Validation

- `tests/test_health.py` — 4 new unit tests (probe command shape, ready/not-ready, container-exit abort)
- `pytest tests/test_launcher.py tests/test_primitives.py` — 93 passed (existing `nc -z` assertions in `find_available_port` untouched — that call site scans for a *free* port pre-launch and is unaffected)
- `pytest -k "health or wait_for_port or launch or primitive"` — 203 passed
- Live-verified on a 2× DGX Spark cluster: `unsloth/Qwen3.8-27B-NVFP4` with `--tp-size 2` now boots, NCCL initializes on both ranks, and serves correctly

## Note

`find_available_port()` in `primitives.py` keeps `nc -z` deliberately — it scans for an unused port *before* launch, where opening a connection to a live socket is exactly the desired signal.